### PR TITLE
debugged MCSH force training, Optimize fingerprint calculations

### DIFF
--- a/amptorch/descriptor/Gaussian/__init__.py
+++ b/amptorch/descriptor/Gaussian/__init__.py
@@ -225,7 +225,7 @@ class Gaussian(BaseDescriptor):
             )
             x_p = _gen_2Darray_for_ffi(x, ffi)
 
-            errno = lib.calculate_sf_no_deriv(
+            errno = lib.calculate_sf_noderiv(
                 cell_p,
                 cart_p,
                 scale_p,

--- a/amptorch/descriptor/Gaussian/calculate_sf.cpp
+++ b/amptorch/descriptor/Gaussian/calculate_sf.cpp
@@ -538,7 +538,7 @@ extern "C" int calculate_sf_no_deriv(double** cell, double** cart, double** scal
                     precal[0] = cutf(rRij / params_d[s][0]);
                     precal[1] = dcutf(rRij, params_d[s][0]);
 
-                    symf[ii][s] += G2(rRij, precal, params_d[s], dradtmp); // FIXME: index
+                    symf[ii][s] += G2_noderiv(rRij, precal, params_d[s], dradtmp); // FIXME: index
                     tmpd[0] = dradtmp*vecij[0];
                     tmpd[1] = dradtmp*vecij[1];
                     tmpd[2] = dradtmp*vecij[2];
@@ -583,7 +583,7 @@ extern "C" int calculate_sf_no_deriv(double** cell, double** cart, double** scal
                         precal[4] = cutf(rRjk / params_d[s][0]);
                         precal[5] = dcutf(rRjk, params_d[s][0]);
 
-                        symf[ii][s] += G4(rRij, rRik, rRjk, powtwo[s], precal, params_d[s], dangtmp);
+                        symf[ii][s] += G4_noderiv(rRij, rRik, rRjk, powtwo[s], precal, params_d[s], dangtmp);
 
                         tmpd[0] = dangtmp[0]*vecij[0];
                         tmpd[1] = dangtmp[0]*vecij[1];
@@ -604,7 +604,7 @@ extern "C" int calculate_sf_no_deriv(double** cell, double** cart, double** scal
                         precal[2] = cutf(rRik / params_d[s][0]);
                         precal[3] = dcutf(rRik, params_d[s][0]);
 
-                        symf[ii][s] += G5(rRij, rRik, powtwo[s], precal, params_d[s], dangtmp);
+                        symf[ii][s] += G5_noderiv(rRij, rRik, powtwo[s], precal, params_d[s], dangtmp);
 
                         tmpd[0] = dangtmp[0]*vecij[0];
                         tmpd[1] = dangtmp[0]*vecij[1];

--- a/amptorch/descriptor/Gaussian/calculate_sf.cpp
+++ b/amptorch/descriptor/Gaussian/calculate_sf.cpp
@@ -336,7 +336,7 @@ extern "C" int calculate_sf(double** cell, double** cart, double** scale, int* p
 
 
 
-extern "C" int calculate_sf_no_deriv(double** cell, double** cart, double** scale, int* pbc_bools,
+extern "C" int calculate_sf_noderiv(double** cell, double** cart, double** scale, int* pbc_bools,
                             int* atom_i, int natoms, int* cal_atoms, int cal_num, 
                             int** params_i, double** params_d, int nsyms,
                             double** symf) {

--- a/amptorch/descriptor/Gaussian/calculate_sf.h
+++ b/amptorch/descriptor/Gaussian/calculate_sf.h
@@ -13,7 +13,7 @@ extern "C" int calculate_sf(double **, double **, double **, int*,
                             int**, double **, int, 
                             double**, double**);
 
-extern "C" int calculate_sf_no_deriv(double **, double **, double **, int*, 
+extern "C" int calculate_sf_noderiv(double **, double **, double **, int*, 
                             int *, int, int*, int,
                             int**, double **, int, 
                             double**);

--- a/amptorch/descriptor/Gaussian/libsymf_builder.py
+++ b/amptorch/descriptor/Gaussian/libsymf_builder.py
@@ -7,7 +7,7 @@ ffibuilder.cdef(
                         int**, double **, int,
                         double**, double**);
         
-        int calculate_sf_no_deriv(double **, double **, double **, int*, 
+        int calculate_sf_noderiv(double **, double **, double **, int*, 
                             int *, int, int*, int,
                             int**, double **, int, 
                             double**);"""

--- a/amptorch/descriptor/Gaussian/symmetry_functions.cpp
+++ b/amptorch/descriptor/Gaussian/symmetry_functions.cpp
@@ -85,7 +85,7 @@ double G5(double Rij, double Rik, double powtwo, \
 }
 
 
-double G2_noderiv(double Rij, double *precal, double *par) {
+double G2_noderiv(double Rij, double *precal, double *par, double &deriv) {
     // par[0] = cutoff_dist
     // par[1] = eta
     // par[2] = R_s
@@ -95,7 +95,7 @@ double G2_noderiv(double Rij, double *precal, double *par) {
 }
 
 double G4_noderiv(double Rij, double Rik, double Rjk, double powtwo, \
-          double *precal, double *par) {
+          double *precal, double *par, double *deriv) {
     // cosv: cos(theta)
     // par[0] = cutoff_dist
     // par[1] = eta
@@ -110,7 +110,7 @@ double G4_noderiv(double Rij, double Rik, double Rjk, double powtwo, \
 }
 
 double G5_noderiv(double Rij, double Rik, double powtwo, \
-          double *precal, double *par) {
+          double *precal, double *par, double *deriv) {
     // cosv: cos(theta)
     // par[0] = cutoff_dist
     // par[1] = eta

--- a/amptorch/descriptor/MCSH/__init__.py
+++ b/amptorch/descriptor/MCSH/__init__.py
@@ -174,7 +174,7 @@ class AtomisticMCSH(BaseDescriptor):
 
         size_info = np.array([atom_num, cal_num, self.params_set['num']])
 
-        if calculate_derivatives:
+        if calc_derivatives:
             x = np.zeros([cal_num, self.params_set['num']], dtype=np.float64, order='C')
             dx = np.zeros([cal_num * self.params_set['num'], atom_num * 3], dtype=np.float64, order='C')
 

--- a/amptorch/descriptor/MCSH/__init__.py
+++ b/amptorch/descriptor/MCSH/__init__.py
@@ -196,7 +196,7 @@ class AtomisticMCSH(BaseDescriptor):
 
         threshold = 1e-15
         super_threshold_indices_prime = np.abs(fp_prime) < threshold
-        print("threshhold: {} \tnum points set to zero:{} \t outof: {}".format(threshold, np.sum(super_threshold_indices), fp_prime.shape[0] * fp_prime.shape[1]))
+        print("threshhold: {} \tnum points set to zero:{} \t outof: {}".format(threshold, np.sum(super_threshold_indices_prime), fp_prime.shape[0] * fp_prime.shape[1]))
         fp_prime[super_threshold_indices_prime] = 0.0
 
         scipy_sparse_fp_prime = sparse.coo_matrix(fp_prime)

--- a/amptorch/descriptor/MCSH/__init__.py
+++ b/amptorch/descriptor/MCSH/__init__.py
@@ -29,6 +29,7 @@ class AtomisticMCSH(BaseDescriptor):
     def prepare_descriptor_parameters(self):
         descriptor_setup = []
         cutoff = self.MCSHs["cutoff"]
+        
         for i in range(20):
             if str(i) in self.MCSHs["MCSHs"].keys():
                 descriptor_setup += [
@@ -103,6 +104,8 @@ class AtomisticMCSH(BaseDescriptor):
         if "prime_threshold" in self.MCSHs:
             self.params_set["prime_threshold"] = float(self.MCSHs["prime_threshold"])
 
+        self.params_set["norm"] = self.MCSHs["norm"].get("norm", False)
+
         return
     
     
@@ -171,60 +174,76 @@ class AtomisticMCSH(BaseDescriptor):
 
         size_info = np.array([atom_num, cal_num, self.params_set['num']])
 
-        # if calculate_derivatives:
-        x = np.zeros([cal_num, self.params_set['num']], dtype=np.float64, order='C')
-        dx = np.zeros([cal_num * self.params_set['num'], atom_num * 3], dtype=np.float64, order='C')
+        if calculate_derivatives:
+            x = np.zeros([cal_num, self.params_set['num']], dtype=np.float64, order='C')
+            dx = np.zeros([cal_num * self.params_set['num'], atom_num * 3], dtype=np.float64, order='C')
 
-        x_p = _gen_2Darray_for_ffi(x, ffi)
-        dx_p = _gen_2Darray_for_ffi(dx, ffi)
+            x_p = _gen_2Darray_for_ffi(x, ffi)
+            dx_p = _gen_2Darray_for_ffi(dx, ffi)
 
-        errno = lib.calculate_atomistic_mcsh(cell_p, cart_p, scale_p, pbc_p,\
-                    atom_indices_p, atom_num, cal_atoms_p, cal_num, \
-                    self.params_set['ip'], self.params_set['dp'], self.params_set['num'], self.params_set['gaussian_params_p'], self.params_set['ngaussians_p'], self.params_set['element_index_to_order_p'],\
-                    x_p, dx_p)
+            if self.params_set['norm']:
+                errno = lib.calculate_atomistic_mcsh_norm(cell_p, cart_p, scale_p, pbc_p,\
+                            atom_indices_p, atom_num, cal_atoms_p, cal_num, \
+                            self.params_set['ip'], self.params_set['dp'], self.params_set['num'], self.params_set['gaussian_params_p'], self.params_set['ngaussians_p'], self.params_set['element_index_to_order_p'],\
+                            x_p, dx_p)
+            else:
+                errno = lib.calculate_atomistic_mcsh(cell_p, cart_p, scale_p, pbc_p,\
+                            atom_indices_p, atom_num, cal_atoms_p, cal_num, \
+                            self.params_set['ip'], self.params_set['dp'], self.params_set['num'], self.params_set['gaussian_params_p'], self.params_set['ngaussians_p'], self.params_set['element_index_to_order_p'],\
+                            x_p, dx_p)
+            
+            if errno == 1:
+                raise NotImplementedError("Descriptor not implemented!")
+            fp = np.array(x)
+            fp_prime = np.array(dx)
+
+            # if "prime_threshold" in self.params_set:
+            #     threshold = self.params_set["prime_threshold"]
+            #     super_threshold_indices = np.abs(fp_prime) < threshold
+            #     print("threshhold: {} \tnum points set to zero:{} \t outof: {}".format(threshold, np.sum(super_threshold_indices), fp_prime.shape[0] * fp_prime.shape[1]))
+            #     fp_prime[super_threshold_indices] = 0.0
+
+            # threshold = 1e-9
+            # super_threshold_indices_prime = np.abs(fp_prime) < threshold
+            # print("threshhold: {} \tnum points set to zero:{} \t outof: {}".format(threshold, np.sum(super_threshold_indices_prime), fp_prime.shape[0] * fp_prime.shape[1]))
+            # fp_prime[super_threshold_indices_prime] = 0.0
+
+            scipy_sparse_fp_prime = sparse.coo_matrix(fp_prime)
+            # print(fp)
+            # print(fp.shape)
+            # print(np.sum(super_threshold_indices))
+            # print(np.min(np.abs(scipy_sparse_fp_prime.data)))
+            # print("density: {}% \n\n----------------------".format(100*len(scipy_sparse_fp_prime.data) / (fp_prime.shape[0] * fp_prime.shape[1])))
+
+            return (
+                    size_info,
+                    fp,
+                    scipy_sparse_fp_prime.data,
+                    scipy_sparse_fp_prime.row,
+                    scipy_sparse_fp_prime.col,
+                    np.array(fp_prime.shape),
+                )
         
-        if errno == 1:
-            raise NotImplementedError("Descriptor not implemented!")
-        fp = np.array(x)
-        fp_prime = np.array(dx)
+        else:
+            x = np.zeros([cal_num, self.params_set['num']], dtype=np.float64, order='C')
 
-        # if "prime_threshold" in self.params_set:
-        #     threshold = self.params_set["prime_threshold"]
-        #     super_threshold_indices = np.abs(fp_prime) < threshold
-        #     print("threshhold: {} \tnum points set to zero:{} \t outof: {}".format(threshold, np.sum(super_threshold_indices), fp_prime.shape[0] * fp_prime.shape[1]))
-        #     fp_prime[super_threshold_indices] = 0.0
+            x_p = _gen_2Darray_for_ffi(x, ffi)
 
-        # threshold = 1e-9
-        # super_threshold_indices_prime = np.abs(fp_prime) < threshold
-        # print("threshhold: {} \tnum points set to zero:{} \t outof: {}".format(threshold, np.sum(super_threshold_indices_prime), fp_prime.shape[0] * fp_prime.shape[1]))
-        # fp_prime[super_threshold_indices_prime] = 0.0
+            if self.params_set['norm']:
+                errno = lib.calculate_atomistic_mcsh_norm_noderiv(cell_p, cart_p, scale_p, pbc_p,\
+                            atom_indices_p, atom_num, cal_atoms_p, cal_num, \
+                            self.params_set['ip'], self.params_set['dp'], self.params_set['num'], self.params_set['gaussian_params_p'], self.params_set['ngaussians_p'],\
+                            x_p)
+            else:
+                errno = lib.calculate_atomistic_mcsh_noderiv(cell_p, cart_p, scale_p, pbc_p,\
+                            atom_indices_p, atom_num, cal_atoms_p, cal_num, \
+                            self.params_set['ip'], self.params_set['dp'], self.params_set['num'], self.params_set['gaussian_params_p'], self.params_set['ngaussians_p'],\
+                            x_p)
 
-        scipy_sparse_fp_prime = sparse.coo_matrix(fp_prime)
-        # print(fp)
-        # print(fp.shape)
-        # print(np.sum(super_threshold_indices))
-        # print(np.min(np.abs(scipy_sparse_fp_prime.data)))
-        # print("density: {}% \n\n----------------------".format(100*len(scipy_sparse_fp_prime.data) / (fp_prime.shape[0] * fp_prime.shape[1])))
-
-        return (
-                size_info,
-                fp,
-                scipy_sparse_fp_prime.data,
-                scipy_sparse_fp_prime.row,
-                scipy_sparse_fp_prime.col,
-                np.array(fp_prime.shape),
-            )
-        
-        # else:
-        #     x = np.zeros([cal_num, self.params_set[element_index]['num']], dtype=np.float64, order='C')
-        #     x_p = _gen_2Darray_for_ffi(x, ffi)
-
-        #     errno = lib.calculate_atomistic_mcsh(cell_p, cart_p, scale_p, pbc_p,\
-        #                 atom_indices_p, atom_num, cal_atoms_p, cal_num, \
-        #                 self.params_set['ip'], self.params_set['dp'], self.params_set['num'], self.params_set['gaussian_params_p'], self.params_set['ngaussians_p'],\
-        #                 x_p, dx_p)
+            if errno == 1:
+                raise NotImplementedError("Descriptor not implemented!")
                     
-        #     fp = np.array(x)
+            fp = np.array(x)
 
-        #     return size_info, fp, None, None, None, None
+            return size_info, fp, None, None, None, None
 

--- a/amptorch/descriptor/MCSH/__init__.py
+++ b/amptorch/descriptor/MCSH/__init__.py
@@ -104,7 +104,7 @@ class AtomisticMCSH(BaseDescriptor):
         if "prime_threshold" in self.MCSHs:
             self.params_set["prime_threshold"] = float(self.MCSHs["prime_threshold"])
 
-        self.params_set["norm"] = self.MCSHs["norm"].get("norm", False)
+        self.params_set["norm"] = self.MCSHs.get("norm", False)
 
         return
     

--- a/amptorch/descriptor/MCSH/__init__.py
+++ b/amptorch/descriptor/MCSH/__init__.py
@@ -194,6 +194,11 @@ class AtomisticMCSH(BaseDescriptor):
         #     print("threshhold: {} \tnum points set to zero:{} \t outof: {}".format(threshold, np.sum(super_threshold_indices), fp_prime.shape[0] * fp_prime.shape[1]))
         #     fp_prime[super_threshold_indices] = 0.0
 
+        threshold = 1e-15
+        super_threshold_indices_prime = np.abs(fp_prime) < threshold
+        print("threshhold: {} \tnum points set to zero:{} \t outof: {}".format(threshold, np.sum(super_threshold_indices), fp_prime.shape[0] * fp_prime.shape[1]))
+        fp_prime[super_threshold_indices_prime] = 0.0
+
         scipy_sparse_fp_prime = sparse.coo_matrix(fp_prime)
         # print(fp)
         # print(fp.shape)

--- a/amptorch/descriptor/MCSH/__init__.py
+++ b/amptorch/descriptor/MCSH/__init__.py
@@ -194,10 +194,10 @@ class AtomisticMCSH(BaseDescriptor):
         #     print("threshhold: {} \tnum points set to zero:{} \t outof: {}".format(threshold, np.sum(super_threshold_indices), fp_prime.shape[0] * fp_prime.shape[1]))
         #     fp_prime[super_threshold_indices] = 0.0
 
-        threshold = 1e-9
-        super_threshold_indices_prime = np.abs(fp_prime) < threshold
-        print("threshhold: {} \tnum points set to zero:{} \t outof: {}".format(threshold, np.sum(super_threshold_indices_prime), fp_prime.shape[0] * fp_prime.shape[1]))
-        fp_prime[super_threshold_indices_prime] = 0.0
+        # threshold = 1e-9
+        # super_threshold_indices_prime = np.abs(fp_prime) < threshold
+        # print("threshhold: {} \tnum points set to zero:{} \t outof: {}".format(threshold, np.sum(super_threshold_indices_prime), fp_prime.shape[0] * fp_prime.shape[1]))
+        # fp_prime[super_threshold_indices_prime] = 0.0
 
         scipy_sparse_fp_prime = sparse.coo_matrix(fp_prime)
         # print(fp)

--- a/amptorch/descriptor/MCSH/__init__.py
+++ b/amptorch/descriptor/MCSH/__init__.py
@@ -194,7 +194,7 @@ class AtomisticMCSH(BaseDescriptor):
         #     print("threshhold: {} \tnum points set to zero:{} \t outof: {}".format(threshold, np.sum(super_threshold_indices), fp_prime.shape[0] * fp_prime.shape[1]))
         #     fp_prime[super_threshold_indices] = 0.0
 
-        threshold = 1e-15
+        threshold = 1e-9
         super_threshold_indices_prime = np.abs(fp_prime) < threshold
         print("threshhold: {} \tnum points set to zero:{} \t outof: {}".format(threshold, np.sum(super_threshold_indices_prime), fp_prime.shape[0] * fp_prime.shape[1]))
         fp_prime[super_threshold_indices_prime] = 0.0

--- a/amptorch/descriptor/MCSH/__init__.py
+++ b/amptorch/descriptor/MCSH/__init__.py
@@ -230,14 +230,14 @@ class AtomisticMCSH(BaseDescriptor):
             x_p = _gen_2Darray_for_ffi(x, ffi)
 
             if self.params_set['norm']:
-                errno = lib.calculate_atomistic_mcsh_norm_noderiv(cell_p, cart_p, scale_p, pbc_p,\
+                errno = lib.calculate_atomistic_mcsh_norm(cell_p, cart_p, scale_p, pbc_p,\
                             atom_indices_p, atom_num, cal_atoms_p, cal_num, \
-                            self.params_set['ip'], self.params_set['dp'], self.params_set['num'], self.params_set['gaussian_params_p'], self.params_set['ngaussians_p'],\
+                            self.params_set['ip'], self.params_set['dp'], self.params_set['num'], self.params_set['gaussian_params_p'], self.params_set['ngaussians_p'], self.params_set['element_index_to_order_p'],\
                             x_p)
             else:
                 errno = lib.calculate_atomistic_mcsh_noderiv(cell_p, cart_p, scale_p, pbc_p,\
                             atom_indices_p, atom_num, cal_atoms_p, cal_num, \
-                            self.params_set['ip'], self.params_set['dp'], self.params_set['num'], self.params_set['gaussian_params_p'], self.params_set['ngaussians_p'],\
+                            self.params_set['ip'], self.params_set['dp'], self.params_set['num'], self.params_set['gaussian_params_p'], self.params_set['ngaussians_p'], self.params_set['element_index_to_order_p'],\
                             x_p)
 
             if errno == 1:

--- a/amptorch/descriptor/MCSH/atomistic_mcsh.cpp
+++ b/amptorch/descriptor/MCSH/atomistic_mcsh.cpp
@@ -76,35 +76,35 @@ void calc_MCSH_1_1(double x0, double y0, double z0, double r0_sqr, double A, dou
     double const_2_C2_y = 2.0 * C2 * y0;
     double const_2_C2_z = 2.0 * C2 * z0;
 
-    // // dmiu1 dx/dy/dz
-    // deriv[0] = dx0dx() * temp * (temp_dx + const_2_C2_x * temp_x);
-    // deriv[1] = dy0dy() * miu_1_1_1 * const_2_C2_y;
-    // deriv[2] = dz0dz() * miu_1_1_1 * const_2_C2_z;
-
-    // // dmiu2 dx/dy/dz
-    // deriv[3] = dx0dx() * miu_1_1_2 * const_2_C2_x;
-    // deriv[4] = dy0dy() * temp * (temp_dy + const_2_C2_y * temp_y);
-    // deriv[5] = dz0dz() * miu_1_1_2 * const_2_C2_z;
-
-    // // dmiu3 dx/dy/dz
-    // deriv[6] = dx0dx() * miu_1_1_3 * const_2_C2_x;
-    // deriv[7] = dy0dy() * miu_1_1_3 * const_2_C2_y;
-    // deriv[8] = dz0dz() * temp * (temp_dz + const_2_C2_z * temp_z);
-
     // dmiu1 dx/dy/dz
-    deriv[0] = 1;
-    deriv[1] = 1;
-    deriv[2] = 1;
+    deriv[0] = dx0dx() * temp * (temp_dx + const_2_C2_x * temp_x);
+    deriv[1] = dy0dy() * miu_1_1_1 * const_2_C2_y;
+    deriv[2] = dz0dz() * miu_1_1_1 * const_2_C2_z;
 
     // dmiu2 dx/dy/dz
-    deriv[3] = 1;
-    deriv[4] = 1;
-    deriv[5] = 1;
+    deriv[3] = dx0dx() * miu_1_1_2 * const_2_C2_x;
+    deriv[4] = dy0dy() * temp * (temp_dy + const_2_C2_y * temp_y);
+    deriv[5] = dz0dz() * miu_1_1_2 * const_2_C2_z;
 
     // dmiu3 dx/dy/dz
-    deriv[6] = 1;
-    deriv[7] = 1;
-    deriv[8] = 1;
+    deriv[6] = dx0dx() * miu_1_1_3 * const_2_C2_x;
+    deriv[7] = dy0dy() * miu_1_1_3 * const_2_C2_y;
+    deriv[8] = dz0dz() * temp * (temp_dz + const_2_C2_z * temp_z);
+
+    // // dmiu1 dx/dy/dz
+    // deriv[0] = 1;
+    // deriv[1] = 1;
+    // deriv[2] = 1;
+
+    // // dmiu2 dx/dy/dz
+    // deriv[3] = 1;
+    // deriv[4] = 1;
+    // deriv[5] = 1;
+
+    // // dmiu3 dx/dy/dz
+    // deriv[6] = 1;
+    // deriv[7] = 1;
+    // deriv[8] = 1;
 
     value[0] = miu_1_1_1;
     value[1] = miu_1_1_2;

--- a/amptorch/descriptor/MCSH/atomistic_mcsh.cpp
+++ b/amptorch/descriptor/MCSH/atomistic_mcsh.cpp
@@ -23,15 +23,15 @@ double calc_gamma(double alpha, double beta){
 }
 
 double dx0dx(){
-    return 1;
+    return 1.0;
 }
 
 double dy0dy(){
-    return 1;
+    return 1.0;
 }
 
 double dz0dz(){
-    return 1;
+    return 1.0;
 }
 
 void calc_MCSH_0_1(double x0, double y0, double z0, double r0_sqr, double A, double B, double alpha, double beta, double *value, double *deriv)

--- a/amptorch/descriptor/MCSH/atomistic_mcsh.cpp
+++ b/amptorch/descriptor/MCSH/atomistic_mcsh.cpp
@@ -76,35 +76,35 @@ void calc_MCSH_1_1(double x0, double y0, double z0, double r0_sqr, double A, dou
     double const_2_C2_y = 2.0 * C2 * y0;
     double const_2_C2_z = 2.0 * C2 * z0;
 
-    // // dmiu1 dx/dy/dz
-    // deriv[0] = dx0dx() * temp * (temp_dx + const_2_C2_x * temp_x);
-    // deriv[1] = dy0dy() * miu_1_1_1 * const_2_C2_y;
-    // deriv[2] = dz0dz() * miu_1_1_1 * const_2_C2_z;
-
-    // // dmiu2 dx/dy/dz
-    // deriv[3] = dx0dx() * miu_1_1_2 * const_2_C2_x;
-    // deriv[4] = dy0dy() * temp * (temp_dy + const_2_C2_y * temp_y);
-    // deriv[5] = dz0dz() * miu_1_1_2 * const_2_C2_z;
-
-    // // dmiu3 dx/dy/dz
-    // deriv[6] = dx0dx() * miu_1_1_3 * const_2_C2_x;
-    // deriv[7] = dy0dy() * miu_1_1_3 * const_2_C2_y;
-    // deriv[8] = dz0dz() * temp * (temp_dz + const_2_C2_z * temp_z);
-
     // dmiu1 dx/dy/dz
-    deriv[0] = 1.0;
-    deriv[1] = 1.0;
-    deriv[2] = 1.0;
+    deriv[0] = dx0dx() * temp * (temp_dx + const_2_C2_x * temp_x);
+    deriv[1] = dy0dy() * miu_1_1_1 * const_2_C2_y;
+    deriv[2] = dz0dz() * miu_1_1_1 * const_2_C2_z;
 
     // dmiu2 dx/dy/dz
-    deriv[3] = 1.0;
-    deriv[4] = 1.0;
-    deriv[5] = 1.0;
+    deriv[3] = dx0dx() * miu_1_1_2 * const_2_C2_x;
+    deriv[4] = dy0dy() * temp * (temp_dy + const_2_C2_y * temp_y);
+    deriv[5] = dz0dz() * miu_1_1_2 * const_2_C2_z;
 
     // dmiu3 dx/dy/dz
-    deriv[6] = 1.0;
-    deriv[7] = 1.0;
-    deriv[8] = 1.0;
+    deriv[6] = dx0dx() * miu_1_1_3 * const_2_C2_x;
+    deriv[7] = dy0dy() * miu_1_1_3 * const_2_C2_y;
+    deriv[8] = dz0dz() * temp * (temp_dz + const_2_C2_z * temp_z);
+
+    // // dmiu1 dx/dy/dz
+    // deriv[0] = 1.0;
+    // deriv[1] = 1.0;
+    // deriv[2] = 1.0;
+
+    // // dmiu2 dx/dy/dz
+    // deriv[3] = 1.0;
+    // deriv[4] = 1.0;
+    // deriv[5] = 1.0;
+
+    // // dmiu3 dx/dy/dz
+    // deriv[6] = 1.0;
+    // deriv[7] = 1.0;
+    // deriv[8] = 1.0;
 
     value[0] = miu_1_1_1;
     value[1] = miu_1_1_2;

--- a/amptorch/descriptor/MCSH/atomistic_mcsh.cpp
+++ b/amptorch/descriptor/MCSH/atomistic_mcsh.cpp
@@ -91,50 +91,10 @@ void calc_MCSH_1_1(double x0, double y0, double z0, double r0_sqr, double A, dou
     deriv[7] = dy0dy() * miu_1_1_3 * const_2_C2_y;
     deriv[8] = dz0dz() * temp * (temp_dz + const_2_C2_z * temp_z);
 
-    // // dmiu1 dx/dy/dz
-    // deriv[0] = 1.0;
-    // deriv[1] = 1.0;
-    // deriv[2] = 1.0;
-
-    // // dmiu2 dx/dy/dz
-    // deriv[3] = 1.0;
-    // deriv[4] = 1.0;
-    // deriv[5] = 1.0;
-
-    // // dmiu3 dx/dy/dz
-    // deriv[6] = 1.0;
-    // deriv[7] = 1.0;
-    // deriv[8] = 1.0;
-
     value[0] = miu_1_1_1;
     value[1] = miu_1_1_2;
     value[2] = miu_1_1_3;
 
-
-    // double temp = C1 * lambda * exp( C2 * r0_sqr);
-
-    // double miu_1_1_1 = temp * x0;
-    // double miu_1_1_2 = temp * y0;
-    // double miu_1_1_3 = temp * z0;
-
-    // // dmiu1 dx/dy/dz
-    // deriv[0] = dx0dx() * temp * (1.0 + 2.0 * C2 * x0 * x0);
-    // deriv[1] = dy0dy() * miu_1_1_1 * (2.0 * C2 * y0);
-    // deriv[2] = dz0dz() * miu_1_1_1 * (2.0 * C2 * z0);
-
-    // // dmiu2 dx/dy/dz
-    // deriv[3] = dx0dx() * miu_1_1_2 * (2.0 * C2 * x0);
-    // deriv[4] = dy0dy() * temp * (1.0 + 2.0 * C2 * y0 * y0);
-    // deriv[5] = dz0dz() * miu_1_1_2 * (.0 * C2 * z0);
-
-    // // dmiu3 dx/dy/dz
-    // deriv[6] = dx0dx() * miu_1_1_3 * (2.0 * C2 * x0);
-    // deriv[7] = dy0dy() * miu_1_1_3 * (2.0 * C2 * y0);
-    // deriv[8] = dz0dz() * temp * (1.0 + 2.0 * C2 * z0 * z0);
-
-    // value[0] = miu_1_1_1;
-    // value[1] = miu_1_1_2;
-    // value[2] = miu_1_1_3;
 }
 
 void calc_MCSH_2_1(double x0, double y0, double z0, double r0_sqr, double A, double B, double alpha, double beta, double *value, double *deriv)

--- a/amptorch/descriptor/MCSH/atomistic_mcsh.cpp
+++ b/amptorch/descriptor/MCSH/atomistic_mcsh.cpp
@@ -76,20 +76,35 @@ void calc_MCSH_1_1(double x0, double y0, double z0, double r0_sqr, double A, dou
     double const_2_C2_y = 2.0 * C2 * y0;
     double const_2_C2_z = 2.0 * C2 * z0;
 
+    // // dmiu1 dx/dy/dz
+    // deriv[0] = dx0dx() * temp * (temp_dx + const_2_C2_x * temp_x);
+    // deriv[1] = dy0dy() * miu_1_1_1 * const_2_C2_y;
+    // deriv[2] = dz0dz() * miu_1_1_1 * const_2_C2_z;
+
+    // // dmiu2 dx/dy/dz
+    // deriv[3] = dx0dx() * miu_1_1_2 * const_2_C2_x;
+    // deriv[4] = dy0dy() * temp * (temp_dy + const_2_C2_y * temp_y);
+    // deriv[5] = dz0dz() * miu_1_1_2 * const_2_C2_z;
+
+    // // dmiu3 dx/dy/dz
+    // deriv[6] = dx0dx() * miu_1_1_3 * const_2_C2_x;
+    // deriv[7] = dy0dy() * miu_1_1_3 * const_2_C2_y;
+    // deriv[8] = dz0dz() * temp * (temp_dz + const_2_C2_z * temp_z);
+
     // dmiu1 dx/dy/dz
-    deriv[0] = dx0dx() ;
-    deriv[1] = dy0dy() * miu_1_1_1 ;
-    deriv[2] = dz0dz() * miu_1_1_1 ;
+    deriv[0] = 1;
+    deriv[1] = 1;
+    deriv[2] = 1;
 
     // dmiu2 dx/dy/dz
-    deriv[3] = dx0dx() * miu_1_1_2 ;
-    deriv[4] = dy0dy() ;
-    deriv[5] = dz0dz() * miu_1_1_2 ;
+    deriv[3] = 1;
+    deriv[4] = 1;
+    deriv[5] = 1;
 
     // dmiu3 dx/dy/dz
-    deriv[6] = dx0dx() * miu_1_1_3 ;
-    deriv[7] = dy0dy() * miu_1_1_3 ;
-    deriv[8] = dz0dz() ;
+    deriv[6] = 1;
+    deriv[7] = 1;
+    deriv[8] = 1;
 
     value[0] = miu_1_1_1;
     value[1] = miu_1_1_2;

--- a/amptorch/descriptor/MCSH/atomistic_mcsh.cpp
+++ b/amptorch/descriptor/MCSH/atomistic_mcsh.cpp
@@ -5720,11 +5720,6 @@ void calc_MCSH_3_1_noderiv(double x0, double y0, double z0, double r0_sqr, doubl
     double miu_3_1_2 = temp * temp_y;
     double miu_3_1_3 = temp * temp_z;
 
-    //deriv consts
-    double const_2_C2_x = 2.0 * C2 * x0;
-    double const_2_C2_y = 2.0 * C2 * y0;
-    double const_2_C2_z = 2.0 * C2 * z0;
-
     value[0] = miu_3_1_1;
     value[1] = miu_3_1_2;
     value[2] = miu_3_1_3;
@@ -5783,7 +5778,7 @@ void calc_MCSH_3_3_noderiv(double x0, double y0, double z0, double r0_sqr, doubl
     value[0] = m_3_3;
 }
 
-void calc_MCSH_4_1_noderiv(double x0, double y0, double z0, double r0_sqr, double A, double B, double alpha, double beta, double *valu, double *deriv)
+void calc_MCSH_4_1_noderiv(double x0, double y0, double z0, double r0_sqr, double A, double B, double alpha, double beta, double *value)
 {   
     // double r0_sqr = x0*x0 + y0*y0 + z0*z0;
     double C1 = calc_C1(A,B,alpha,beta);
@@ -5820,7 +5815,6 @@ void calc_MCSH_4_1_noderiv(double x0, double y0, double z0, double r0_sqr, doubl
     double miu_4_1_1 = temp * temp_x;
     double miu_4_1_2 = temp * temp_y;
     double miu_4_1_3 = temp * temp_z;
-
 
     value[0] = miu_4_1_1;
     value[1] = miu_4_1_2;
@@ -6057,10 +6051,6 @@ void calc_MCSH_5_3_noderiv(double x0, double y0, double z0, double r0_sqr, doubl
     double C2 = calc_C2(alpha, beta);
     
     double lambda = calc_lambda(alpha, beta);
-    double lambda_sqr = lambda * lambda;
-    // double x0_sqr = x0*x0;
-    // double y0_sqr = y0*y0;
-    // double z0_sqr = z0*z0;
 
     double lambda_x0 = x0 * lambda;
     double lambda_y0 = y0 * lambda;
@@ -6307,7 +6297,6 @@ void calc_MCSH_6_3_noderiv(double x0, double y0, double z0, double r0_sqr, doubl
     double C2 = calc_C2(alpha, beta);
     
     double lambda = calc_lambda(alpha, beta);
-    double lambda_sqr = lambda * lambda;
 
     double lambda_x0 = x0 * lambda;
     double lambda_y0 = y0 * lambda;
@@ -6525,7 +6514,6 @@ void calc_MCSH_6_7_noderiv(double x0, double y0, double z0, double r0_sqr, doubl
     double C2 = calc_C2(alpha, beta);
     
     double lambda = calc_lambda(alpha, beta);
-    double lambda_sqr = lambda * lambda;
 
     double lambda_x0 = x0 * lambda;
     double lambda_y0 = y0 * lambda;
@@ -6679,7 +6667,6 @@ void calc_MCSH_7_3_noderiv(double x0, double y0, double z0, double r0_sqr, doubl
     double C2 = calc_C2(alpha, beta);
     
     double lambda = calc_lambda(alpha, beta);
-    double lambda_sqr = lambda * lambda;
 
     double lambda_x0 = x0 * lambda;
     double lambda_y0 = y0 * lambda;
@@ -6804,7 +6791,6 @@ void calc_MCSH_7_5_noderiv(double x0, double y0, double z0, double r0_sqr, doubl
     double C2 = calc_C2(alpha, beta);
     
     double lambda = calc_lambda(alpha, beta);
-    double lambda_sqr = lambda * lambda;
 
     double lambda_x0 = x0 * lambda;
     double lambda_y0 = y0 * lambda;
@@ -6993,7 +6979,6 @@ void calc_MCSH_7_8_noderiv(double x0, double y0, double z0, double r0_sqr, doubl
     double C2 = calc_C2(alpha, beta);
     
     double lambda = calc_lambda(alpha, beta);
-    double lambda_sqr = lambda * lambda;
 
     double lambda_x0 = x0 * lambda;
     double lambda_y0 = y0 * lambda;
@@ -7176,7 +7161,6 @@ void calc_MCSH_8_3_noderiv(double x0, double y0, double z0, double r0_sqr, doubl
     double C2 = calc_C2(alpha, beta);
     
     double lambda = calc_lambda(alpha, beta);
-    double lambda_sqr = lambda * lambda;
 
     double lambda_x0 = x0 * lambda;
     double lambda_y0 = y0 * lambda;
@@ -7460,7 +7444,6 @@ void calc_MCSH_8_7_noderiv(double x0, double y0, double z0, double r0_sqr, doubl
     double C2 = calc_C2(alpha, beta);
     
     double lambda = calc_lambda(alpha, beta);
-    double lambda_sqr = lambda * lambda;
 
     double lambda_x0 = x0 * lambda;
     double lambda_y0 = y0 * lambda;
@@ -7594,7 +7577,6 @@ void calc_MCSH_8_9_noderiv(double x0, double y0, double z0, double r0_sqr, doubl
     double C2 = calc_C2(alpha, beta);
     
     double lambda = calc_lambda(alpha, beta);
-    double lambda_sqr = lambda * lambda;
 
     double lambda_x0 = x0 * lambda;
     double lambda_y0 = y0 * lambda;
@@ -7657,7 +7639,6 @@ void calc_MCSH_8_10_noderiv(double x0, double y0, double z0, double r0_sqr, doub
     double C2 = calc_C2(alpha, beta);
     
     double lambda = calc_lambda(alpha, beta);
-    double lambda_sqr = lambda * lambda;
 
     double lambda_x0 = x0 * lambda;
     double lambda_y0 = y0 * lambda;
@@ -7852,7 +7833,6 @@ void calc_MCSH_9_3_noderiv(double x0, double y0, double z0, double r0_sqr, doubl
     double C2 = calc_C2(alpha, beta);
     
     double lambda = calc_lambda(alpha, beta);
-    double lambda_sqr = lambda * lambda;
 
     double lambda_x0 = x0 * lambda;
     double lambda_y0 = y0 * lambda;
@@ -7999,7 +7979,6 @@ void calc_MCSH_9_5_noderiv(double x0, double y0, double z0, double r0_sqr, doubl
     double C2 = calc_C2(alpha, beta);
     
     double lambda = calc_lambda(alpha, beta);
-    double lambda_sqr = lambda * lambda;
 
     double lambda_x0 = x0 * lambda;
     double lambda_y0 = y0 * lambda;
@@ -8323,7 +8302,6 @@ void calc_MCSH_9_9_noderiv(double x0, double y0, double z0, double r0_sqr, doubl
     double C2 = calc_C2(alpha, beta);
     
     double lambda = calc_lambda(alpha, beta);
-    double lambda_sqr = lambda * lambda;
 
     double lambda_x0 = x0 * lambda;
     double lambda_y0 = y0 * lambda;

--- a/amptorch/descriptor/MCSH/atomistic_mcsh.cpp
+++ b/amptorch/descriptor/MCSH/atomistic_mcsh.cpp
@@ -77,19 +77,19 @@ void calc_MCSH_1_1(double x0, double y0, double z0, double r0_sqr, double A, dou
     double const_2_C2_z = 2.0 * C2 * z0;
 
     // dmiu1 dx/dy/dz
-    deriv[0] = dx0dx() * temp * (temp_dx + const_2_C2_x * temp_x);
-    deriv[1] = dy0dy() * miu_1_1_1 * const_2_C2_y;
-    deriv[2] = dz0dz() * miu_1_1_1 * const_2_C2_z;
+    deriv[0] = dx0dx() ;
+    deriv[1] = dy0dy() * miu_1_1_1 ;
+    deriv[2] = dz0dz() * miu_1_1_1 ;
 
     // dmiu2 dx/dy/dz
-    deriv[3] = dx0dx() * miu_1_1_2 * const_2_C2_x;
-    deriv[4] = dy0dy() * temp * (temp_dy + const_2_C2_y * temp_y);
-    deriv[5] = dz0dz() * miu_1_1_2 * const_2_C2_z;
+    deriv[3] = dx0dx() * miu_1_1_2 ;
+    deriv[4] = dy0dy() ;
+    deriv[5] = dz0dz() * miu_1_1_2 ;
 
     // dmiu3 dx/dy/dz
-    deriv[6] = dx0dx() * miu_1_1_3 * const_2_C2_x;
-    deriv[7] = dy0dy() * miu_1_1_3 * const_2_C2_y;
-    deriv[8] = dz0dz() * temp * (temp_dz + const_2_C2_z * temp_z);
+    deriv[6] = dx0dx() * miu_1_1_3 ;
+    deriv[7] = dy0dy() * miu_1_1_3 ;
+    deriv[8] = dz0dz() ;
 
     value[0] = miu_1_1_1;
     value[1] = miu_1_1_2;

--- a/amptorch/descriptor/MCSH/atomistic_mcsh.cpp
+++ b/amptorch/descriptor/MCSH/atomistic_mcsh.cpp
@@ -76,35 +76,35 @@ void calc_MCSH_1_1(double x0, double y0, double z0, double r0_sqr, double A, dou
     double const_2_C2_y = 2.0 * C2 * y0;
     double const_2_C2_z = 2.0 * C2 * z0;
 
-    // dmiu1 dx/dy/dz
-    deriv[0] = dx0dx() * temp * (temp_dx + const_2_C2_x * temp_x);
-    deriv[1] = dy0dy() * miu_1_1_1 * const_2_C2_y;
-    deriv[2] = dz0dz() * miu_1_1_1 * const_2_C2_z;
-
-    // dmiu2 dx/dy/dz
-    deriv[3] = dx0dx() * miu_1_1_2 * const_2_C2_x;
-    deriv[4] = dy0dy() * temp * (temp_dy + const_2_C2_y * temp_y);
-    deriv[5] = dz0dz() * miu_1_1_2 * const_2_C2_z;
-
-    // dmiu3 dx/dy/dz
-    deriv[6] = dx0dx() * miu_1_1_3 * const_2_C2_x;
-    deriv[7] = dy0dy() * miu_1_1_3 * const_2_C2_y;
-    deriv[8] = dz0dz() * temp * (temp_dz + const_2_C2_z * temp_z);
-
     // // dmiu1 dx/dy/dz
-    // deriv[0] = 1;
-    // deriv[1] = 1;
-    // deriv[2] = 1;
+    // deriv[0] = dx0dx() * temp * (temp_dx + const_2_C2_x * temp_x);
+    // deriv[1] = dy0dy() * miu_1_1_1 * const_2_C2_y;
+    // deriv[2] = dz0dz() * miu_1_1_1 * const_2_C2_z;
 
     // // dmiu2 dx/dy/dz
-    // deriv[3] = 1;
-    // deriv[4] = 1;
-    // deriv[5] = 1;
+    // deriv[3] = dx0dx() * miu_1_1_2 * const_2_C2_x;
+    // deriv[4] = dy0dy() * temp * (temp_dy + const_2_C2_y * temp_y);
+    // deriv[5] = dz0dz() * miu_1_1_2 * const_2_C2_z;
 
     // // dmiu3 dx/dy/dz
-    // deriv[6] = 1;
-    // deriv[7] = 1;
-    // deriv[8] = 1;
+    // deriv[6] = dx0dx() * miu_1_1_3 * const_2_C2_x;
+    // deriv[7] = dy0dy() * miu_1_1_3 * const_2_C2_y;
+    // deriv[8] = dz0dz() * temp * (temp_dz + const_2_C2_z * temp_z);
+
+    // dmiu1 dx/dy/dz
+    deriv[0] = 1.0;
+    deriv[1] = 1.0;
+    deriv[2] = 1.0;
+
+    // dmiu2 dx/dy/dz
+    deriv[3] = 1.0;
+    deriv[4] = 1.0;
+    deriv[5] = 1.0;
+
+    // dmiu3 dx/dy/dz
+    deriv[6] = 1.0;
+    deriv[7] = 1.0;
+    deriv[8] = 1.0;
 
     value[0] = miu_1_1_1;
     value[1] = miu_1_1_2;

--- a/amptorch/descriptor/MCSH/atomistic_mcsh.cpp
+++ b/amptorch/descriptor/MCSH/atomistic_mcsh.cpp
@@ -1553,18 +1553,18 @@ void calc_MCSH_6_5(double x0, double y0, double z0, double r0_sqr, double A, dou
     double temp_dy_3 = lambda * (3.0 * lambda_y0_sqr + C3_1);
     double temp_dz_3 = lambda * (3.0 * lambda_z0_sqr + C3_1);
 
-    double temp_miu1 = 10395 * temp_x_3 * temp_y_3 - 2835 * (temp_x_3 * lambda_y0 + lambda_x0 * temp_y_3) + 945 * lambda_x0 * lambda_y0;
-    double temp_miu2 = 10395 * temp_x_3 * temp_z_3 - 2835 * (temp_x_3 * lambda_z0 + lambda_x0 * temp_z_3) + 945 * lambda_x0 * lambda_z0;
-    double temp_miu3 = 10395 * temp_y_3 * temp_z_3 - 2835 * (temp_y_3 * lambda_z0 + lambda_y0 * temp_z_3) + 945 * lambda_y0 * lambda_z0;
+    double temp_miu1 = 10395.0 * temp_x_3 * temp_y_3 - 2835.0 * (temp_x_3 * lambda_y0 + lambda_x0 * temp_y_3) + 945.0 * lambda_x0 * lambda_y0;
+    double temp_miu2 = 10395.0 * temp_x_3 * temp_z_3 - 2835.0 * (temp_x_3 * lambda_z0 + lambda_x0 * temp_z_3) + 945.0 * lambda_x0 * lambda_z0;
+    double temp_miu3 = 10395.0 * temp_y_3 * temp_z_3 - 2835.0 * (temp_y_3 * lambda_z0 + lambda_y0 * temp_z_3) + 945.0 * lambda_y0 * lambda_z0;
 
-    double temp_dmiu1_dx = 10395 * temp_dx_3 * temp_y_3 - 2835 * (temp_dx_3 * lambda_y0 + lambda * temp_y_3) + 945 * lambda * lambda_y0;
-    double temp_dmiu1_dy = 10395 * temp_x_3 * temp_dy_3 - 2835 * (temp_x_3 * lambda + lambda_x0 * temp_dy_3) + 945 * lambda_x0 * lambda;
+    double temp_dmiu1_dx = 10395.0 * temp_dx_3 * temp_y_3 - 2835.0 * (temp_dx_3 * lambda_y0 + lambda * temp_y_3) + 945.0 * lambda * lambda_y0;
+    double temp_dmiu1_dy = 10395.0 * temp_x_3 * temp_dy_3 - 2835.0 * (temp_x_3 * lambda + lambda_x0 * temp_dy_3) + 945.0 * lambda_x0 * lambda;
 
-    double temp_dmiu2_dx = 10395 * temp_dx_3 * temp_z_3 - 2835 * (temp_dx_3 * lambda_z0 + lambda * temp_z_3) + 945 * lambda * lambda_z0;
-    double temp_dmiu2_dz = 10395 * temp_x_3 * temp_dz_3 - 2835 * (temp_x_3 * lambda + lambda_x0 * temp_dz_3) + 945 * lambda_x0 * lambda;
+    double temp_dmiu2_dx = 10395.0 * temp_dx_3 * temp_z_3 - 2835.0 * (temp_dx_3 * lambda_z0 + lambda * temp_z_3) + 945.0 * lambda * lambda_z0;
+    double temp_dmiu2_dz = 10395.0 * temp_x_3 * temp_dz_3 - 2835.0 * (temp_x_3 * lambda + lambda_x0 * temp_dz_3) + 945.0 * lambda_x0 * lambda;
 
-    double temp_dmiu3_dy = 10395 * temp_dy_3 * temp_z_3 - 2835 * (temp_dy_3 * lambda_z0 + lambda * temp_z_3) + 945 * lambda * lambda_z0;
-    double temp_dmiu3_dz = 10395 * temp_y_3 * temp_dz_3 - 2835 * (temp_y_3 * lambda + lambda_y0 * temp_dz_3) + 945 * lambda_y0 * lambda;
+    double temp_dmiu3_dy = 10395.0 * temp_dy_3 * temp_z_3 - 2835.0 * (temp_dy_3 * lambda_z0 + lambda * temp_z_3) + 945.0 * lambda * lambda_z0;
+    double temp_dmiu3_dz = 10395.0 * temp_y_3 * temp_dz_3 - 2835.0 * (temp_y_3 * lambda + lambda_y0 * temp_dz_3) + 945.0 * lambda_y0 * lambda;
 
     double miu_6_5_1 = temp * temp_miu1;
     double miu_6_5_2 = temp * temp_miu2;
@@ -2409,9 +2409,9 @@ void calc_MCSH_7_6(double x0, double y0, double z0, double r0_sqr, double A, dou
     double temp_dterm1_dy = 135135.0 * temp_dy_4 - 62370.0 * temp_dy_2;
     double temp_dterm1_dz = 135135.0 * temp_dz_4 - 62370.0 * temp_dz_2;
 
-    double temp_term2_x = -10395.0 * temp_x_4 + 5670 * temp_x_2 - 315.0;
-    double temp_term2_y = -10395.0 * temp_y_4 + 5670 * temp_y_2 - 315.0;
-    double temp_term2_z = -10395.0 * temp_z_4 + 5670 * temp_z_2 - 315.0;
+    double temp_term2_x = -10395.0 * temp_x_4 + 5670.0 * temp_x_2 - 315.0;
+    double temp_term2_y = -10395.0 * temp_y_4 + 5670.0 * temp_y_2 - 315.0;
+    double temp_term2_z = -10395.0 * temp_z_4 + 5670.0 * temp_z_2 - 315.0;
 
     double temp_dterm2_dx = -10395.0 * temp_dx_4 + 5670.0 * temp_dx_2;
     double temp_dterm2_dy = -10395.0 * temp_dy_4 + 5670.0 * temp_dy_2;
@@ -4506,9 +4506,9 @@ void calc_MCSH_9_5(double x0, double y0, double z0, double r0_sqr, double A, dou
     double temp_term2_y = -6081075.0 * temp_y_6 + 6081075.0 * temp_y_4 - 1403325.0 * temp_x_2 + 42525.0;
     double temp_term2_z = -6081075.0 * temp_z_6 + 6081075.0 * temp_z_4 - 1403325.0 * temp_x_2 + 42525.0;
 
-    double temp_dterm2_dx = -6081075.0 * temp_dx_6 + 6081075.0 * temp_dx_4 - 1403325 * temp_dx_2;
-    double temp_dterm2_dy = -6081075.0 * temp_dy_6 + 6081075.0 * temp_dy_4 - 1403325 * temp_dy_2;
-    double temp_dterm2_dz = -6081075.0 * temp_dz_6 + 6081075.0 * temp_dz_4 - 1403325 * temp_dz_2;
+    double temp_dterm2_dx = -6081075.0 * temp_dx_6 + 6081075.0 * temp_dx_4 - 1403325.0 * temp_dx_2;
+    double temp_dterm2_dy = -6081075.0 * temp_dy_6 + 6081075.0 * temp_dy_4 - 1403325.0 * temp_dy_2;
+    double temp_dterm2_dz = -6081075.0 * temp_dz_6 + 6081075.0 * temp_dz_4 - 1403325.0 * temp_dz_2;
 
     double temp_miu1 = temp_y_3 * temp_term1_x + lambda_y0 * temp_term2_x;
     double temp_miu2 = temp_x_3 * temp_term1_y + lambda_x0 * temp_term2_y;
@@ -5553,6 +5553,3051 @@ void calc_MCSH_9_12(double x0, double y0, double z0, double r0_sqr, double A, do
     value[0] = m_9_12;
 }
 
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+void calc_MCSH_0_1_noderiv(double x0, double y0, double z0, double r0_sqr, double A, double B, double alpha, double beta, double *value)
+{   
+    // double r0_sqr = x0*x0 + y0*y0 + z0*z0;
+    double C1 = calc_C1(A,B,alpha,beta);
+    double C2 = calc_C2(alpha, beta);
+    double m_0_1 = C1 * exp( C2 * r0_sqr);
+
+    value[0] = m_0_1;
+}
+
+void calc_MCSH_1_1_noderiv(double x0, double y0, double z0, double r0_sqr, double A, double B, double alpha, double beta, double *value)
+{   
+    // double r0_sqr = x0*x0 + y0*y0 + z0*z0;
+    double C1 = calc_C1(A,B,alpha,beta);
+    double C2 = calc_C2(alpha, beta);
+    double lambda = calc_lambda(alpha, beta);
+
+    double temp = C1 * exp( C2 * r0_sqr);
+
+    double temp_x = lambda * x0;
+    double temp_y = lambda * y0;
+    double temp_z = lambda * z0;
+
+    double miu_1_1_1 = temp * temp_x;
+    double miu_1_1_2 = temp * temp_y;
+    double miu_1_1_3 = temp * temp_z;
+
+    value[0] = miu_1_1_1;
+    value[1] = miu_1_1_2;
+    value[2] = miu_1_1_3;
+
+}
+
+void calc_MCSH_2_1_noderiv(double x0, double y0, double z0, double r0_sqr, double A, double B, double alpha, double beta, double *value)
+{   
+    // double r0_sqr = x0*x0 + y0*y0 + z0*z0;
+    double C1 = calc_C1(A,B,alpha,beta);
+    double C2 = calc_C2(alpha, beta);
+
+    double lambda = calc_lambda(alpha, beta);
+
+    double lambda_x0 = x0 * lambda;
+    double lambda_y0 = y0 * lambda;
+    double lambda_z0 = z0 * lambda;
+
+    double lambda_x0_sqr = lambda_x0 * lambda_x0;
+    double lambda_y0_sqr = lambda_y0 * lambda_y0;
+    double lambda_z0_sqr = lambda_z0 * lambda_z0;
+
+    double gamma = calc_gamma(alpha, beta);
+    double C3 = (3.0/(2.0*gamma)) - 1.0;
+
+    double temp = C1 * exp( C2 * r0_sqr);
+
+    double temp_x = 3.0 * lambda_x0_sqr + C3;
+    double temp_y = 3.0 * lambda_y0_sqr + C3;
+    double temp_z = 3.0 * lambda_z0_sqr + C3;
+
+    double miu_2_1_1 = temp * temp_x;
+    double miu_2_1_2 = temp * temp_y;
+    double miu_2_1_3 = temp * temp_z;
+
+    value[0] = miu_2_1_1;
+    value[1] = miu_2_1_2;
+    value[2] = miu_2_1_3;
+}
+
+void calc_MCSH_2_2_noderiv(double x0, double y0, double z0, double r0_sqr, double A, double B, double alpha, double beta, double *value)
+{   
+    // double r0_sqr = x0*x0 + y0*y0 + z0*z0;
+    double C1 = calc_C1(A,B,alpha,beta);
+    double C2 = calc_C2(alpha, beta);
+    
+    double lambda = calc_lambda(alpha, beta);
+
+    double temp = C1 * exp( C2 * r0_sqr) * lambda * lambda * 3.0;
+
+    double miu_2_2_1 = temp * x0 * y0;
+    double miu_2_2_2 = temp * x0 * z0;
+    double miu_2_2_3 = temp * y0 * z0;
+
+    value[0] = miu_2_2_1;
+    value[1] = miu_2_2_2;
+    value[2] = miu_2_2_3;
+}
+
+void calc_MCSH_3_1_noderiv(double x0, double y0, double z0, double r0_sqr, double A, double B, double alpha, double beta, double *value)
+{   
+    // double r0_sqr = x0*x0 + y0*y0 + z0*z0;
+    double C1 = calc_C1(A,B,alpha,beta);
+    double C2 = calc_C2(alpha, beta);
+    
+    double lambda = calc_lambda(alpha, beta);
+
+    double lambda_x0 = x0 * lambda;
+    double lambda_y0 = y0 * lambda;
+    double lambda_z0 = z0 * lambda;
+
+    double lambda_x0_sqr = lambda_x0 * lambda_x0;
+    double lambda_y0_sqr = lambda_y0 * lambda_y0;
+    double lambda_z0_sqr = lambda_z0 * lambda_z0;
+
+    double lambda_x0_3 = lambda_x0_sqr * lambda_x0;
+    double lambda_y0_3 = lambda_y0_sqr * lambda_y0;
+    double lambda_z0_3 = lambda_z0_sqr * lambda_z0;
+
+    double gamma = calc_gamma(alpha, beta);
+    double C3 = (45.0/(2.0*gamma)) - 9.0;
+
+    double temp = C1 * exp( C2 * r0_sqr);
+
+    double temp_x = 15.0 * lambda_x0_3 + C3 * lambda_x0;
+    double temp_y = 15.0 * lambda_y0_3 + C3 * lambda_y0;
+    double temp_z = 15.0 * lambda_z0_3 + C3 * lambda_z0;
+
+    double miu_3_1_1 = temp * temp_x;
+    double miu_3_1_2 = temp * temp_y;
+    double miu_3_1_3 = temp * temp_z;
+
+    //deriv consts
+    double const_2_C2_x = 2.0 * C2 * x0;
+    double const_2_C2_y = 2.0 * C2 * y0;
+    double const_2_C2_z = 2.0 * C2 * z0;
+
+    value[0] = miu_3_1_1;
+    value[1] = miu_3_1_2;
+    value[2] = miu_3_1_3;
+}
+
+void calc_MCSH_3_2_noderiv(double x0, double y0, double z0, double r0_sqr, double A, double B, double alpha, double beta, double *value)
+{   
+    // double r0_sqr = x0*x0 + y0*y0 + z0*z0;
+    double C1 = calc_C1(A,B,alpha,beta);
+    double C2 = calc_C2(alpha, beta);
+    
+    double lambda = calc_lambda(alpha, beta);
+
+    double lambda_x0 = x0 * lambda;
+    double lambda_y0 = y0 * lambda;
+    double lambda_z0 = z0 * lambda;
+
+    double lambda_x0_sqr = lambda_x0 * lambda_x0;
+    double lambda_y0_sqr = lambda_y0 * lambda_y0;
+    double lambda_z0_sqr = lambda_z0 * lambda_z0;
+
+    double gamma = calc_gamma(alpha, beta);
+    double C3 = (15.0/(2.0*gamma)) - 3.0;
+
+    double temp = C1 * exp( C2 * r0_sqr) * lambda;
+
+    double temp_x = 15.0 * lambda_x0_sqr + C3;
+    double temp_y = 15.0 * lambda_y0_sqr + C3;
+    double temp_z = 15.0 * lambda_z0_sqr + C3;
+
+    double miu_3_2_1 = temp * lambda_y0 * temp_x;
+    double miu_3_2_2 = temp * lambda_x0 * temp_y;
+    double miu_3_2_3 = temp * lambda_z0 * temp_x;
+    double miu_3_2_4 = temp * lambda_x0 * temp_z;
+    double miu_3_2_5 = temp * lambda_z0 * temp_y;
+    double miu_3_2_6 = temp * lambda_y0 * temp_z;
+
+    value[0] = miu_3_2_1;
+    value[1] = miu_3_2_2;
+    value[2] = miu_3_2_3;
+    value[3] = miu_3_2_4;
+    value[4] = miu_3_2_5;
+    value[5] = miu_3_2_6;
+}
+
+void calc_MCSH_3_3_noderiv(double x0, double y0, double z0, double r0_sqr, double A, double B, double alpha, double beta, double *value)
+{   
+    // double r0_sqr = x0*x0 + y0*y0 + z0*z0;
+    double C1 = calc_C1(A,B,alpha,beta);
+    double C2 = calc_C2(alpha, beta);
+    double lambda = calc_lambda(alpha, beta);
+
+    double temp =  C1 * exp( C2 * r0_sqr) * lambda * lambda * lambda * 15.0;
+    double m_3_3 = temp * x0 * y0 * z0;
+
+    value[0] = m_3_3;
+}
+
+void calc_MCSH_4_1_noderiv(double x0, double y0, double z0, double r0_sqr, double A, double B, double alpha, double beta, double *valu, double *deriv)
+{   
+    // double r0_sqr = x0*x0 + y0*y0 + z0*z0;
+    double C1 = calc_C1(A,B,alpha,beta);
+    double C2 = calc_C2(alpha, beta);
+    
+    double lambda = calc_lambda(alpha, beta);
+
+    double lambda_x0 = lambda * x0;
+    double lambda_y0 = lambda * y0;
+    double lambda_z0 = lambda * z0;
+    
+    double lambda_x0_sqr = lambda_x0 * lambda_x0;
+    double lambda_y0_sqr = lambda_y0 * lambda_y0;
+    double lambda_z0_sqr = lambda_z0 * lambda_z0;
+
+    double lambda_x0_3 = lambda_x0_sqr * lambda_x0;
+    double lambda_y0_3 = lambda_y0_sqr * lambda_y0;
+    double lambda_z0_3 = lambda_z0_sqr * lambda_z0;
+
+    double lambda_x0_4 = lambda_x0_3 * lambda_x0;
+    double lambda_y0_4 = lambda_y0_3 * lambda_y0;
+    double lambda_z0_4 = lambda_z0_3 * lambda_z0;
+
+    double gamma = calc_gamma(alpha, beta);
+    double C3 = (315.0/gamma) - 90.0;
+    double C4 = (315.0/(4.0*gamma*gamma)) - (45.0/gamma) + 9.0;
+
+    double temp = C1 * exp( C2 * r0_sqr);
+
+    double temp_x = 105.0 * lambda_x0_4 + C3 * lambda_x0_sqr + C4;
+    double temp_y = 105.0 * lambda_y0_4 + C3 * lambda_y0_sqr + C4;
+    double temp_z = 105.0 * lambda_z0_4 + C3 * lambda_z0_sqr + C4;
+
+    double miu_4_1_1 = temp * temp_x;
+    double miu_4_1_2 = temp * temp_y;
+    double miu_4_1_3 = temp * temp_z;
+
+
+    value[0] = miu_4_1_1;
+    value[1] = miu_4_1_2;
+    value[2] = miu_4_1_3;
+}
+
+void calc_MCSH_4_2_noderiv(double x0, double y0, double z0, double r0_sqr, double A, double B, double alpha, double beta, double *value)
+{   
+    // double r0_sqr = x0*x0 + y0*y0 + z0*z0;
+    double C1 = calc_C1(A,B,alpha,beta);
+    double C2 = calc_C2(alpha, beta);
+    
+    double lambda = calc_lambda(alpha, beta);
+
+    double lambda_x0 = lambda * x0;
+    double lambda_y0 = lambda * y0;
+    double lambda_z0 = lambda * z0;
+    
+    double lambda_x0_sqr = lambda_x0 * lambda_x0;
+    double lambda_y0_sqr = lambda_y0 * lambda_y0;
+    double lambda_z0_sqr = lambda_z0 * lambda_z0;
+
+    double lambda_x0_3 = lambda_x0_sqr * lambda_x0;
+    double lambda_y0_3 = lambda_y0_sqr * lambda_y0;
+    double lambda_z0_3 = lambda_z0_sqr * lambda_z0;
+
+    double gamma = calc_gamma(alpha, beta);
+
+    double C3 = (315.0/(2.0*gamma)) - 45.0;
+
+    double temp = C1 * exp( C2 * r0_sqr);
+
+    double temp_x = 105.0 * lambda_x0_3 + C3 * lambda_x0;
+    double temp_y = 105.0 * lambda_y0_3 + C3 * lambda_y0;
+    double temp_z = 105.0 * lambda_z0_3 + C3 * lambda_z0;
+
+    double miu_4_2_1 = temp * lambda_y0 * temp_x;
+    double miu_4_2_2 = temp * lambda_x0 * temp_y;
+    double miu_4_2_3 = temp * lambda_z0 * temp_x;
+    double miu_4_2_4 = temp * lambda_x0 * temp_z;
+    double miu_4_2_5 = temp * lambda_z0 * temp_y;
+    double miu_4_2_6 = temp * lambda_y0 * temp_z;
+
+    value[0] = miu_4_2_1;
+    value[1] = miu_4_2_2;
+    value[2] = miu_4_2_3;
+    value[3] = miu_4_2_4;
+    value[4] = miu_4_2_5;
+    value[5] = miu_4_2_6;
+}
+
+
+void calc_MCSH_4_3_noderiv(double x0, double y0, double z0, double r0_sqr, double A, double B, double alpha, double beta, double *value)
+{   
+    // double r0_sqr = x0*x0 + y0*y0 + z0*z0;
+    double C1 = calc_C1(A,B,alpha,beta);
+    double C2 = calc_C2(alpha, beta);
+    
+    double lambda = calc_lambda(alpha, beta);
+    double lambda_sqr = lambda * lambda;
+    double x0_sqr = x0*x0;
+    double y0_sqr = y0*y0;
+    double z0_sqr = z0*z0;
+
+    double lambda_x0_sqr = lambda_sqr * x0_sqr;
+    double lambda_y0_sqr = lambda_sqr * y0_sqr;
+    double lambda_z0_sqr = lambda_sqr * z0_sqr;
+
+    double gamma = calc_gamma(alpha, beta);
+
+    double temp_x_2 = lambda_x0_sqr + (1.0/(2.0*gamma));
+    double temp_y_2 = lambda_y0_sqr + (1.0/(2.0*gamma));
+    double temp_z_2 = lambda_z0_sqr + (1.0/(2.0*gamma));
+
+    double temp_term1_x = 105.0 * temp_x_2 - 15.0;
+    double temp_term1_y = 105.0 * temp_y_2 - 15.0;
+    // double temp_term1_z = 105.0 * temp_z_2 - 15.0;
+
+    double temp_term2_x = -15.0 * temp_x_2 + 3.0;
+    double temp_term2_y = -15.0 * temp_y_2 + 3.0;
+    // double temp_term2_z = -15.0 * temp_z_2 + 3.0;
+
+    double temp = C1 * exp( C2 * r0_sqr);
+
+    double temp_miu1 = temp_y_2 * temp_term1_x + temp_term2_x;
+    double temp_miu2 = temp_z_2 * temp_term1_x + temp_term2_x;
+    double temp_miu3 = temp_z_2 * temp_term1_y + temp_term2_y;
+
+    double miu_4_3_1 = temp * temp_miu1;
+    double miu_4_3_2 = temp * temp_miu2;
+    double miu_4_3_3 = temp * temp_miu3;
+
+    value[0] = miu_4_3_1;
+    value[1] = miu_4_3_2;
+    value[2] = miu_4_3_3;
+}
+
+void calc_MCSH_4_4_noderiv(double x0, double y0, double z0, double r0_sqr, double A, double B, double alpha, double beta, double *value)
+{   
+    // double r0_sqr = x0*x0 + y0*y0 + z0*z0;
+    double C1 = calc_C1(A,B,alpha,beta);
+    double C2 = calc_C2(alpha, beta);
+    
+    double lambda = calc_lambda(alpha, beta);
+
+    double lambda_x0 = lambda * x0;
+    double lambda_y0 = lambda * y0;
+    double lambda_z0 = lambda * z0;
+
+    double lambda_x0_sqr = lambda_x0 * lambda_x0;
+    double lambda_y0_sqr = lambda_y0 * lambda_y0;
+    double lambda_z0_sqr = lambda_z0 * lambda_z0;
+
+    double gamma = calc_gamma(alpha, beta);
+    double C3 = (105.0 / (2.0 * gamma)) - 15.0;
+
+    double temp = C1 * exp( C2 * r0_sqr);
+
+    double temp_x = 105.0 * lambda_x0_sqr + C3;
+    double temp_y = 105.0 * lambda_y0_sqr + C3;
+    double temp_z = 105.0 * lambda_z0_sqr + C3;
+
+    double miu_4_4_1 = temp * lambda_y0 * lambda_z0 * temp_x;
+    double miu_4_4_2 = temp * lambda_x0 * lambda_z0 * temp_y;
+    double miu_4_4_3 = temp * lambda_x0 * lambda_y0 * temp_z;
+
+    value[0] = miu_4_4_1;
+    value[1] = miu_4_4_2;
+    value[2] = miu_4_4_3;
+
+}
+
+
+void calc_MCSH_5_1_noderiv(double x0, double y0, double z0, double r0_sqr, double A, double B, double alpha, double beta, double *value)
+{   
+    // double r0_sqr = x0*x0 + y0*y0 + z0*z0;
+    double C1 = calc_C1(A,B,alpha,beta);
+    double C2 = calc_C2(alpha, beta);
+    
+    double lambda = calc_lambda(alpha, beta);
+
+    double lambda_x0 = lambda * x0;
+    double lambda_y0 = lambda * y0;
+    double lambda_z0 = lambda * z0;
+
+    double lambda_x0_sqr = lambda_x0 * lambda_x0;
+    double lambda_y0_sqr = lambda_y0 * lambda_y0;
+    double lambda_z0_sqr = lambda_z0 * lambda_z0;
+
+    double lambda_x0_3 = lambda_x0_sqr * lambda_x0;
+    double lambda_y0_3 = lambda_y0_sqr * lambda_y0;
+    double lambda_z0_3 = lambda_z0_sqr * lambda_z0;
+
+    double lambda_x0_4 = lambda_x0_3 * lambda_x0;
+    double lambda_y0_4 = lambda_y0_3 * lambda_y0;
+    double lambda_z0_4 = lambda_z0_3 * lambda_z0;
+
+    double lambda_x0_5 = lambda_x0_4 * lambda_x0;
+    double lambda_y0_5 = lambda_y0_4 * lambda_y0;
+    double lambda_z0_5 = lambda_z0_4 * lambda_z0;
+
+    double gamma = calc_gamma(alpha, beta);
+    double C3 = (4725.0 / gamma) - 1050.0;
+    double C4 = (14175.0 / (4.0*gamma*gamma)) - (1575.0 / gamma) + 225.0;
+
+    double temp = C1 * exp( C2 * r0_sqr);
+
+    double temp_x = 945.0 * lambda_x0_5 + C3 * lambda_x0_3 + C4 * lambda_x0;
+    double temp_y = 945.0 * lambda_y0_5 + C3 * lambda_y0_3 + C4 * lambda_y0;
+    double temp_z = 945.0 * lambda_z0_5 + C3 * lambda_z0_3 + C4 * lambda_z0;
+
+    double miu_5_1_1 = temp * temp_x;
+    double miu_5_1_2 = temp * temp_y;
+    double miu_5_1_3 = temp * temp_z;
+
+    value[0] = miu_5_1_1;
+    value[1] = miu_5_1_2;
+    value[2] = miu_5_1_3;
+}
+
+void calc_MCSH_5_2_noderiv(double x0, double y0, double z0, double r0_sqr, double A, double B, double alpha, double beta, double *value)
+{   
+    // double r0_sqr = x0*x0 + y0*y0 + z0*z0;
+    double C1 = calc_C1(A,B,alpha,beta);
+    double C2 = calc_C2(alpha, beta);
+    
+    double lambda = calc_lambda(alpha, beta);
+
+    double lambda_x0 = x0 * lambda;
+    double lambda_y0 = y0 * lambda;
+    double lambda_z0 = z0 * lambda;
+
+    double lambda_x0_sqr = lambda_x0 * lambda_x0;
+    double lambda_y0_sqr = lambda_y0 * lambda_y0;
+    double lambda_z0_sqr = lambda_z0 * lambda_z0;
+
+    double lambda_x0_3 = lambda_x0_sqr * lambda_x0;
+    double lambda_y0_3 = lambda_y0_sqr * lambda_y0;
+    double lambda_z0_3 = lambda_z0_sqr * lambda_z0;
+
+    double lambda_x0_4 = lambda_x0_3 * lambda_x0;
+    double lambda_y0_4 = lambda_y0_3 * lambda_y0;
+    double lambda_z0_4 = lambda_z0_3 * lambda_z0;
+
+    double gamma = calc_gamma(alpha, beta);
+    double C3 = (945.0 * 3.0 / gamma) - 630.0;
+    double C4 = (945.0 * 3.0 / (4.0 * gamma * gamma)) - (630.0 / (2.0 * gamma)) + 45.0;
+
+    double temp = C1 * exp( C2 * r0_sqr);
+
+    double temp_x = 945.0 * lambda_x0_4 + C3 * lambda_x0_sqr + C4;
+    double temp_y = 945.0 * lambda_y0_4 + C3 * lambda_y0_sqr + C4;
+    double temp_z = 945.0 * lambda_z0_4 + C3 * lambda_z0_sqr + C4;
+
+    double miu_5_2_1 = temp * lambda_y0 * temp_x;
+    double miu_5_2_2 = temp * lambda_x0 * temp_y;
+    double miu_5_2_3 = temp * lambda_z0 * temp_x;
+    double miu_5_2_4 = temp * lambda_x0 * temp_z;
+    double miu_5_2_5 = temp * lambda_z0 * temp_y;
+    double miu_5_2_6 = temp * lambda_y0 * temp_z;
+
+    value[0] = miu_5_2_1;
+    value[1] = miu_5_2_2;
+    value[2] = miu_5_2_3;
+    value[3] = miu_5_2_4;
+    value[4] = miu_5_2_5;
+    value[5] = miu_5_2_6;
+}
+
+void calc_MCSH_5_3_noderiv(double x0, double y0, double z0, double r0_sqr, double A, double B, double alpha, double beta, double *value)
+{   
+    // double r0_sqr = x0*x0 + y0*y0 + z0*z0;
+    double C1 = calc_C1(A,B,alpha,beta);
+    double C2 = calc_C2(alpha, beta);
+    
+    double lambda = calc_lambda(alpha, beta);
+    double lambda_sqr = lambda * lambda;
+    // double x0_sqr = x0*x0;
+    // double y0_sqr = y0*y0;
+    // double z0_sqr = z0*z0;
+
+    double lambda_x0 = x0 * lambda;
+    double lambda_y0 = y0 * lambda;
+    double lambda_z0 = z0 * lambda;
+
+    double lambda_x0_sqr = lambda_x0 * lambda_x0;
+    double lambda_y0_sqr = lambda_y0 * lambda_y0;
+    double lambda_z0_sqr = lambda_z0 * lambda_z0;
+
+    double lambda_x0_3 = lambda_x0_sqr * lambda_x0;
+    double lambda_y0_3 = lambda_y0_sqr * lambda_y0;
+    double lambda_z0_3 = lambda_z0_sqr * lambda_z0;
+
+    double gamma = calc_gamma(alpha, beta);
+    // double C3 = (945 / (2 * gamma)) - 105;
+    // double C4 = (-315 / ( 2 *gamma)) + 45;
+
+    double temp = C1 * exp( C2 * r0_sqr);
+
+    double temp_x_2 = lambda_x0_sqr + (1.0/(2.0*gamma));
+    double temp_y_2 = lambda_y0_sqr + (1.0/(2.0*gamma));
+    double temp_z_2 = lambda_z0_sqr + (1.0/(2.0*gamma));
+
+    double C3_1 = 3.0 / (2.0 * gamma);
+    double temp_x_3 = lambda_x0_3 + C3_1 * lambda_x0;
+    double temp_y_3 = lambda_y0_3 + C3_1 * lambda_y0;
+    double temp_z_3 = lambda_z0_3 + C3_1 * lambda_z0;
+
+    double temp_term1_x = 945.0 * temp_x_3 - 315.0 * lambda_x0;
+    double temp_term1_y = 945.0 * temp_y_3 - 315.0 * lambda_y0;
+    double temp_term1_z = 945.0 * temp_z_3 - 315.0 * lambda_z0;
+
+    double temp_term2_x = -105.0 * temp_x_3 + 45.0 * lambda_x0;
+    double temp_term2_y = -105.0 * temp_y_3 + 45.0 * lambda_y0;
+    double temp_term2_z = -105.0 * temp_z_3 + 45.0 * lambda_z0;
+
+    double temp_miu1 = temp_y_2 * temp_term1_x + temp_term2_x;
+    double temp_miu2 = temp_x_2 * temp_term1_y + temp_term2_y;
+    double temp_miu3 = temp_z_2 * temp_term1_x + temp_term2_x;
+    double temp_miu4 = temp_x_2 * temp_term1_z + temp_term2_z;
+    double temp_miu5 = temp_z_2 * temp_term1_y + temp_term2_y;
+    double temp_miu6 = temp_y_2 * temp_term1_z + temp_term2_z;
+
+    double miu_5_3_1 = temp * temp_miu1;
+    double miu_5_3_2 = temp * temp_miu2;
+    double miu_5_3_3 = temp * temp_miu3;
+    double miu_5_3_4 = temp * temp_miu4;
+    double miu_5_3_5 = temp * temp_miu5;
+    double miu_5_3_6 = temp * temp_miu6;
+
+    value[0] = miu_5_3_1;
+    value[1] = miu_5_3_2;
+    value[2] = miu_5_3_3;
+    value[3] = miu_5_3_4;
+    value[4] = miu_5_3_5;
+    value[5] = miu_5_3_6;
+}
+
+void calc_MCSH_5_4_noderiv(double x0, double y0, double z0, double r0_sqr, double A, double B, double alpha, double beta, double *value)
+{   
+    // double r0_sqr = x0*x0 + y0*y0 + z0*z0;
+    double C1 = calc_C1(A,B,alpha,beta);
+    double C2 = calc_C2(alpha, beta);
+    
+    double lambda = calc_lambda(alpha, beta);
+
+    double lambda_x0 = x0 * lambda;
+    double lambda_y0 = y0 * lambda;
+    double lambda_z0 = z0 * lambda;
+    
+    double lambda_x0_sqr = lambda_x0 * lambda_x0;
+    double lambda_y0_sqr = lambda_y0 * lambda_y0;
+    double lambda_z0_sqr = lambda_y0 * lambda_z0;
+
+    double lambda_x0_3 = lambda_x0_sqr * lambda_x0;
+    double lambda_y0_3 = lambda_y0_sqr * lambda_y0;
+    double lambda_z0_3 = lambda_z0_sqr * lambda_z0;
+
+    double gamma = calc_gamma(alpha, beta);
+    double C3 = (2835.0 / (2.0 * gamma)) - 315.0;
+
+    double temp = C1 * exp( C2 * r0_sqr);
+
+    double temp_x = 945.0 * lambda_x0_3 + C3 * lambda_x0;
+    double temp_y = 945.0 * lambda_y0_3 + C3 * lambda_y0;
+    double temp_z = 945.0 * lambda_z0_3 + C3 * lambda_z0;
+
+    double miu_5_4_1 = temp * lambda_y0 * lambda_z0 * temp_x;
+    double miu_5_4_2 = temp * lambda_x0 * lambda_z0 * temp_y;
+    double miu_5_4_3 = temp * lambda_x0 * lambda_y0 * temp_z;
+
+    value[0] = miu_5_4_1;
+    value[1] = miu_5_4_2;
+    value[2] = miu_5_4_3;
+
+}
+
+void calc_MCSH_5_5_noderiv(double x0, double y0, double z0, double r0_sqr, double A, double B, double alpha, double beta, double *value)
+{   
+    // double r0_sqr = x0*x0 + y0*y0 + z0*z0;
+    double C1 = calc_C1(A,B,alpha,beta);
+    double C2 = calc_C2(alpha, beta);
+    
+    double lambda = calc_lambda(alpha, beta);
+
+    double lambda_x0 = x0 * lambda;
+    double lambda_y0 = y0 * lambda;
+    double lambda_z0 = z0 * lambda;
+    
+    double lambda_x0_sqr = lambda_x0 * lambda_x0;
+    double lambda_y0_sqr = lambda_y0 * lambda_y0;
+    double lambda_z0_sqr = lambda_z0 * lambda_z0;
+
+    double gamma = calc_gamma(alpha, beta);
+
+    double temp = C1 * exp( C2 * r0_sqr);
+
+    double temp_x_2 = lambda_x0_sqr + (1.0/(2.0*gamma));
+    double temp_y_2 = lambda_y0_sqr + (1.0/(2.0*gamma));
+    double temp_z_2 = lambda_z0_sqr + (1.0/(2.0*gamma));
+
+    double temp_miu1 = 945.0 * temp_x_2 * temp_y_2 - 105.0 * (temp_x_2 + temp_y_2) + 15.0;
+    double temp_miu2 = 945.0 * temp_x_2 * temp_z_2 - 105.0 * (temp_x_2 + temp_z_2) + 15.0;
+    double temp_miu3 = 945.0 * temp_y_2 * temp_z_2 - 105.0 * (temp_y_2 + temp_z_2) + 15.0;
+
+    double miu_5_5_1 = temp * lambda_z0 * temp_miu1;
+    double miu_5_5_2 = temp * lambda_y0 * temp_miu2;
+    double miu_5_5_3 = temp * lambda_x0 * temp_miu3;
+
+    value[0] = miu_5_5_1;
+    value[1] = miu_5_5_2;
+    value[2] = miu_5_5_3;
+}
+
+void calc_MCSH_6_1_noderiv(double x0, double y0, double z0, double r0_sqr, double A, double B, double alpha, double beta, double *value)
+{   
+    // double r0_sqr = x0*x0 + y0*y0 + z0*z0;
+    double C1 = calc_C1(A,B,alpha,beta);
+    double C2 = calc_C2(alpha, beta);
+    
+    double lambda = calc_lambda(alpha, beta);
+
+    double lambda_x0 = lambda * x0;
+    double lambda_y0 = lambda * y0;
+    double lambda_z0 = lambda * z0;
+    
+    double lambda_x0_sqr = lambda_x0 * lambda_x0;
+    double lambda_y0_sqr = lambda_y0 * lambda_y0;
+    double lambda_z0_sqr = lambda_z0 * lambda_z0;
+
+    double lambda_x0_3 = lambda_x0_sqr * lambda_x0;
+    double lambda_y0_3 = lambda_y0_sqr * lambda_y0;
+    double lambda_z0_3 = lambda_z0_sqr * lambda_z0;
+
+    double lambda_x0_4 = lambda_x0_3 * lambda_x0;
+    double lambda_y0_4 = lambda_y0_3 * lambda_y0;
+    double lambda_z0_4 = lambda_z0_3 * lambda_z0;
+
+    double lambda_x0_5 = lambda_x0_4 * lambda_x0;
+    double lambda_y0_5 = lambda_y0_4 * lambda_y0;
+    double lambda_z0_5 = lambda_z0_4 * lambda_z0;
+
+    double lambda_x0_6 = lambda_x0_5 * lambda_x0;
+    double lambda_y0_6 = lambda_y0_5 * lambda_y0;
+    double lambda_z0_6 = lambda_z0_5 * lambda_z0;
+
+    double gamma = calc_gamma(alpha, beta);
+    double C3 = (10395.0 * 15.0 / (2.0 * gamma)) - 14175.0;
+    double C4 = (10395.0 * 45.0 / (4.0 * gamma * gamma)) - (14175.0 * 3.0 / gamma) + 4725.0;
+    double C5 = (10395.0 * 15.0 / (8.0 * gamma * gamma * gamma)) - (14175.0 * 3.0 / (4.0 * gamma * gamma)) + (4725.0 / (2.0 * gamma)) - 225.0;
+
+    double temp = C1 * exp( C2 * r0_sqr);
+
+    double temp_x = 10395.0 * lambda_x0_6 + C3 * lambda_x0_4 + C4 * lambda_x0_sqr + C5;
+    double temp_y = 10395.0 * lambda_y0_6 + C3 * lambda_y0_4 + C4 * lambda_y0_sqr + C5;
+    double temp_z = 10395.0 * lambda_z0_6 + C3 * lambda_z0_4 + C4 * lambda_z0_sqr + C5;
+
+    double miu_6_1_1 = temp * temp_x;
+    double miu_6_1_2 = temp * temp_y;
+    double miu_6_1_3 = temp * temp_z;
+
+    value[0] = miu_6_1_1;
+    value[1] = miu_6_1_2;
+    value[2] = miu_6_1_3;
+}
+
+void calc_MCSH_6_2_noderiv(double x0, double y0, double z0, double r0_sqr, double A, double B, double alpha, double beta, double *value)
+{   
+    // double r0_sqr = x0*x0 + y0*y0 + z0*z0;
+    double C1 = calc_C1(A,B,alpha,beta);
+    double C2 = calc_C2(alpha, beta);
+    
+    double lambda = calc_lambda(alpha, beta);
+
+    double lambda_x0 = x0 * lambda;
+    double lambda_y0 = y0 * lambda;
+    double lambda_z0 = z0 * lambda;
+
+    double lambda_x0_sqr = lambda_x0 * lambda_x0;
+    double lambda_y0_sqr = lambda_y0 * lambda_y0;
+    double lambda_z0_sqr = lambda_z0 * lambda_z0;
+
+    double lambda_x0_3 = lambda_x0_sqr * lambda_x0;
+    double lambda_y0_3 = lambda_y0_sqr * lambda_y0;
+    double lambda_z0_3 = lambda_z0_sqr * lambda_z0;
+
+    double lambda_x0_4 = lambda_x0_3 * lambda_x0;
+    double lambda_y0_4 = lambda_y0_3 * lambda_y0;
+    double lambda_z0_4 = lambda_z0_3 * lambda_z0;
+
+    double lambda_x0_5 = lambda_x0_4 * lambda_x0;
+    double lambda_y0_5 = lambda_y0_4 * lambda_y0;
+    double lambda_z0_5 = lambda_z0_4 * lambda_z0;
+
+    double gamma = calc_gamma(alpha, beta);
+    double C3 = (10395.0 * 5.0 / gamma) - 9450.0;
+    double C4 = (10395.0 * 15.0 / ( 4.0 * gamma * gamma)) - (9450.0 * 3.0 / (2.0 * gamma)) + 1575.0;
+
+    double temp = C1 * exp( C2 * r0_sqr);
+
+    double temp_x = 10395.0 * lambda_x0_5 + C3 * lambda_x0_3 + C4 * lambda_x0;
+    double temp_y = 10395.0 * lambda_y0_5 + C3 * lambda_y0_3 + C4 * lambda_y0;
+    double temp_z = 10395.0 * lambda_z0_5 + C3 * lambda_z0_3 + C4 * lambda_z0;
+
+    double miu_6_2_1 = temp * lambda_y0 * temp_x;
+    double miu_6_2_2 = temp * lambda_x0 * temp_y;
+    double miu_6_2_3 = temp * lambda_z0 * temp_x;
+    double miu_6_2_4 = temp * lambda_x0 * temp_z;
+    double miu_6_2_5 = temp * lambda_z0 * temp_y;
+    double miu_6_2_6 = temp * lambda_y0 * temp_z;
+
+    value[0] = miu_6_2_1;
+    value[1] = miu_6_2_2;
+    value[2] = miu_6_2_3;
+    value[3] = miu_6_2_4;
+    value[4] = miu_6_2_5;
+    value[5] = miu_6_2_6;
+}
+
+void calc_MCSH_6_3_noderiv(double x0, double y0, double z0, double r0_sqr, double A, double B, double alpha, double beta, double *value)
+{   
+    // double r0_sqr = x0*x0 + y0*y0 + z0*z0;
+    double C1 = calc_C1(A,B,alpha,beta);
+    double C2 = calc_C2(alpha, beta);
+    
+    double lambda = calc_lambda(alpha, beta);
+    double lambda_sqr = lambda * lambda;
+
+    double lambda_x0 = x0 * lambda;
+    double lambda_y0 = y0 * lambda;
+    double lambda_z0 = z0 * lambda;
+
+    double lambda_x0_sqr = lambda_x0 * lambda_x0;
+    double lambda_y0_sqr = lambda_y0 * lambda_y0;
+    double lambda_z0_sqr = lambda_z0 * lambda_z0;
+
+    double lambda_x0_3 = lambda_x0_sqr * lambda_x0;
+    double lambda_y0_3 = lambda_y0_sqr * lambda_y0;
+    double lambda_z0_3 = lambda_z0_sqr * lambda_z0;
+
+    double lambda_x0_4 = lambda_x0_3 * lambda_x0;
+    double lambda_y0_4 = lambda_y0_3 * lambda_y0;
+    double lambda_z0_4 = lambda_z0_3 * lambda_z0;
+
+    double gamma = calc_gamma(alpha, beta);
+
+    double temp = C1 * exp( C2 * r0_sqr);
+
+    double temp_x_2 = lambda_x0_sqr + (1.0/(2.0*gamma));
+    double temp_y_2 = lambda_y0_sqr + (1.0/(2.0*gamma));
+    double temp_z_2 = lambda_z0_sqr + (1.0/(2.0*gamma));
+    
+    double C4_1 = 3.0 / gamma, C4_2 = 3.0 / (4.0 * gamma * gamma);
+    double temp_x_4 = lambda_x0_4 + C4_1 * lambda_x0_sqr + C4_2;
+    double temp_y_4 = lambda_y0_4 + C4_1 * lambda_y0_sqr + C4_2;
+    double temp_z_4 = lambda_z0_4 + C4_1 * lambda_z0_sqr + C4_2;
+
+    double temp_term1_x = 10395.0 * temp_x_4 - 5670.0 * temp_x_2 + 315.0;
+    double temp_term1_y = 10395.0 * temp_y_4 - 5670.0 * temp_y_2 + 315.0;
+    double temp_term1_z = 10395.0 * temp_z_4 - 5670.0 * temp_z_2 + 315.0;
+
+    double temp_term2_x = -945.0 * temp_x_4 + 630.0 * temp_x_2 - 45.0;
+    double temp_term2_y = -945.0 * temp_y_4 + 630.0 * temp_y_2 - 45.0;
+    double temp_term2_z = -945.0 * temp_z_4 + 630.0 * temp_z_2 - 45.0;
+
+    double temp_miu1 = temp_y_2 * temp_term1_x + temp_term2_x;
+    double temp_miu2 = temp_x_2 * temp_term1_y + temp_term2_y;
+    double temp_miu3 = temp_z_2 * temp_term1_x + temp_term2_x;
+    double temp_miu4 = temp_x_2 * temp_term1_z + temp_term2_z;
+    double temp_miu5 = temp_z_2 * temp_term1_y + temp_term2_y;
+    double temp_miu6 = temp_y_2 * temp_term1_z + temp_term2_z;
+
+    double miu_6_3_1 = temp * temp_miu1;
+    double miu_6_3_2 = temp * temp_miu2;
+    double miu_6_3_3 = temp * temp_miu3;
+    double miu_6_3_4 = temp * temp_miu4;
+    double miu_6_3_5 = temp * temp_miu5;
+    double miu_6_3_6 = temp * temp_miu6;
+
+    value[0] = miu_6_3_1;
+    value[1] = miu_6_3_2;
+    value[2] = miu_6_3_3;
+    value[3] = miu_6_3_4;
+    value[4] = miu_6_3_5;
+    value[5] = miu_6_3_6;
+}
+
+
+void calc_MCSH_6_4_noderiv(double x0, double y0, double z0, double r0_sqr, double A, double B, double alpha, double beta, double *value)
+{   
+    // double r0_sqr = x0*x0 + y0*y0 + z0*z0;
+    double C1 = calc_C1(A,B,alpha,beta);
+    double C2 = calc_C2(alpha, beta);
+    
+    double lambda = calc_lambda(alpha, beta);
+
+    double lambda_x0 = x0 * lambda;
+    double lambda_y0 = y0 * lambda;
+    double lambda_z0 = z0 * lambda;
+    
+    double lambda_x0_sqr = lambda_x0 * lambda_x0;
+    double lambda_y0_sqr = lambda_y0 * lambda_y0;
+    double lambda_z0_sqr = lambda_z0 * lambda_z0;
+
+    double lambda_x0_3 = lambda_x0_sqr * lambda_x0;
+    double lambda_y0_3 = lambda_y0_sqr * lambda_y0;
+    double lambda_z0_3 = lambda_z0_sqr * lambda_z0;
+
+    double lambda_x0_4 = lambda_x0_3 * lambda_x0;
+    double lambda_y0_4 = lambda_y0_3 * lambda_y0;
+    double lambda_z0_4 = lambda_z0_3 * lambda_z0;
+
+    double gamma = calc_gamma(alpha, beta);
+    double C3 = (10395.0 * 3.0 / gamma) - 5670.0;
+    double C4 = (10395.0 * 3.0 / (4.0 * gamma * gamma)) - (5670.0 / (2.0 * gamma)) + 315.0;
+
+    double temp = C1 * exp( C2 * r0_sqr);
+
+    double temp_x = 10395.0 * lambda_x0_4 + C3 * lambda_x0_sqr + C4;
+    double temp_y = 10395.0 * lambda_y0_4 + C3 * lambda_y0_sqr + C4;
+    double temp_z = 10395.0 * lambda_z0_4 + C3 * lambda_z0_sqr + C4;
+
+    double miu_6_4_1 = temp * lambda_y0 * lambda_z0 * temp_x;
+    double miu_6_4_2 = temp * lambda_x0 * lambda_z0 * temp_y;
+    double miu_6_4_3 = temp * lambda_x0 * lambda_y0 * temp_z;
+
+    value[0] = miu_6_4_1;
+    value[1] = miu_6_4_2;
+    value[2] = miu_6_4_3;
+}
+
+void calc_MCSH_6_5_noderiv(double x0, double y0, double z0, double r0_sqr, double A, double B, double alpha, double beta, double *value)
+{   
+    // double r0_sqr = x0*x0 + y0*y0 + z0*z0;
+    double C1 = calc_C1(A,B,alpha,beta);
+    double C2 = calc_C2(alpha, beta);
+    
+    double lambda = calc_lambda(alpha, beta);
+    // double lambda_sqr = lambda * lambda;
+
+    double lambda_x0 = x0 * lambda;
+    double lambda_y0 = y0 * lambda;
+    double lambda_z0 = z0 * lambda;
+
+    double lambda_x0_sqr = lambda_x0 * lambda_x0;
+    double lambda_y0_sqr = lambda_y0 * lambda_y0;
+    double lambda_z0_sqr = lambda_z0 * lambda_z0;
+
+    double lambda_x0_3 = lambda_x0_sqr * lambda_x0;
+    double lambda_y0_3 = lambda_y0_sqr * lambda_y0;
+    double lambda_z0_3 = lambda_z0_sqr * lambda_z0;
+
+    double gamma = calc_gamma(alpha, beta);
+
+    double temp = C1 * exp( C2 * r0_sqr);
+
+    double C3_1 = 3.0 / (2.0 * gamma);
+    double temp_x_3 = lambda_x0_3 + C3_1 * lambda_x0;
+    double temp_y_3 = lambda_y0_3 + C3_1 * lambda_y0;
+    double temp_z_3 = lambda_z0_3 + C3_1 * lambda_z0;
+
+    double temp_miu1 = 10395.0 * temp_x_3 * temp_y_3 - 2835.0 * (temp_x_3 * lambda_y0 + lambda_x0 * temp_y_3) + 945.0 * lambda_x0 * lambda_y0;
+    double temp_miu2 = 10395.0 * temp_x_3 * temp_z_3 - 2835.0 * (temp_x_3 * lambda_z0 + lambda_x0 * temp_z_3) + 945.0 * lambda_x0 * lambda_z0;
+    double temp_miu3 = 10395.0 * temp_y_3 * temp_z_3 - 2835.0 * (temp_y_3 * lambda_z0 + lambda_y0 * temp_z_3) + 945.0 * lambda_y0 * lambda_z0;
+
+    double miu_6_5_1 = temp * temp_miu1;
+    double miu_6_5_2 = temp * temp_miu2;
+    double miu_6_5_3 = temp * temp_miu3;
+
+    value[0] = miu_6_5_1;
+    value[1] = miu_6_5_2;
+    value[2] = miu_6_5_3;
+}
+
+void calc_MCSH_6_6_noderiv(double x0, double y0, double z0, double r0_sqr, double A, double B, double alpha, double beta, double *value)
+{   
+    // double r0_sqr = x0*x0 + y0*y0 + z0*z0;
+    double C1 = calc_C1(A,B,alpha,beta);
+    double C2 = calc_C2(alpha, beta);
+    
+    double lambda = calc_lambda(alpha, beta);
+
+    double lambda_x0 = x0 * lambda;
+    double lambda_y0 = y0 * lambda;
+    double lambda_z0 = z0 * lambda;
+
+    double lambda_x0_sqr = lambda_x0 * lambda_x0;
+    double lambda_y0_sqr = lambda_y0 * lambda_y0;
+    double lambda_z0_sqr = lambda_z0 * lambda_z0;
+
+    double lambda_x0_3 = lambda_x0_sqr * lambda_x0;
+    double lambda_y0_3 = lambda_y0_sqr * lambda_y0;
+    double lambda_z0_3 = lambda_z0_sqr * lambda_z0;
+
+    double gamma = calc_gamma(alpha, beta);
+
+    double temp = C1 * exp( C2 * r0_sqr);
+
+    double temp_x_2 = lambda_x0_sqr + (1.0/(2.0*gamma));
+    double temp_y_2 = lambda_y0_sqr + (1.0/(2.0*gamma));
+    double temp_z_2 = lambda_z0_sqr + (1.0/(2.0*gamma));
+
+    double C3_1 = 3.0 / (2.0 * gamma);
+    double temp_x_3 = lambda_x0_3 + C3_1 * lambda_x0;
+    double temp_y_3 = lambda_y0_3 + C3_1 * lambda_y0;
+    double temp_z_3 = lambda_z0_3 + C3_1 * lambda_z0;
+
+    double temp_term1_x = 10395.0 * temp_x_3 - 2835.0 * lambda_x0;
+    double temp_term1_y = 10395.0 * temp_y_3 - 2835.0 * lambda_y0;
+    double temp_term1_z = 10395.0 * temp_z_3 - 2835.0 * lambda_z0;
+
+    double temp_term2_x = -945.0 * temp_x_3 + 315.0 * lambda_x0;
+    double temp_term2_y = -945.0 * temp_y_3 + 315.0 * lambda_y0;
+    double temp_term2_z = -945.0 * temp_z_3 + 315.0 * lambda_z0;
+
+    double temp_miu1 = temp_y_2 * temp_term1_x + temp_term2_x;
+    double temp_miu2 = temp_x_2 * temp_term1_y + temp_term2_y;
+    double temp_miu3 = temp_z_2 * temp_term1_x + temp_term2_x;
+    double temp_miu4 = temp_x_2 * temp_term1_z + temp_term2_z;
+    double temp_miu5 = temp_z_2 * temp_term1_y + temp_term2_y;
+    double temp_miu6 = temp_y_2 * temp_term1_z + temp_term2_z;
+
+    double miu_6_6_1 = temp * lambda_z0 * temp_miu1;
+    double miu_6_6_2 = temp * lambda_z0 * temp_miu2;
+    double miu_6_6_3 = temp * lambda_y0 * temp_miu3;
+    double miu_6_6_4 = temp * lambda_y0 * temp_miu4;
+    double miu_6_6_5 = temp * lambda_x0 * temp_miu5;
+    double miu_6_6_6 = temp * lambda_x0 * temp_miu6;
+
+    value[0] = miu_6_6_1;
+    value[1] = miu_6_6_2;
+    value[2] = miu_6_6_3;
+    value[3] = miu_6_6_4;
+    value[4] = miu_6_6_5;
+    value[5] = miu_6_6_6;
+}
+
+
+void calc_MCSH_6_7_noderiv(double x0, double y0, double z0, double r0_sqr, double A, double B, double alpha, double beta, double *value)
+{
+    double C1 = calc_C1(A,B,alpha,beta);
+    double C2 = calc_C2(alpha, beta);
+    
+    double lambda = calc_lambda(alpha, beta);
+    double lambda_sqr = lambda * lambda;
+
+    double lambda_x0 = x0 * lambda;
+    double lambda_y0 = y0 * lambda;
+    double lambda_z0 = z0 * lambda;
+
+    double lambda_x0_sqr = lambda_x0 * lambda_x0;
+    double lambda_y0_sqr = lambda_y0 * lambda_y0;
+    double lambda_z0_sqr = lambda_z0 * lambda_z0;
+
+    double gamma = calc_gamma(alpha, beta);
+
+    double temp_x = lambda_x0_sqr + (1.0/(2.0*gamma));
+    double temp_y = lambda_y0_sqr + (1.0/(2.0*gamma));
+    double temp_z = lambda_z0_sqr + (1.0/(2.0*gamma));
+
+    double t1 = 10395.0 * temp_x * temp_y * temp_z;
+    double t2 = -945.0 * temp_x * temp_y;
+    double t3 = -945.0 * temp_x * temp_z;
+    double t4 = -945.0 * temp_y * temp_z;
+    double t5 = 105.0 * temp_x;
+    double t6 = 105.0 * temp_y;
+    double t7 = 105.0 * temp_z;
+    double t8 = -15.0;
+
+    double sum_ts = t1 + t2 + t3 + t4 + t5 + t6 + t7 + t8;
+
+    double temp =  C1 * exp( C2 * r0_sqr);
+    double m_6_7 = temp * sum_ts;
+
+    value[0] = m_6_7;
+}
+
+void calc_MCSH_7_1_noderiv(double x0, double y0, double z0, double r0_sqr, double A, double B, double alpha, double beta, double *value)
+{   
+    // double r0_sqr = x0*x0 + y0*y0 + z0*z0;
+    double C1 = calc_C1(A,B,alpha,beta);
+    double C2 = calc_C2(alpha, beta);
+    
+    double lambda = calc_lambda(alpha, beta);
+    double lambda_x0 = lambda * x0;
+    double lambda_y0 = lambda * y0;
+    double lambda_z0 = lambda * z0;
+    
+    double lambda_x0_sqr = lambda_x0 * lambda_x0;
+    double lambda_y0_sqr = lambda_y0 * lambda_y0;
+    double lambda_z0_sqr = lambda_z0 * lambda_z0;
+
+    double lambda_x0_3 = lambda_x0_sqr * lambda_x0;
+    double lambda_y0_3 = lambda_y0_sqr * lambda_y0;
+    double lambda_z0_3 = lambda_z0_sqr * lambda_z0;
+
+    double lambda_x0_4 = lambda_x0_3 * lambda_x0;
+    double lambda_y0_4 = lambda_y0_3 * lambda_y0;
+    double lambda_z0_4 = lambda_z0_3 * lambda_z0;
+
+    double lambda_x0_5 = lambda_x0_4 * lambda_x0;
+    double lambda_y0_5 = lambda_y0_4 * lambda_y0;
+    double lambda_z0_5 = lambda_z0_4 * lambda_z0;
+
+    double lambda_x0_6 = lambda_x0_5 * lambda_x0;
+    double lambda_y0_6 = lambda_y0_5 * lambda_y0;
+    double lambda_z0_6 = lambda_z0_5 * lambda_z0;
+
+    double lambda_x0_7 = lambda_x0_6 * lambda_x0;
+    double lambda_y0_7 = lambda_y0_6 * lambda_y0;
+    double lambda_z0_7 = lambda_z0_6 * lambda_z0;
+
+    double gamma = calc_gamma(alpha, beta);
+    double C3 = (135135.0 * 21.0 / (2.0 * gamma)) - 218295.0;
+    double C4 = (135135.0 * 105.0 / (4.0 * gamma * gamma)) - (218295.0 * 5.0 / gamma) + 99225.0;
+    double C5 = (135135.0 * 105.0 / (8.0 * gamma * gamma * gamma)) - (218295.0 * 15.0 / (4.0 * gamma * gamma)) + (99225.0 * 3.0 / (2.0 * gamma)) - 11025.0;
+
+    double temp = C1 * exp( C2 * r0_sqr);
+
+    double temp_x = 135135.0 * lambda_x0_7 + C3 * lambda_x0_5 + C4 * lambda_x0_3 + C5 * lambda_x0;
+    double temp_y = 135135.0 * lambda_y0_7 + C3 * lambda_y0_5 + C4 * lambda_y0_3 + C5 * lambda_y0;
+    double temp_z = 135135.0 * lambda_z0_7 + C3 * lambda_z0_5 + C4 * lambda_z0_3 + C5 * lambda_z0;
+
+    double miu_7_1_1 = temp * temp_x;
+    double miu_7_1_2 = temp * temp_y;
+    double miu_7_1_3 = temp * temp_z;
+
+    value[0] = miu_7_1_1;
+    value[1] = miu_7_1_2;
+    value[2] = miu_7_1_3;
+}
+
+void calc_MCSH_7_2_noderiv(double x0, double y0, double z0, double r0_sqr, double A, double B, double alpha, double beta, double *value)
+{   
+    // double r0_sqr = x0*x0 + y0*y0 + z0*z0;
+    double C1 = calc_C1(A,B,alpha,beta);
+    double C2 = calc_C2(alpha, beta);
+    
+    double lambda = calc_lambda(alpha, beta);
+
+    double lambda_x0 = x0 * lambda;
+    double lambda_y0 = y0 * lambda;
+    double lambda_z0 = z0 * lambda;
+
+    double lambda_x0_sqr = lambda_x0 * lambda_x0;
+    double lambda_y0_sqr = lambda_y0 * lambda_y0;
+    double lambda_z0_sqr = lambda_z0 * lambda_z0;
+
+    double lambda_x0_3 = lambda_x0_sqr * lambda_x0;
+    double lambda_y0_3 = lambda_y0_sqr * lambda_y0;
+    double lambda_z0_3 = lambda_z0_sqr * lambda_z0;
+
+    double lambda_x0_4 = lambda_x0_3 * lambda_x0;
+    double lambda_y0_4 = lambda_y0_3 * lambda_y0;
+    double lambda_z0_4 = lambda_z0_3 * lambda_z0;
+
+    double lambda_x0_5 = lambda_x0_4 * lambda_x0;
+    double lambda_y0_5 = lambda_y0_4 * lambda_y0;
+    double lambda_z0_5 = lambda_z0_4 * lambda_z0;
+
+    double lambda_x0_6 = lambda_x0_5 * lambda_x0;
+    double lambda_y0_6 = lambda_y0_5 * lambda_y0;
+    double lambda_z0_6 = lambda_z0_5 * lambda_z0;
+
+    double gamma = calc_gamma(alpha, beta);
+    double C3 = (135135.0 * 15.0 / (2.0 * gamma)) - 155925.0;
+    double C4 = (135135.0 * 45.0 / (4.0 * gamma * gamma)) - (155925.0 * 3.0 / gamma) + 42525.0;
+    double C5 = (135135.0 * 15.0 / (8.0 * gamma * gamma * gamma)) - (155925.0 * 3.0 / (4.0 * gamma * gamma)) + (42525.0 / (2.0 * gamma)) - 1575.0; 
+
+    double temp = C1 * exp( C2 * r0_sqr);
+
+    double temp_x = 135135.0 * lambda_x0_6 + C3 * lambda_x0_4 + C4 * lambda_x0_sqr + C5;
+    double temp_y = 135135.0 * lambda_y0_6 + C3 * lambda_y0_4 + C4 * lambda_y0_sqr + C5;
+    double temp_z = 135135.0 * lambda_z0_6 + C3 * lambda_z0_4 + C4 * lambda_z0_sqr + C5;
+
+    double miu_7_2_1 = temp * lambda_y0 * temp_x;
+    double miu_7_2_2 = temp * lambda_x0 * temp_y;
+    double miu_7_2_3 = temp * lambda_z0 * temp_x;
+    double miu_7_2_4 = temp * lambda_x0 * temp_z;
+    double miu_7_2_5 = temp * lambda_z0 * temp_y;
+    double miu_7_2_6 = temp * lambda_y0 * temp_z;
+
+    value[0] = miu_7_2_1;
+    value[1] = miu_7_2_2;
+    value[2] = miu_7_2_3;
+    value[3] = miu_7_2_4;
+    value[4] = miu_7_2_5;
+    value[5] = miu_7_2_6;
+}
+
+
+void calc_MCSH_7_3_noderiv(double x0, double y0, double z0, double r0_sqr, double A, double B, double alpha, double beta, double *value)
+{   
+    // double r0_sqr = x0*x0 + y0*y0 + z0*z0;
+    double C1 = calc_C1(A,B,alpha,beta);
+    double C2 = calc_C2(alpha, beta);
+    
+    double lambda = calc_lambda(alpha, beta);
+    double lambda_sqr = lambda * lambda;
+
+    double lambda_x0 = x0 * lambda;
+    double lambda_y0 = y0 * lambda;
+    double lambda_z0 = z0 * lambda;
+
+    double lambda_x0_sqr = lambda_x0 * lambda_x0;
+    double lambda_y0_sqr = lambda_y0 * lambda_y0;
+    double lambda_z0_sqr = lambda_z0 * lambda_z0;
+
+    double lambda_x0_3 = lambda_x0_sqr * lambda_x0;
+    double lambda_y0_3 = lambda_y0_sqr * lambda_y0;
+    double lambda_z0_3 = lambda_z0_sqr * lambda_z0;
+
+    double lambda_x0_4 = lambda_x0_3 * lambda_x0;
+    double lambda_y0_4 = lambda_y0_3 * lambda_y0;
+    double lambda_z0_4 = lambda_z0_3 * lambda_z0;
+
+    double lambda_x0_5 = lambda_x0_4 * lambda_x0;
+    double lambda_y0_5 = lambda_y0_4 * lambda_y0;
+    double lambda_z0_5 = lambda_z0_4 * lambda_z0;
+
+    double gamma = calc_gamma(alpha, beta);
+
+    double temp = C1 * exp( C2 * r0_sqr);
+
+    double temp_x_2 = lambda_x0_sqr + (1.0/(2.0*gamma));
+    double temp_y_2 = lambda_y0_sqr + (1.0/(2.0*gamma));
+    double temp_z_2 = lambda_z0_sqr + (1.0/(2.0*gamma));
+
+    double C3_1 = 3.0 / (2.0 * gamma);
+    double temp_x_3 = lambda_x0_3 + C3_1 * lambda_x0;
+    double temp_y_3 = lambda_y0_3 + C3_1 * lambda_y0;
+    double temp_z_3 = lambda_z0_3 + C3_1 * lambda_z0;
+
+    double C5_1 = 5.0 / gamma, C5_2 = 15.0 / (4.0 * gamma * gamma);
+    double temp_x_5 = lambda_x0_5 + C5_1 * lambda_x0_3 + C5_2 * lambda_x0;
+    double temp_y_5 = lambda_y0_5 + C5_1 * lambda_y0_3 + C5_2 * lambda_y0;
+    double temp_z_5 = lambda_z0_5 + C5_1 * lambda_z0_3 + C5_2 * lambda_z0; 
+
+    double temp_term1_x = 135135.0 * temp_x_5 - 103950.0 * temp_x_3 + 14175.0 * lambda_x0;
+    double temp_term1_y = 135135.0 * temp_y_5 - 103950.0 * temp_y_3 + 14175.0 * lambda_y0;
+    double temp_term1_z = 135135.0 * temp_z_5 - 103950.0 * temp_z_3 + 14175.0 * lambda_z0;
+
+    double temp_term2_x = -10395.0 * temp_x_5 + 9450.0 * temp_x_3 - 1575.0 * lambda_x0;
+    double temp_term2_y = -10395.0 * temp_y_5 + 9450.0 * temp_y_3 - 1575.0 * lambda_y0;
+    double temp_term2_z = -10395.0 * temp_z_5 + 9450.0 * temp_z_3 - 1575.0 * lambda_z0;
+
+    double temp_miu1 = temp_y_2 * temp_term1_x + temp_term2_x;
+    double temp_miu2 = temp_x_2 * temp_term1_y + temp_term2_y;
+    double temp_miu3 = temp_z_2 * temp_term1_x + temp_term2_x;
+    double temp_miu4 = temp_x_2 * temp_term1_z + temp_term2_z;
+    double temp_miu5 = temp_z_2 * temp_term1_y + temp_term2_y;
+    double temp_miu6 = temp_y_2 * temp_term1_z + temp_term2_z;
+
+    double miu_7_3_1 = temp * temp_miu1;
+    double miu_7_3_2 = temp * temp_miu2;
+    double miu_7_3_3 = temp * temp_miu3;
+    double miu_7_3_4 = temp * temp_miu4;
+    double miu_7_3_5 = temp * temp_miu5;
+    double miu_7_3_6 = temp * temp_miu6;
+
+    value[0] = miu_7_3_1;
+    value[1] = miu_7_3_2;
+    value[2] = miu_7_3_3;
+    value[3] = miu_7_3_4;
+    value[4] = miu_7_3_5;
+    value[5] = miu_7_3_6;
+}
+
+
+void calc_MCSH_7_4_noderiv(double x0, double y0, double z0, double r0_sqr, double A, double B, double alpha, double beta, double *value)
+{   
+    // double r0_sqr = x0*x0 + y0*y0 + z0*z0;
+    double C1 = calc_C1(A,B,alpha,beta);
+    double C2 = calc_C2(alpha, beta);
+    
+    double lambda = calc_lambda(alpha, beta);
+
+    double lambda_x0 = x0 * lambda;
+    double lambda_y0 = y0 * lambda;
+    double lambda_z0 = z0 * lambda;
+    
+    double lambda_x0_sqr = lambda_x0 * lambda_x0;
+    double lambda_y0_sqr = lambda_y0 * lambda_y0;
+    double lambda_z0_sqr = lambda_z0 * lambda_z0;
+
+    double lambda_x0_3 = lambda_x0_sqr * lambda_x0;
+    double lambda_y0_3 = lambda_y0_sqr * lambda_y0;
+    double lambda_z0_3 = lambda_z0_sqr * lambda_z0;
+
+    double lambda_x0_4 = lambda_x0_3 * lambda_x0;
+    double lambda_y0_4 = lambda_y0_3 * lambda_y0;
+    double lambda_z0_4 = lambda_z0_3 * lambda_z0;
+    
+    double lambda_x0_5 = lambda_x0_4 * lambda_x0;
+    double lambda_y0_5 = lambda_y0_4 * lambda_y0;
+    double lambda_z0_5 = lambda_z0_4 * lambda_z0;
+
+    double gamma = calc_gamma(alpha, beta);
+    double C3 = (135135.0 * 5.0 / gamma) - 103950.0;
+    double C4 = (135135.0 * 15.0 / (4.0 * gamma * gamma)) - (103950.0 * 3.0 / (2.0 * gamma)) + 14175.0;
+
+    double temp = C1 * exp( C2 * r0_sqr);
+
+    double temp_x = 135135.0 * lambda_x0_5 + C3 * lambda_x0_3 + C4 * lambda_x0;
+    double temp_y = 135135.0 * lambda_y0_5 + C3 * lambda_y0_3 + C4 * lambda_y0;
+    double temp_z = 135135.0 * lambda_z0_5 + C3 * lambda_z0_3 + C4 * lambda_z0;
+
+    double miu_7_4_1 = temp * lambda_y0 * lambda_z0 * temp_x;
+    double miu_7_4_2 = temp * lambda_x0 * lambda_z0 * temp_y;
+    double miu_7_4_3 = temp * lambda_x0 * lambda_y0 * temp_z;
+
+    value[0] = miu_7_4_1;
+    value[1] = miu_7_4_2;
+    value[2] = miu_7_4_3;
+}
+
+void calc_MCSH_7_5_noderiv(double x0, double y0, double z0, double r0_sqr, double A, double B, double alpha, double beta, double *value)
+{   
+    // double r0_sqr = x0*x0 + y0*y0 + z0*z0;
+    double C1 = calc_C1(A,B,alpha,beta);
+    double C2 = calc_C2(alpha, beta);
+    
+    double lambda = calc_lambda(alpha, beta);
+    double lambda_sqr = lambda * lambda;
+
+    double lambda_x0 = x0 * lambda;
+    double lambda_y0 = y0 * lambda;
+    double lambda_z0 = z0 * lambda;
+
+    double lambda_x0_sqr = lambda_x0 * lambda_x0;
+    double lambda_y0_sqr = lambda_y0 * lambda_y0;
+    double lambda_z0_sqr = lambda_z0 * lambda_z0;
+
+    double lambda_x0_3 = lambda_x0_sqr * lambda_x0;
+    double lambda_y0_3 = lambda_y0_sqr * lambda_y0;
+    double lambda_z0_3 = lambda_z0_sqr * lambda_z0;
+
+    double lambda_x0_4 = lambda_x0_3 * lambda_x0;
+    double lambda_y0_4 = lambda_y0_3 * lambda_y0;
+    double lambda_z0_4 = lambda_z0_3 * lambda_z0;
+
+    double gamma = calc_gamma(alpha, beta);
+
+    double temp = C1 * exp( C2 * r0_sqr);
+
+    double temp_x_2 = lambda_x0_sqr + (1.0/(2.0*gamma));
+    double temp_y_2 = lambda_y0_sqr + (1.0/(2.0*gamma));
+    double temp_z_2 = lambda_z0_sqr + (1.0/(2.0*gamma));
+
+    double C3_1 = 3.0 / (2.0 * gamma);
+    double temp_x_3 = lambda_x0_3 + C3_1 * lambda_x0;
+    double temp_y_3 = lambda_y0_3 + C3_1 * lambda_y0;
+    double temp_z_3 = lambda_z0_3 + C3_1 * lambda_z0;
+
+    double C4_1 = 3.0 / gamma, C4_2 = 3.0 / (4.0 * gamma * gamma);
+    double temp_x_4 = lambda_x0_4 + C4_1 * lambda_x0_sqr + C4_2;
+    double temp_y_4 = lambda_y0_4 + C4_1 * lambda_y0_sqr + C4_2;
+    double temp_z_4 = lambda_z0_4 + C4_1 * lambda_z0_sqr + C4_2;
+
+    double temp_term1_x = 135135.0 * temp_x_4 - 62370.0 * temp_x_2 + 2835.0;
+    double temp_term1_y = 135135.0 * temp_y_4 - 62370.0 * temp_y_2 + 2835.0;
+    double temp_term1_z = 135135.0 * temp_z_4 - 62370.0 * temp_z_2 + 2835.0;
+
+    double temp_term2_x = -31185.0 * temp_x_4 + 17010.0 * temp_x_2 - 945.0;
+    double temp_term2_y = -31185.0 * temp_y_4 + 17010.0 * temp_y_2 - 945.0;
+    double temp_term2_z = -31185.0 * temp_z_4 + 17010.0 * temp_z_2 - 945.0;
+
+    double temp_miu1 = temp_y_3 * temp_term1_x + lambda_y0 * temp_term2_x;
+    double temp_miu2 = temp_x_3 * temp_term1_y + lambda_x0 * temp_term2_y;
+    double temp_miu3 = temp_z_3 * temp_term1_x + lambda_z0 * temp_term2_x;
+    double temp_miu4 = temp_x_3 * temp_term1_z + lambda_x0 * temp_term2_z;
+    double temp_miu5 = temp_z_3 * temp_term1_y + lambda_z0 * temp_term2_y;
+    double temp_miu6 = temp_y_3 * temp_term1_z + lambda_y0 * temp_term2_z;
+
+    double miu_7_5_1 = temp * temp_miu1;
+    double miu_7_5_2 = temp * temp_miu2;
+    double miu_7_5_3 = temp * temp_miu3;
+    double miu_7_5_4 = temp * temp_miu4;
+    double miu_7_5_5 = temp * temp_miu5;
+    double miu_7_5_6 = temp * temp_miu6;
+
+    value[0] = miu_7_5_1;
+    value[1] = miu_7_5_2;
+    value[2] = miu_7_5_3;
+    value[3] = miu_7_5_4;
+    value[4] = miu_7_5_5;
+    value[5] = miu_7_5_6;
+}
+
+void calc_MCSH_7_6_noderiv(double x0, double y0, double z0, double r0_sqr, double A, double B, double alpha, double beta, double *value)
+{   
+    // double r0_sqr = x0*x0 + y0*y0 + z0*z0;
+    double C1 = calc_C1(A,B,alpha,beta);
+    double C2 = calc_C2(alpha, beta);
+    
+    double lambda = calc_lambda(alpha, beta);
+
+    double lambda_x0 = x0 * lambda;
+    double lambda_y0 = y0 * lambda;
+    double lambda_z0 = z0 * lambda;
+
+    double lambda_x0_sqr = lambda_x0 * lambda_x0;
+    double lambda_y0_sqr = lambda_y0 * lambda_y0;
+    double lambda_z0_sqr = lambda_z0 * lambda_z0;
+
+    double lambda_x0_3 = lambda_x0_sqr * lambda_x0;
+    double lambda_y0_3 = lambda_y0_sqr * lambda_y0;
+    double lambda_z0_3 = lambda_z0_sqr * lambda_z0;
+
+    double lambda_x0_4 = lambda_x0_3 * lambda_x0;
+    double lambda_y0_4 = lambda_y0_3 * lambda_y0;
+    double lambda_z0_4 = lambda_z0_3 * lambda_z0;
+
+    double gamma = calc_gamma(alpha, beta);
+
+    double temp = C1 * exp( C2 * r0_sqr);
+
+    double temp_x_2 = lambda_x0_sqr + (1.0/(2.0*gamma));
+    double temp_y_2 = lambda_y0_sqr + (1.0/(2.0*gamma));
+    double temp_z_2 = lambda_z0_sqr + (1.0/(2.0*gamma));
+
+    double C4_1 = 3.0 / gamma, C4_2 = 3.0 / (4.0 * gamma * gamma);
+    double temp_x_4 = lambda_x0_4 + C4_1 * lambda_x0_sqr + C4_2;
+    double temp_y_4 = lambda_y0_4 + C4_1 * lambda_y0_sqr + C4_2;
+    double temp_z_4 = lambda_z0_4 + C4_1 * lambda_z0_sqr + C4_2;
+
+    double temp_term1_x = 135135.0 * temp_x_4 - 62370.0 * temp_x_2 + 2835.0;
+    double temp_term1_y = 135135.0 * temp_y_4 - 62370.0 * temp_y_2 + 2835.0;
+    double temp_term1_z = 135135.0 * temp_z_4 - 62370.0 * temp_z_2 + 2835.0;
+
+    double temp_term2_x = -10395.0 * temp_x_4 + 5670.0 * temp_x_2 - 315.0;
+    double temp_term2_y = -10395.0 * temp_y_4 + 5670.0 * temp_y_2 - 315.0;
+    double temp_term2_z = -10395.0 * temp_z_4 + 5670.0 * temp_z_2 - 315.0;
+
+    double temp_miu1 = temp_y_2 * temp_term1_x + temp_term2_x;
+    double temp_miu2 = temp_x_2 * temp_term1_y + temp_term2_y;
+    double temp_miu3 = temp_z_2 * temp_term1_x + temp_term2_x;
+    double temp_miu4 = temp_x_2 * temp_term1_z + temp_term2_z;
+    double temp_miu5 = temp_z_2 * temp_term1_y + temp_term2_y;
+    double temp_miu6 = temp_y_2 * temp_term1_z + temp_term2_z;
+
+    double miu_7_6_1 = temp * lambda_z0 * temp_miu1;
+    double miu_7_6_2 = temp * lambda_z0 * temp_miu2;
+    double miu_7_6_3 = temp * lambda_y0 * temp_miu3;
+    double miu_7_6_4 = temp * lambda_y0 * temp_miu4;
+    double miu_7_6_5 = temp * lambda_x0 * temp_miu5;
+    double miu_7_6_6 = temp * lambda_x0 * temp_miu6;
+
+    value[0] = miu_7_6_1;
+    value[1] = miu_7_6_2;
+    value[2] = miu_7_6_3;
+    value[3] = miu_7_6_4;
+    value[4] = miu_7_6_5;
+    value[5] = miu_7_6_6;
+}
+
+
+void calc_MCSH_7_7_noderiv(double x0, double y0, double z0, double r0_sqr, double A, double B, double alpha, double beta, double *value)
+{   
+    // double r0_sqr = x0*x0 + y0*y0 + z0*z0;
+    double C1 = calc_C1(A,B,alpha,beta);
+    double C2 = calc_C2(alpha, beta);
+    
+    double lambda = calc_lambda(alpha, beta);
+
+    double lambda_x0 = x0 * lambda;
+    double lambda_y0 = y0 * lambda;
+    double lambda_z0 = z0 * lambda;
+
+    double lambda_x0_sqr = lambda_x0 * lambda_x0;
+    double lambda_y0_sqr = lambda_y0 * lambda_y0;
+    double lambda_z0_sqr = lambda_z0 * lambda_z0;
+
+    double lambda_x0_3 = lambda_x0_sqr * lambda_x0;
+    double lambda_y0_3 = lambda_y0_sqr * lambda_y0;
+    double lambda_z0_3 = lambda_z0_sqr * lambda_z0;
+
+    double gamma = calc_gamma(alpha, beta);
+
+    double temp = C1 * exp( C2 * r0_sqr);
+
+    double C3_1 = 3.0 / (2.0 * gamma);
+    double temp_x_3 = lambda_x0_3 + C3_1 * lambda_x0;
+    double temp_y_3 = lambda_y0_3 + C3_1 * lambda_y0;
+    double temp_z_3 = lambda_z0_3 + C3_1 * lambda_z0;
+
+    double temp_term1_x = 135135.0 * temp_x_3 - 31185.0 * lambda_x0;
+    double temp_term1_y = 135135.0 * temp_y_3 - 31185.0 * lambda_y0;
+
+    double temp_term2_x = -31185.0 * temp_x_3 + 8505.0 * lambda_x0;
+    double temp_term2_y = -31185.0 * temp_y_3 + 8505.0 * lambda_y0;
+
+    double temp_miu1 = temp_y_3 * temp_term1_x + lambda_y0 * temp_term2_x;
+    double temp_miu2 = temp_z_3 * temp_term1_x + lambda_z0 * temp_term2_x;
+    double temp_miu3 = temp_z_3 * temp_term1_y + lambda_z0 * temp_term2_y;
+
+    double miu_7_7_1 = temp * lambda_z0 * temp_miu1;
+    double miu_7_7_2 = temp * lambda_y0 * temp_miu2;
+    double miu_7_7_3 = temp * lambda_x0 * temp_miu3;
+
+    value[0] = miu_7_7_1;
+    value[1] = miu_7_7_2;
+    value[2] = miu_7_7_3;
+}
+
+void calc_MCSH_7_8_noderiv(double x0, double y0, double z0, double r0_sqr, double A, double B, double alpha, double beta, double *value)
+{   
+    // double r0_sqr = x0*x0 + y0*y0 + z0*z0;
+    double C1 = calc_C1(A,B,alpha,beta);
+    double C2 = calc_C2(alpha, beta);
+    
+    double lambda = calc_lambda(alpha, beta);
+    double lambda_sqr = lambda * lambda;
+
+    double lambda_x0 = x0 * lambda;
+    double lambda_y0 = y0 * lambda;
+    double lambda_z0 = z0 * lambda;
+
+    double lambda_x0_sqr = lambda_x0 * lambda_x0;
+    double lambda_y0_sqr = lambda_y0 * lambda_y0;
+    double lambda_z0_sqr = lambda_z0 * lambda_z0;
+
+    double lambda_x0_3 = lambda_x0_sqr * lambda_x0;
+    double lambda_y0_3 = lambda_y0_sqr * lambda_y0;
+    double lambda_z0_3 = lambda_z0_sqr * lambda_z0;
+
+    double gamma = calc_gamma(alpha, beta);
+
+    double temp = C1 * exp( C2 * r0_sqr);
+
+    double temp_x_2 = lambda_x0_sqr + (1.0/(2.0*gamma));
+    double temp_y_2 = lambda_y0_sqr + (1.0/(2.0*gamma));
+    double temp_z_2 = lambda_z0_sqr + (1.0/(2.0*gamma));
+
+    double C3_1 = 3.0 / (2.0 * gamma);
+    double temp_x_3 = lambda_x0_3 + C3_1 * lambda_x0;
+    double temp_y_3 = lambda_y0_3 + C3_1 * lambda_y0;
+    double temp_z_3 = lambda_z0_3 + C3_1 * lambda_z0;
+    
+    double temp_term1_x = 135135.0 * temp_x_3 - 31185.0 * lambda_x0;
+    double temp_term1_y = 135135.0 * temp_y_3 - 31185.0 * lambda_y0;
+    double temp_term1_z = 135135.0 * temp_z_3 - 31185.0 * lambda_z0;
+
+    double temp_term2_x = -10395.0 * temp_x_3 + 2835.0 * lambda_x0;
+    double temp_term2_y = -10395.0 * temp_y_3 + 2835.0 * lambda_y0;
+    double temp_term2_z = -10395.0 * temp_z_3 + 2835.0 * lambda_z0;
+
+    double temp_term3_x = 945.0 * temp_x_3 - 315.0 * lambda_x0;
+    double temp_term3_y = 945.0 * temp_y_3 - 315.0 * lambda_y0;
+    double temp_term3_z = 945.0 * temp_z_3 - 315.0 * lambda_z0;
+
+    double temp_miu1 = temp_y_2 * temp_z_2 * temp_term1_x + (temp_y_2 + temp_z_2) * temp_term2_x + temp_term3_x;
+    double temp_miu2 = temp_x_2 * temp_z_2 * temp_term1_y + (temp_x_2 + temp_z_2) * temp_term2_y + temp_term3_y;
+    double temp_miu3 = temp_x_2 * temp_y_2 * temp_term1_z + (temp_x_2 + temp_y_2) * temp_term2_z + temp_term3_z;
+
+    double miu_7_8_1 = temp * temp_miu1;
+    double miu_7_8_2 = temp * temp_miu2;
+    double miu_7_8_3 = temp * temp_miu3;
+
+    value[0] = miu_7_8_1;
+    value[1] = miu_7_8_2;
+    value[2] = miu_7_8_3;
+}
+
+void calc_MCSH_8_1_noderiv(double x0, double y0, double z0, double r0_sqr, double A, double B, double alpha, double beta, double *value)
+{   
+    // double r0_sqr = x0*x0 + y0*y0 + z0*z0;
+    double C1 = calc_C1(A,B,alpha,beta);
+    double C2 = calc_C2(alpha, beta);
+    
+    double lambda = calc_lambda(alpha, beta);
+
+    double lambda_x0 = lambda * x0;
+    double lambda_y0 = lambda * y0;
+    double lambda_z0 = lambda * z0;
+    
+    double lambda_x0_sqr = lambda_x0 * lambda_x0;
+    double lambda_y0_sqr = lambda_y0 * lambda_y0;
+    double lambda_z0_sqr = lambda_z0 * lambda_z0;
+
+    double lambda_x0_3 = lambda_x0_sqr * lambda_x0;
+    double lambda_y0_3 = lambda_y0_sqr * lambda_y0;
+    double lambda_z0_3 = lambda_z0_sqr * lambda_z0;
+
+    double lambda_x0_4 = lambda_x0_3 * lambda_x0;
+    double lambda_y0_4 = lambda_y0_3 * lambda_y0;
+    double lambda_z0_4 = lambda_z0_3 * lambda_z0;
+
+    double lambda_x0_5 = lambda_x0_4 * lambda_x0;
+    double lambda_y0_5 = lambda_y0_4 * lambda_y0;
+    double lambda_z0_5 = lambda_z0_4 * lambda_z0;
+
+    double lambda_x0_6 = lambda_x0_5 * lambda_x0;
+    double lambda_y0_6 = lambda_y0_5 * lambda_y0;
+    double lambda_z0_6 = lambda_z0_5 * lambda_z0;
+
+    double lambda_x0_7 = lambda_x0_6 * lambda_x0;
+    double lambda_y0_7 = lambda_y0_6 * lambda_y0;
+    double lambda_z0_7 = lambda_z0_6 * lambda_z0;
+
+    double lambda_x0_8 = lambda_x0_7 * lambda_x0;
+    double lambda_y0_8 = lambda_y0_7 * lambda_y0;
+    double lambda_z0_8 = lambda_z0_7 * lambda_z0;
+
+    double gamma = calc_gamma(alpha, beta);
+    double C3 = (2027025.0 * 14.0 / gamma) - 3783780.0;
+    double C4 = (2027025.0 * 105.0 / (2.0 * gamma * gamma)) - (3783780.0 * 15.0 / (2.0 * gamma)) + 2182950.0;
+    double C5 = (2027025.0 * 105.0 / (2.0 * gamma * gamma * gamma)) - (3783780.0 * 45.0 / (4.0 * gamma * gamma)) + (2182950.0 * 3.0 / gamma) - 396900.0;
+    double C6 = (2027025.0 * 105.0 / (16.0 * gamma * gamma * gamma * gamma)) - (3783780.0 * 15.0 / (8.0 * gamma * gamma * gamma)) + (2182950.0 * 3.0 / (4.0 * gamma *gamma)) - (396900.0 / (2.0 * gamma)) + 11025.0;
+
+    double temp = C1 * exp( C2 * r0_sqr);
+
+    double temp_x = 2027025.0 * lambda_x0_8 + C3 * lambda_x0_6 + C4 * lambda_x0_4 + C5 * lambda_x0_sqr + C6;
+    double temp_y = 2027025.0 * lambda_y0_8 + C3 * lambda_y0_6 + C4 * lambda_y0_4 + C5 * lambda_y0_sqr + C6;
+    double temp_z = 2027025.0 * lambda_z0_8 + C3 * lambda_z0_6 + C4 * lambda_z0_4 + C5 * lambda_z0_sqr + C6;
+
+    double miu_8_1_1 = temp * temp_x;
+    double miu_8_1_2 = temp * temp_y;
+    double miu_8_1_3 = temp * temp_z;
+
+    value[0] = miu_8_1_1;
+    value[1] = miu_8_1_2;
+    value[2] = miu_8_1_3;
+}
+
+void calc_MCSH_8_2_noderiv(double x0, double y0, double z0, double r0_sqr, double A, double B, double alpha, double beta, double *value)
+{   
+    // double r0_sqr = x0*x0 + y0*y0 + z0*z0;
+    double C1 = calc_C1(A,B,alpha,beta);
+    double C2 = calc_C2(alpha, beta);
+    
+    double lambda = calc_lambda(alpha, beta);
+
+    double lambda_x0 = x0 * lambda;
+    double lambda_y0 = y0 * lambda;
+    double lambda_z0 = z0 * lambda;
+
+    double lambda_x0_sqr = lambda_x0 * lambda_x0;
+    double lambda_y0_sqr = lambda_y0 * lambda_y0;
+    double lambda_z0_sqr = lambda_z0 * lambda_z0;
+
+    double lambda_x0_3 = lambda_x0_sqr * lambda_x0;
+    double lambda_y0_3 = lambda_y0_sqr * lambda_y0;
+    double lambda_z0_3 = lambda_z0_sqr * lambda_z0;
+
+    double lambda_x0_4 = lambda_x0_3 * lambda_x0;
+    double lambda_y0_4 = lambda_y0_3 * lambda_y0;
+    double lambda_z0_4 = lambda_z0_3 * lambda_z0;
+
+    double lambda_x0_5 = lambda_x0_4 * lambda_x0;
+    double lambda_y0_5 = lambda_y0_4 * lambda_y0;
+    double lambda_z0_5 = lambda_z0_4 * lambda_z0;
+
+    double lambda_x0_6 = lambda_x0_5 * lambda_x0;
+    double lambda_y0_6 = lambda_y0_5 * lambda_y0;
+    double lambda_z0_6 = lambda_z0_5 * lambda_z0;
+
+    double lambda_x0_7 = lambda_x0_6 * lambda_x0;
+    double lambda_y0_7 = lambda_y0_6 * lambda_y0;
+    double lambda_z0_7 = lambda_z0_6 * lambda_z0;
+
+    double gamma = calc_gamma(alpha, beta);
+    double C3 = (2027025.0 * 21.0 / (2.0 * gamma)) - 2837835.0;
+    double C4 = (2027025.0 * 105.0 / (4.0 * gamma * gamma)) - (2837835.0 * 5.0 / gamma) + 1091475.0;
+    double C5 = (2027025.0 * 105.0 / (8.0 * gamma * gamma * gamma)) - (2837835.0 * 15.0 / (4.0 * gamma * gamma)) + (1091475.0 * 3.0 / (2.0 * gamma)) - 99225.0; 
+
+    double temp = C1 * exp( C2 * r0_sqr);
+
+    double temp_x = 2027025.0 * lambda_x0_7 + C3 * lambda_x0_5 + C4 * lambda_x0_3 + C5 * lambda_x0;
+    double temp_y = 2027025.0 * lambda_y0_7 + C3 * lambda_y0_5 + C4 * lambda_y0_3 + C5 * lambda_y0;
+    double temp_z = 2027025.0 * lambda_z0_7 + C3 * lambda_z0_5 + C4 * lambda_z0_3 + C5 * lambda_z0;
+
+    double miu_8_2_1 = temp * lambda_y0 * temp_x;
+    double miu_8_2_2 = temp * lambda_x0 * temp_y;
+    double miu_8_2_3 = temp * lambda_z0 * temp_x;
+    double miu_8_2_4 = temp * lambda_x0 * temp_z;
+    double miu_8_2_5 = temp * lambda_z0 * temp_y;
+    double miu_8_2_6 = temp * lambda_y0 * temp_z;
+
+    value[0] = miu_8_2_1;
+    value[1] = miu_8_2_2;
+    value[2] = miu_8_2_3;
+    value[3] = miu_8_2_4;
+    value[4] = miu_8_2_5;
+    value[5] = miu_8_2_6;
+}
+
+
+void calc_MCSH_8_3_noderiv(double x0, double y0, double z0, double r0_sqr, double A, double B, double alpha, double beta, double *value)
+{   
+    // double r0_sqr = x0*x0 + y0*y0 + z0*z0;
+    double C1 = calc_C1(A,B,alpha,beta);
+    double C2 = calc_C2(alpha, beta);
+    
+    double lambda = calc_lambda(alpha, beta);
+    double lambda_sqr = lambda * lambda;
+
+    double lambda_x0 = x0 * lambda;
+    double lambda_y0 = y0 * lambda;
+    double lambda_z0 = z0 * lambda;
+
+    double lambda_x0_sqr = lambda_x0 * lambda_x0;
+    double lambda_y0_sqr = lambda_y0 * lambda_y0;
+    double lambda_z0_sqr = lambda_z0 * lambda_z0;
+
+    double lambda_x0_3 = lambda_x0_sqr * lambda_x0;
+    double lambda_y0_3 = lambda_y0_sqr * lambda_y0;
+    double lambda_z0_3 = lambda_z0_sqr * lambda_z0;
+
+    double lambda_x0_4 = lambda_x0_3 * lambda_x0;
+    double lambda_y0_4 = lambda_y0_3 * lambda_y0;
+    double lambda_z0_4 = lambda_z0_3 * lambda_z0;
+
+    double lambda_x0_5 = lambda_x0_4 * lambda_x0;
+    double lambda_y0_5 = lambda_y0_4 * lambda_y0;
+    double lambda_z0_5 = lambda_z0_4 * lambda_z0;
+
+    double lambda_x0_6 = lambda_x0_5 * lambda_x0;
+    double lambda_y0_6 = lambda_y0_5 * lambda_y0;
+    double lambda_z0_6 = lambda_z0_5 * lambda_z0;
+
+    double gamma = calc_gamma(alpha, beta);
+
+    double temp = C1 * exp( C2 * r0_sqr);
+
+    double temp_x_2 = lambda_x0_sqr + (1.0/(2.0*gamma));
+    double temp_y_2 = lambda_y0_sqr + (1.0/(2.0*gamma));
+    double temp_z_2 = lambda_z0_sqr + (1.0/(2.0*gamma));
+
+    double C4_1 = 3.0 / gamma, C4_2 = 3.0 / (4.0 * gamma * gamma);
+    double temp_x_4 = lambda_x0_4 + C4_1 * lambda_x0_sqr + C4_2;
+    double temp_y_4 = lambda_y0_4 + C4_1 * lambda_y0_sqr + C4_2;
+    double temp_z_4 = lambda_z0_4 + C4_1 * lambda_z0_sqr + C4_2;
+
+    double C6_1 = 15.0 / (2.0 * gamma), C6_2 = 45.0 / (4.0 * gamma * gamma), C6_3 =  15.0 / (8.0 * gamma * gamma * gamma);
+    double temp_x_6 = lambda_x0_6 + C6_1 * lambda_x0_4 + C6_2 * lambda_x0_sqr + C6_3;
+    double temp_y_6 = lambda_y0_6 + C6_1 * lambda_y0_4 + C6_2 * lambda_y0_sqr + C6_3;
+    double temp_z_6 = lambda_z0_6 + C6_1 * lambda_z0_4 + C6_2 * lambda_z0_sqr + C6_3;
+
+    double temp_term1_x = 2027025.0 * temp_x_6 - 2027025.0 * temp_x_4 + 467775.0 * temp_x_2 - 14175.0;
+    double temp_term1_y = 2027025.0 * temp_y_6 - 2027025.0 * temp_y_4 + 467775.0 * temp_y_2 - 14175.0;
+    double temp_term1_z = 2027025.0 * temp_z_6 - 2027025.0 * temp_z_4 + 467775.0 * temp_z_2 - 14175.0;
+
+    double temp_term2_x = -135135.0 * temp_x_6 + 155925.0 * temp_x_4 - 42525.0 * temp_x_2 + 1575.0;
+    double temp_term2_y = -135135.0 * temp_y_6 + 155925.0 * temp_y_4 - 42525.0 * temp_y_2 + 1575.0;
+    double temp_term2_z = -135135.0 * temp_z_6 + 155925.0 * temp_z_4 - 42525.0 * temp_z_2 + 1575.0;
+
+    double temp_miu1 = temp_y_2 * temp_term1_x + temp_term2_x;
+    double temp_miu2 = temp_x_2 * temp_term1_y + temp_term2_y;
+    double temp_miu3 = temp_z_2 * temp_term1_x + temp_term2_x;
+    double temp_miu4 = temp_x_2 * temp_term1_z + temp_term2_z;
+    double temp_miu5 = temp_z_2 * temp_term1_y + temp_term2_y;
+    double temp_miu6 = temp_y_2 * temp_term1_z + temp_term2_z;
+
+    double miu_8_3_1 = temp * temp_miu1;
+    double miu_8_3_2 = temp * temp_miu2;
+    double miu_8_3_3 = temp * temp_miu3;
+    double miu_8_3_4 = temp * temp_miu4;
+    double miu_8_3_5 = temp * temp_miu5;
+    double miu_8_3_6 = temp * temp_miu6;
+
+    value[0] = miu_8_3_1;
+    value[1] = miu_8_3_2;
+    value[2] = miu_8_3_3;
+    value[3] = miu_8_3_4;
+    value[4] = miu_8_3_5;
+    value[5] = miu_8_3_6;
+}
+
+
+void calc_MCSH_8_4_noderiv(double x0, double y0, double z0, double r0_sqr, double A, double B, double alpha, double beta, double *value)
+{   
+    // double r0_sqr = x0*x0 + y0*y0 + z0*z0;
+    double C1 = calc_C1(A,B,alpha,beta);
+    double C2 = calc_C2(alpha, beta);
+    
+    double lambda = calc_lambda(alpha, beta);
+
+    double lambda_x0 = x0 * lambda;
+    double lambda_y0 = y0 * lambda;
+    double lambda_z0 = z0 * lambda;
+    
+    double lambda_x0_sqr = lambda_x0 * lambda_x0;
+    double lambda_y0_sqr = lambda_y0 * lambda_y0;
+    double lambda_z0_sqr = lambda_z0 * lambda_z0;
+
+    double lambda_x0_3 = lambda_x0_sqr * lambda_x0;
+    double lambda_y0_3 = lambda_y0_sqr * lambda_y0;
+    double lambda_z0_3 = lambda_z0_sqr * lambda_z0;
+
+    double lambda_x0_4 = lambda_x0_3 * lambda_x0;
+    double lambda_y0_4 = lambda_y0_3 * lambda_y0;
+    double lambda_z0_4 = lambda_z0_3 * lambda_z0;
+
+    double lambda_x0_5 = lambda_x0_4 * lambda_x0;
+    double lambda_y0_5 = lambda_y0_4 * lambda_y0;
+    double lambda_z0_5 = lambda_z0_4 * lambda_z0;
+
+    double lambda_x0_6 = lambda_x0_5 * lambda_x0;
+    double lambda_y0_6 = lambda_y0_5 * lambda_y0;
+    double lambda_z0_6 = lambda_z0_5 * lambda_z0;
+
+    double gamma = calc_gamma(alpha, beta);
+    double C3 = (2027025.0 * 15.0 / (2.0 * gamma)) - 2027025.0;
+    double C4 = (2027025.0 * 45.0 / (4.0 * gamma * gamma)) - (2027025.0 * 3.0 / gamma) + 467775.0;
+    double C5 = (2027025.0 * 15.0 / (8.0 * gamma * gamma * gamma)) - (2027025.0 * 3.0 / (4.0 * gamma * gamma)) + (467775.0 / (2.0 * gamma)) - 14175.0;
+
+    double temp = C1 * exp( C2 * r0_sqr);
+
+    double temp_x = 2027025.0 * lambda_x0_6 + C3 * lambda_x0_4 + C4 * lambda_x0_sqr + C5;
+    double temp_y = 2027025.0 * lambda_y0_6 + C3 * lambda_y0_4 + C4 * lambda_y0_sqr + C5;
+    double temp_z = 2027025.0 * lambda_z0_6 + C3 * lambda_z0_4 + C4 * lambda_z0_sqr + C5;
+
+    double miu_8_4_1 = temp * lambda_y0 * lambda_z0 * temp_x;
+    double miu_8_4_2 = temp * lambda_x0 * lambda_z0 * temp_y;
+    double miu_8_4_3 = temp * lambda_x0 * lambda_y0 * temp_z;
+
+    value[0] = miu_8_4_1;
+    value[1] = miu_8_4_2;
+    value[2] = miu_8_4_3;
+}
+
+void calc_MCSH_8_5_noderiv(double x0, double y0, double z0, double r0_sqr, double A, double B, double alpha, double beta, double *value)
+{   
+    // double r0_sqr = x0*x0 + y0*y0 + z0*z0;
+    double C1 = calc_C1(A,B,alpha,beta);
+    double C2 = calc_C2(alpha, beta);
+    
+    double lambda = calc_lambda(alpha, beta);
+    // double lambda_sqr = lambda * lambda;
+
+    double lambda_x0 = x0 * lambda;
+    double lambda_y0 = y0 * lambda;
+    double lambda_z0 = z0 * lambda;
+
+    double lambda_x0_sqr = lambda_x0 * lambda_x0;
+    double lambda_y0_sqr = lambda_y0 * lambda_y0;
+    double lambda_z0_sqr = lambda_z0 * lambda_z0;
+
+    double lambda_x0_3 = lambda_x0_sqr * lambda_x0;
+    double lambda_y0_3 = lambda_y0_sqr * lambda_y0;
+    double lambda_z0_3 = lambda_z0_sqr * lambda_z0;
+
+    double lambda_x0_4 = lambda_x0_3 * lambda_x0;
+    double lambda_y0_4 = lambda_y0_3 * lambda_y0;
+    double lambda_z0_4 = lambda_z0_3 * lambda_z0;
+
+    double lambda_x0_5 = lambda_x0_4 * lambda_x0;
+    double lambda_y0_5 = lambda_y0_4 * lambda_y0;
+    double lambda_z0_5 = lambda_z0_4 * lambda_z0;
+
+    double gamma = calc_gamma(alpha, beta);
+
+    double temp = C1 * exp( C2 * r0_sqr);
+
+    double C3_1 = 3.0 / (2.0 * gamma);
+    double temp_x_3 = lambda_x0_3 + C3_1 * lambda_x0;
+    double temp_y_3 = lambda_y0_3 + C3_1 * lambda_y0;
+    double temp_z_3 = lambda_z0_3 + C3_1 * lambda_z0;
+
+    double C5_1 = 5.0 / gamma, C5_2 = 15.0 / (4.0 * gamma * gamma);
+    double temp_x_5 = lambda_x0_5 + C5_1 * lambda_x0_3 + C5_2 * lambda_x0;
+    double temp_y_5 = lambda_y0_5 + C5_1 * lambda_y0_3 + C5_2 * lambda_y0;
+    double temp_z_5 = lambda_z0_5 + C5_1 * lambda_z0_3 + C5_2 * lambda_z0; 
+
+    double temp_term1_x = 2027025.0 * temp_x_5 - 1351350.0 * temp_x_3 + 155925.0 * lambda_x0;
+    double temp_term1_y = 2027025.0 * temp_y_5 - 1351350.0 * temp_y_3 + 155925.0 * lambda_y0;
+    double temp_term1_z = 2027025.0 * temp_z_5 - 1351350.0 * temp_z_3 + 155925.0 * lambda_z0;
+
+    double temp_term2_x = -405405.0 * temp_x_5 + 311805.0 * temp_x_3 - 42525.0 * lambda_x0;
+    double temp_term2_y = -405405.0 * temp_y_5 + 311805.0 * temp_y_3 - 42525.0 * lambda_y0;
+    double temp_term2_z = -405405.0 * temp_z_5 + 311805.0 * temp_z_3 - 42525.0 * lambda_z0;
+
+    double temp_miu1 = temp_y_3 * temp_term1_x + lambda_y0 * temp_term2_x;
+    double temp_miu2 = temp_x_3 * temp_term1_y + lambda_x0 * temp_term2_y;
+    double temp_miu3 = temp_z_3 * temp_term1_x + lambda_z0 * temp_term2_x;
+    double temp_miu4 = temp_x_3 * temp_term1_z + lambda_x0 * temp_term2_z;
+    double temp_miu5 = temp_z_3 * temp_term1_y + lambda_z0 * temp_term2_y;
+    double temp_miu6 = temp_y_3 * temp_term1_z + lambda_y0 * temp_term2_z;
+
+    double miu_8_5_1 = temp * temp_miu1;
+    double miu_8_5_2 = temp * temp_miu2;
+    double miu_8_5_3 = temp * temp_miu3;
+    double miu_8_5_4 = temp * temp_miu4;
+    double miu_8_5_5 = temp * temp_miu5;
+    double miu_8_5_6 = temp * temp_miu6;
+
+    value[0] = miu_8_5_1;
+    value[1] = miu_8_5_2;
+    value[2] = miu_8_5_3;
+    value[3] = miu_8_5_4;
+    value[4] = miu_8_5_5;
+    value[5] = miu_8_5_6;
+}
+
+void calc_MCSH_8_6_noderiv(double x0, double y0, double z0, double r0_sqr, double A, double B, double alpha, double beta, double *value)
+{   
+    // double r0_sqr = x0*x0 + y0*y0 + z0*z0;
+    double C1 = calc_C1(A,B,alpha,beta);
+    double C2 = calc_C2(alpha, beta);
+    
+    double lambda = calc_lambda(alpha, beta);
+
+    double lambda_x0 = x0 * lambda;
+    double lambda_y0 = y0 * lambda;
+    double lambda_z0 = z0 * lambda;
+
+    double lambda_x0_sqr = lambda_x0 * lambda_x0;
+    double lambda_y0_sqr = lambda_y0 * lambda_y0;
+    double lambda_z0_sqr = lambda_z0 * lambda_z0;
+
+    double lambda_x0_3 = lambda_x0_sqr * lambda_x0;
+    double lambda_y0_3 = lambda_y0_sqr * lambda_y0;
+    double lambda_z0_3 = lambda_z0_sqr * lambda_z0;
+
+    double lambda_x0_4 = lambda_x0_3 * lambda_x0;
+    double lambda_y0_4 = lambda_y0_3 * lambda_y0;
+    double lambda_z0_4 = lambda_z0_3 * lambda_z0;
+
+    double lambda_x0_5 = lambda_x0_4 * lambda_x0;
+    double lambda_y0_5 = lambda_y0_4 * lambda_y0;
+    double lambda_z0_5 = lambda_z0_4 * lambda_z0;
+
+    double gamma = calc_gamma(alpha, beta);
+
+    double temp = C1 * exp( C2 * r0_sqr);
+
+    double temp_x_2 = lambda_x0_sqr + (1.0/(2.0*gamma));
+    double temp_y_2 = lambda_y0_sqr + (1.0/(2.0*gamma));
+    double temp_z_2 = lambda_z0_sqr + (1.0/(2.0*gamma));
+
+    double C3_1 = 3.0 / (2.0 * gamma);
+    double temp_x_3 = lambda_x0_3 + C3_1 * lambda_x0;
+    double temp_y_3 = lambda_y0_3 + C3_1 * lambda_y0;
+    double temp_z_3 = lambda_z0_3 + C3_1 * lambda_z0;
+
+    double C5_1 = 5.0 / gamma, C5_2 = 15.0 / (4.0 * gamma * gamma);
+    double temp_x_5 = lambda_x0_5 + C5_1 * lambda_x0_3 + C5_2 * lambda_x0;
+    double temp_y_5 = lambda_y0_5 + C5_1 * lambda_y0_3 + C5_2 * lambda_y0;
+    double temp_z_5 = lambda_z0_5 + C5_1 * lambda_z0_3 + C5_2 * lambda_z0;
+
+    double temp_term1_x = 2027025.0 * temp_x_5 - 1351350.0 * temp_x_3 + 155925.0 * lambda_x0;
+    double temp_term1_y = 2027025.0 * temp_y_5 - 1351350.0 * temp_y_3 + 155925.0 * lambda_y0;
+    double temp_term1_z = 2027025.0 * temp_z_5 - 1351350.0 * temp_z_3 + 155925.0 * lambda_z0;
+
+    double temp_term2_x = -135135.0 * temp_x_5 + 103950.0 * temp_x_3 - 14175.0 * lambda_x0;
+    double temp_term2_y = -135135.0 * temp_y_5 + 103950.0 * temp_y_3 - 14175.0 * lambda_y0;
+    double temp_term2_z = -135135.0 * temp_z_5 + 103950.0 * temp_z_3 - 14175.0 * lambda_z0;
+    
+    double temp_miu1 = temp_y_2 * temp_term1_x + temp_term2_x;
+    double temp_miu2 = temp_x_2 * temp_term1_y + temp_term2_y;
+    double temp_miu3 = temp_z_2 * temp_term1_x + temp_term2_x;
+    double temp_miu4 = temp_x_2 * temp_term1_z + temp_term2_z;
+    double temp_miu5 = temp_z_2 * temp_term1_y + temp_term2_y;
+    double temp_miu6 = temp_y_2 * temp_term1_z + temp_term2_z;
+
+    double miu_8_6_1 = temp * lambda_z0 * temp_miu1;
+    double miu_8_6_2 = temp * lambda_z0 * temp_miu2;
+    double miu_8_6_3 = temp * lambda_y0 * temp_miu3;
+    double miu_8_6_4 = temp * lambda_y0 * temp_miu4;
+    double miu_8_6_5 = temp * lambda_x0 * temp_miu5;
+    double miu_8_6_6 = temp * lambda_x0 * temp_miu6;
+
+    value[0] = miu_8_6_1;
+    value[1] = miu_8_6_2;
+    value[2] = miu_8_6_3;
+    value[3] = miu_8_6_4;
+    value[4] = miu_8_6_5;
+    value[5] = miu_8_6_6;
+}
+
+
+void calc_MCSH_8_7_noderiv(double x0, double y0, double z0, double r0_sqr, double A, double B, double alpha, double beta, double *value)
+{   
+    // double r0_sqr = x0*x0 + y0*y0 + z0*z0;
+    double C1 = calc_C1(A,B,alpha,beta);
+    double C2 = calc_C2(alpha, beta);
+    
+    double lambda = calc_lambda(alpha, beta);
+    double lambda_sqr = lambda * lambda;
+
+    double lambda_x0 = x0 * lambda;
+    double lambda_y0 = y0 * lambda;
+    double lambda_z0 = z0 * lambda;
+
+    double lambda_x0_sqr = lambda_x0 * lambda_x0;
+    double lambda_y0_sqr = lambda_y0 * lambda_y0;
+    double lambda_z0_sqr = lambda_z0 * lambda_z0;
+
+    double lambda_x0_3 = lambda_x0_sqr * lambda_x0;
+    double lambda_y0_3 = lambda_y0_sqr * lambda_y0;
+    double lambda_z0_3 = lambda_z0_sqr * lambda_z0;
+
+    double lambda_x0_4 = lambda_x0_3 * lambda_x0;
+    double lambda_y0_4 = lambda_y0_3 * lambda_y0;
+    double lambda_z0_4 = lambda_z0_3 * lambda_z0;
+
+    double gamma = calc_gamma(alpha, beta);
+    double temp = C1 * exp( C2 * r0_sqr);
+
+    double temp_x_2 = lambda_x0_sqr + (1.0/(2.0*gamma));
+    double temp_y_2 = lambda_y0_sqr + (1.0/(2.0*gamma));
+    double temp_z_2 = lambda_z0_sqr + (1.0/(2.0*gamma));
+
+    double C4_1 = 3.0 / gamma, C4_2 = 3.0 / (4.0 * gamma * gamma);
+    double temp_x_4 = lambda_x0_4 + C4_1 * lambda_x0_sqr + C4_2;
+    double temp_y_4 = lambda_y0_4 + C4_1 * lambda_y0_sqr + C4_2;
+    double temp_z_4 = lambda_z0_4 + C4_1 * lambda_z0_sqr + C4_2;
+
+    double temp_term1_x = 2027025.0 * temp_x_4 - 810810.0 * temp_x_2 + 31185.0;
+    double temp_term1_y = 2027025.0 * temp_y_4 - 810810.0 * temp_y_2 + 31185.0;
+    // double temp_term1_z = 2027025.0 * temp_z_4 - 810810.0 * temp_z_2 + 31185.0;
+
+    double temp_term2_x = -810810.0 * temp_x_4 + 374220.0 * temp_x_2 - 17010.0;
+    double temp_term2_y = -810810.0 * temp_y_4 + 374220.0 * temp_y_2 - 17010.0;
+    // double temp_term2_z = -810810.0 * temp_z_4 + 374220.0 * temp_z_2 - 17010.0;
+
+    double temp_term3_x = 31185.0 * temp_x_4 - 17010.0 * temp_x_2 + 945.0;
+    double temp_term3_y = 31185.0 * temp_y_4 - 17010.0 * temp_y_2 + 945.0;
+    // double temp_term3_z = 31185.0 * temp_z_4 - 17010.0 * temp_z_2 + 945.0;
+
+    double temp_miu1 = temp_y_4 * temp_term1_x + temp_y_2 * temp_term2_x + temp_term3_x;
+    double temp_miu2 = temp_z_4 * temp_term1_x + temp_z_2 * temp_term2_x + temp_term3_x;
+    double temp_miu3 = temp_z_4 * temp_term1_y + temp_z_2 * temp_term2_y + temp_term3_y;
+
+    double miu_8_7_1 = temp * temp_miu1;
+    double miu_8_7_2 = temp * temp_miu2;
+    double miu_8_7_3 = temp * temp_miu3;
+
+    value[0] = miu_8_7_1;
+    value[1] = miu_8_7_2;
+    value[2] = miu_8_7_3;
+}
+
+
+void calc_MCSH_8_8_noderiv(double x0, double y0, double z0, double r0_sqr, double A, double B, double alpha, double beta, double *value)
+{   
+    // double r0_sqr = x0*x0 + y0*y0 + z0*z0;
+    double C1 = calc_C1(A,B,alpha,beta);
+    double C2 = calc_C2(alpha, beta);
+    
+    double lambda = calc_lambda(alpha, beta);
+
+    double lambda_x0 = x0 * lambda;
+    double lambda_y0 = y0 * lambda;
+    double lambda_z0 = z0 * lambda;
+
+    double lambda_x0_sqr = lambda_x0 * lambda_x0;
+    double lambda_y0_sqr = lambda_y0 * lambda_y0;
+    double lambda_z0_sqr = lambda_z0 * lambda_z0;
+
+    double lambda_x0_3 = lambda_x0_sqr * lambda_x0;
+    double lambda_y0_3 = lambda_y0_sqr * lambda_y0;
+    double lambda_z0_3 = lambda_z0_sqr * lambda_z0;
+
+    double lambda_x0_4 = lambda_x0_3 * lambda_x0;
+    double lambda_y0_4 = lambda_y0_3 * lambda_y0;
+    double lambda_z0_4 = lambda_z0_3 * lambda_z0;
+
+    double gamma = calc_gamma(alpha, beta);
+    double temp = C1 * exp( C2 * r0_sqr);
+
+    double temp_x_2 = lambda_x0_sqr + (1.0/(2.0*gamma));
+    double temp_y_2 = lambda_y0_sqr + (1.0/(2.0*gamma));
+    double temp_z_2 = lambda_z0_sqr + (1.0/(2.0*gamma));
+
+    double C3_1 = 3.0 / (2.0 * gamma);
+    double temp_x_3 = lambda_x0_3 + C3_1 * lambda_x0;
+    double temp_y_3 = lambda_y0_3 + C3_1 * lambda_y0;
+    double temp_z_3 = lambda_z0_3 + C3_1 * lambda_z0;
+
+    double C4_1 = 3.0 / gamma, C4_2 = 3.0 / (4.0 * gamma * gamma);
+    double temp_x_4 = lambda_x0_4 + C4_1 * lambda_x0_sqr + C4_2;
+    double temp_y_4 = lambda_y0_4 + C4_1 * lambda_y0_sqr + C4_2;
+    double temp_z_4 = lambda_z0_4 + C4_1 * lambda_z0_sqr + C4_2;
+
+    double temp_term1_x = 2027025.0 * temp_x_4 - 810810.0 * temp_x_2 + 31185.0;
+    double temp_term1_y = 2027025.0 * temp_y_4 - 810810.0 * temp_y_2 + 31185.0;
+    double temp_term1_z = 2027025.0 * temp_z_4 - 810810.0 * temp_z_2 + 31185.0;
+
+    double temp_term2_x = -405405.0 * temp_x_4 + 187110.0 * temp_x_2 - 8505.0;
+    double temp_term2_y = -405405.0 * temp_y_4 + 187110.0 * temp_y_2 - 8505.0;
+    double temp_term2_z = -405405.0 * temp_z_4 + 187110.0 * temp_z_2 - 8505.0;
+
+    double temp_miu1 = temp_y_3 * temp_term1_x + lambda_y0 * temp_term2_x;
+    double temp_miu2 = temp_x_3 * temp_term1_y + lambda_x0 * temp_term2_y;
+    double temp_miu3 = temp_z_3 * temp_term1_x + lambda_z0 * temp_term2_x;
+    double temp_miu4 = temp_x_3 * temp_term1_z + lambda_x0 * temp_term2_z;
+    double temp_miu5 = temp_z_3 * temp_term1_y + lambda_z0 * temp_term2_y;
+    double temp_miu6 = temp_y_3 * temp_term1_z + lambda_y0 * temp_term2_z;
+
+    double miu_8_8_1 = temp * lambda_z0 * temp_miu1;
+    double miu_8_8_2 = temp * lambda_z0 * temp_miu2;
+    double miu_8_8_3 = temp * lambda_y0 * temp_miu3;
+    double miu_8_8_4 = temp * lambda_y0 * temp_miu4;
+    double miu_8_8_5 = temp * lambda_x0 * temp_miu5;
+    double miu_8_8_6 = temp * lambda_x0 * temp_miu6;
+
+    value[0] = miu_8_8_1;
+    value[1] = miu_8_8_2;
+    value[2] = miu_8_8_3;
+    value[3] = miu_8_8_4;
+    value[4] = miu_8_8_5;
+    value[5] = miu_8_8_6;
+}
+
+void calc_MCSH_8_9_noderiv(double x0, double y0, double z0, double r0_sqr, double A, double B, double alpha, double beta, double *value)
+{   
+    // double r0_sqr = x0*x0 + y0*y0 + z0*z0;
+    double C1 = calc_C1(A,B,alpha,beta);
+    double C2 = calc_C2(alpha, beta);
+    
+    double lambda = calc_lambda(alpha, beta);
+    double lambda_sqr = lambda * lambda;
+
+    double lambda_x0 = x0 * lambda;
+    double lambda_y0 = y0 * lambda;
+    double lambda_z0 = z0 * lambda;
+
+    double lambda_x0_sqr = lambda_x0 * lambda_x0;
+    double lambda_y0_sqr = lambda_y0 * lambda_y0;
+    double lambda_z0_sqr = lambda_z0 * lambda_z0;
+
+    double lambda_x0_3 = lambda_x0_sqr * lambda_x0;
+    double lambda_y0_3 = lambda_y0_sqr * lambda_y0;
+    double lambda_z0_3 = lambda_z0_sqr * lambda_z0;
+
+    double lambda_x0_4 = lambda_x0_3 * lambda_x0;
+    double lambda_y0_4 = lambda_y0_3 * lambda_y0;
+    double lambda_z0_4 = lambda_z0_3 * lambda_z0;
+
+    double gamma = calc_gamma(alpha, beta);
+
+    double temp = C1 * exp( C2 * r0_sqr);
+
+    double temp_x_2 = lambda_x0_sqr + (1.0/(2.0*gamma));
+    double temp_y_2 = lambda_y0_sqr + (1.0/(2.0*gamma));
+    double temp_z_2 = lambda_z0_sqr + (1.0/(2.0*gamma));
+
+    double C4_1 = 3.0 / gamma, C4_2 = 3.0 / (4.0 * gamma * gamma);
+    double temp_x_4 = lambda_x0_4 + C4_1 * lambda_x0_sqr + C4_2;
+    double temp_y_4 = lambda_y0_4 + C4_1 * lambda_y0_sqr + C4_2;
+    double temp_z_4 = lambda_z0_4 + C4_1 * lambda_z0_sqr + C4_2;
+
+    double temp_term1_x = 2027025.0 * temp_x_4 - 810810.0 * temp_x_2 + 31185.0;
+    double temp_term1_y = 2027025.0 * temp_y_4 - 810810.0 * temp_y_2 + 31185.0;
+    double temp_term1_z = 2027025.0 * temp_z_4 - 810810.0 * temp_z_2 + 31185.0;
+
+    double temp_term2_x = -135135.0 * temp_x_4 + 62370.0 * temp_x_2 - 2835.0;
+    double temp_term2_y = -135135.0 * temp_y_4 + 62370.0 * temp_y_2 - 2835.0;
+    double temp_term2_z = -135135.0 * temp_z_4 + 62370.0 * temp_z_2 - 2835.0;
+
+    double temp_term3_x = 10395.0 * temp_x_4 - 5670.0 * temp_x_2 + 315.0;
+    double temp_term3_y = 10395.0 * temp_y_4 - 5670.0 * temp_y_2 + 315.0;
+    double temp_term3_z = 10395.0 * temp_z_4 - 5670.0 * temp_z_2 + 315.0;
+
+    double temp_miu1 = temp_y_2 * temp_z_2 * temp_term1_x + (temp_y_2 + temp_z_2) * temp_term2_x + temp_term3_x;
+    double temp_miu2 = temp_x_2 * temp_z_2 * temp_term1_y + (temp_x_2 + temp_z_2) * temp_term2_y + temp_term3_y;
+    double temp_miu3 = temp_x_2 * temp_y_2 * temp_term1_z + (temp_x_2 + temp_y_2) * temp_term2_z + temp_term3_z;
+
+    double miu_8_9_1 = temp * temp_miu1;
+    double miu_8_9_2 = temp * temp_miu2;
+    double miu_8_9_3 = temp * temp_miu3;
+
+    value[0] = miu_8_9_1;
+    value[1] = miu_8_9_2;
+    value[2] = miu_8_9_3;
+}
+
+void calc_MCSH_8_10_noderiv(double x0, double y0, double z0, double r0_sqr, double A, double B, double alpha, double beta, double *value)
+{   
+    // double r0_sqr = x0*x0 + y0*y0 + z0*z0;
+    double C1 = calc_C1(A,B,alpha,beta);
+    double C2 = calc_C2(alpha, beta);
+    
+    double lambda = calc_lambda(alpha, beta);
+    double lambda_sqr = lambda * lambda;
+
+    double lambda_x0 = x0 * lambda;
+    double lambda_y0 = y0 * lambda;
+    double lambda_z0 = z0 * lambda;
+
+    double lambda_x0_sqr = lambda_x0 * lambda_x0;
+    double lambda_y0_sqr = lambda_y0 * lambda_y0;
+    double lambda_z0_sqr = lambda_z0 * lambda_z0;
+
+    double lambda_x0_3 = lambda_x0_sqr * lambda_x0;
+    double lambda_y0_3 = lambda_y0_sqr * lambda_y0;
+    double lambda_z0_3 = lambda_z0_sqr * lambda_z0;
+
+    double gamma = calc_gamma(alpha, beta);
+
+    double temp = C1 * exp( C2 * r0_sqr);
+
+    double temp_x_2 = lambda_x0_sqr + (1.0/(2.0*gamma));
+    double temp_y_2 = lambda_y0_sqr + (1.0/(2.0*gamma));
+    double temp_z_2 = lambda_z0_sqr + (1.0/(2.0*gamma));
+
+    double C3_1 = 3.0 / (2.0 * gamma);
+    double temp_x_3 = lambda_x0_3 + C3_1 * lambda_x0;
+    double temp_y_3 = lambda_y0_3 + C3_1 * lambda_y0;
+    double temp_z_3 = lambda_z0_3 + C3_1 * lambda_z0;
+
+    double temp_term1_x = 2027025.0 * temp_x_3 - 405405.0 * lambda_x0;
+    double temp_term1_y = 2027025.0 * temp_y_3 - 405405.0 * lambda_y0;
+    // double temp_term1_z = 2027025.0 * temp_z_3 - 405405.0 * lambda_z0;
+
+    double temp_term2_x = -405405.0 * temp_x_3 + 93555.0 * lambda_x0;
+    double temp_term2_y = -405405.0 * temp_y_3 + 93555.0 * lambda_y0;
+    // double temp_term2_z = -405405.0 * temp_z_3 + 93555.0 * lambda_z0;
+
+    double temp_term3_x = -135135.0 * temp_x_3 + 31185.0 * lambda_x0;
+    double temp_term3_y = -135135.0 * temp_y_3 + 31185.0 * lambda_y0;
+    // double temp_term3_z = -135135.0 * temp_z_3 + 31185.0 * lambda_z0;
+
+    double temp_term4_x = 31185.0 * temp_x_3 - 8505.0 * lambda_x0;
+    double temp_term4_y = 31185.0 * temp_y_3 - 8505.0 * lambda_y0;
+    // double temp_term4_z = 31185.0 * temp_z_3 - 8505.0 * lambda_z0;
+
+    double temp_miu1 = temp_y_3 * temp_z_2 * temp_term1_x + lambda_y0 * temp_z_2 * temp_term2_x + temp_y_3 * temp_term3_x + lambda_y0 * temp_term4_x;
+    double temp_miu2 = temp_z_3 * temp_y_2 * temp_term1_x + lambda_z0 * temp_y_2 * temp_term2_x + temp_z_3 * temp_term3_x + lambda_z0 * temp_term4_x;
+    double temp_miu3 = temp_z_3 * temp_x_2 * temp_term1_y + lambda_z0 * temp_x_2 * temp_term2_y + temp_z_3 * temp_term3_y + lambda_z0 * temp_term4_y;
+
+    double miu_8_10_1 = temp * temp_miu1;
+    double miu_8_10_2 = temp * temp_miu2;
+    double miu_8_10_3 = temp * temp_miu3;
+
+    value[0] = miu_8_10_1;
+    value[1] = miu_8_10_2;
+    value[2] = miu_8_10_3;
+}
+
+void calc_MCSH_9_1_noderiv(double x0, double y0, double z0, double r0_sqr, double A, double B, double alpha, double beta, double *value)
+{   
+    // double r0_sqr = x0*x0 + y0*y0 + z0*z0;
+    double C1 = calc_C1(A,B,alpha,beta);
+    double C2 = calc_C2(alpha, beta);
+    
+    double lambda = calc_lambda(alpha, beta);
+
+    double lambda_x0 = lambda * x0;
+    double lambda_y0 = lambda * y0;
+    double lambda_z0 = lambda * z0;
+    
+    double lambda_x0_sqr = lambda_x0 * lambda_x0;
+    double lambda_y0_sqr = lambda_y0 * lambda_y0;
+    double lambda_z0_sqr = lambda_z0 * lambda_z0;
+
+    double lambda_x0_3 = lambda_x0_sqr * lambda_x0;
+    double lambda_y0_3 = lambda_y0_sqr * lambda_y0;
+    double lambda_z0_3 = lambda_z0_sqr * lambda_z0;
+
+    double lambda_x0_4 = lambda_x0_3 * lambda_x0;
+    double lambda_y0_4 = lambda_y0_3 * lambda_y0;
+    double lambda_z0_4 = lambda_z0_3 * lambda_z0;
+
+    double lambda_x0_5 = lambda_x0_4 * lambda_x0;
+    double lambda_y0_5 = lambda_y0_4 * lambda_y0;
+    double lambda_z0_5 = lambda_z0_4 * lambda_z0;
+
+    double lambda_x0_6 = lambda_x0_5 * lambda_x0;
+    double lambda_y0_6 = lambda_y0_5 * lambda_y0;
+    double lambda_z0_6 = lambda_z0_5 * lambda_z0;
+
+    double lambda_x0_7 = lambda_x0_6 * lambda_x0;
+    double lambda_y0_7 = lambda_y0_6 * lambda_y0;
+    double lambda_z0_7 = lambda_z0_6 * lambda_z0;
+
+    double lambda_x0_8 = lambda_x0_7 * lambda_x0;
+    double lambda_y0_8 = lambda_y0_7 * lambda_y0;
+    double lambda_z0_8 = lambda_z0_7 * lambda_z0;
+
+    double lambda_x0_9 = lambda_x0_8 * lambda_x0;
+    double lambda_y0_9 = lambda_y0_8 * lambda_y0;
+    double lambda_z0_9 = lambda_z0_8 * lambda_z0;
+
+    double gamma = calc_gamma(alpha, beta);
+    double C3 = (34459425.0 * 18.0 / gamma) - 72972900.0;
+    double C4 = (34459425.0 * 189.0 / (2.0 * gamma * gamma)) - (72972900.0 * 21.0 / (2.0 * gamma)) + 51081030.0;
+    double C5 = (34459425.0 * 315.0 / (2.0 * gamma * gamma * gamma)) - (72972900.0 * 105.0 / (4.0 * gamma * gamma)) + (51081030.0 * 5.0 / gamma) - 13097700.0;
+    double C6 = (34459425.0 * 945.0 / (16.0 * gamma * gamma * gamma * gamma)) - (72972900.0 * 105.0 / (8.0 * gamma * gamma * gamma)) + (51081030.0 * 15.0 / (4.0 * gamma *gamma)) - (13097700.0 * 3.0 / (2.0 * gamma)) + 893025.0;
+
+    double temp = C1 * exp( C2 * r0_sqr);
+
+    double temp_x = 34459425.0 * lambda_x0_9 + C3 * lambda_x0_7 + C4 * lambda_x0_5 + C5 * lambda_x0_3 + C6 * lambda_x0;
+    double temp_y = 34459425.0 * lambda_y0_9 + C3 * lambda_y0_7 + C4 * lambda_y0_5 + C5 * lambda_y0_3 + C6 * lambda_y0;
+    double temp_z = 34459425.0 * lambda_z0_9 + C3 * lambda_z0_7 + C4 * lambda_z0_5 + C5 * lambda_z0_3 + C6 * lambda_z0;
+
+    double miu_9_1_1 = temp * temp_x;
+    double miu_9_1_2 = temp * temp_y;
+    double miu_9_1_3 = temp * temp_z;
+
+    value[0] = miu_9_1_1;
+    value[1] = miu_9_1_2;
+    value[2] = miu_9_1_3;
+}
+
+void calc_MCSH_9_2_noderiv(double x0, double y0, double z0, double r0_sqr, double A, double B, double alpha, double beta, double *value)
+{   
+    // double r0_sqr = x0*x0 + y0*y0 + z0*z0;
+    double C1 = calc_C1(A,B,alpha,beta);
+    double C2 = calc_C2(alpha, beta);
+    
+    double lambda = calc_lambda(alpha, beta);
+
+    double lambda_x0 = x0 * lambda;
+    double lambda_y0 = y0 * lambda;
+    double lambda_z0 = z0 * lambda;
+
+    double lambda_x0_sqr = lambda_x0 * lambda_x0;
+    double lambda_y0_sqr = lambda_y0 * lambda_y0;
+    double lambda_z0_sqr = lambda_z0 * lambda_z0;
+
+    double lambda_x0_3 = lambda_x0_sqr * lambda_x0;
+    double lambda_y0_3 = lambda_y0_sqr * lambda_y0;
+    double lambda_z0_3 = lambda_z0_sqr * lambda_z0;
+
+    double lambda_x0_4 = lambda_x0_3 * lambda_x0;
+    double lambda_y0_4 = lambda_y0_3 * lambda_y0;
+    double lambda_z0_4 = lambda_z0_3 * lambda_z0;
+
+    double lambda_x0_5 = lambda_x0_4 * lambda_x0;
+    double lambda_y0_5 = lambda_y0_4 * lambda_y0;
+    double lambda_z0_5 = lambda_z0_4 * lambda_z0;
+
+    double lambda_x0_6 = lambda_x0_5 * lambda_x0;
+    double lambda_y0_6 = lambda_y0_5 * lambda_y0;
+    double lambda_z0_6 = lambda_z0_5 * lambda_z0;
+
+    double lambda_x0_7 = lambda_x0_6 * lambda_x0;
+    double lambda_y0_7 = lambda_y0_6 * lambda_y0;
+    double lambda_z0_7 = lambda_z0_6 * lambda_z0;
+
+    double lambda_x0_8 = lambda_x0_7 * lambda_x0;
+    double lambda_y0_8 = lambda_y0_7 * lambda_y0;
+    double lambda_z0_8 = lambda_z0_7 * lambda_z0;
+
+    double gamma = calc_gamma(alpha, beta);
+    double C3 = (34459425.0 * 14.0 / gamma) - 56756700.0;
+    double C4 = (34459425.0 * 105.0 / (2.0 * gamma * gamma)) - (56756700.0 * 15.0 / (2.0 * gamma)) + 28378350.0;
+    double C5 = (34459425.0 * 105.0 / (2.0 * gamma * gamma * gamma)) - (56756700.0 * 45.20 / (4.0 * gamma * gamma)) + (28378350.0 * 3.0 / gamma) - 4365900.0;
+    double C6 = (34459425.0 * 105.0 / (16.0 * gamma * gamma * gamma * gamma)) - (56756700.0 * 15.0 / (8.0 * gamma * gamma * gamma)) + (28378350.0 * 3.0 / (4.0 * gamma * gamma)) - (4365900.0 / (2.0 * gamma)) + 99225.0;
+
+    double temp = C1 * exp( C2 * r0_sqr);
+
+    double temp_x = 34459425.0 * lambda_x0_8 + C3 * lambda_x0_6 + C4 * lambda_x0_4 + C5 * lambda_x0_sqr + C6;
+    double temp_y = 34459425.0 * lambda_y0_8 + C3 * lambda_y0_6 + C4 * lambda_y0_4 + C5 * lambda_y0_sqr + C6;
+    double temp_z = 34459425.0 * lambda_z0_8 + C3 * lambda_z0_6 + C4 * lambda_z0_4 + C5 * lambda_z0_sqr + C6;
+
+    double miu_9_2_1 = temp * lambda_y0 * temp_x;
+    double miu_9_2_2 = temp * lambda_x0 * temp_y;
+    double miu_9_2_3 = temp * lambda_z0 * temp_x;
+    double miu_9_2_4 = temp * lambda_x0 * temp_z;
+    double miu_9_2_5 = temp * lambda_z0 * temp_y;
+    double miu_9_2_6 = temp * lambda_y0 * temp_z;
+
+    value[0] = miu_9_2_1;
+    value[1] = miu_9_2_2;
+    value[2] = miu_9_2_3;
+    value[3] = miu_9_2_4;
+    value[4] = miu_9_2_5;
+    value[5] = miu_9_2_6;
+}
+
+void calc_MCSH_9_3_noderiv(double x0, double y0, double z0, double r0_sqr, double A, double B, double alpha, double beta, double *value)
+{   
+    // double r0_sqr = x0*x0 + y0*y0 + z0*z0;
+    double C1 = calc_C1(A,B,alpha,beta);
+    double C2 = calc_C2(alpha, beta);
+    
+    double lambda = calc_lambda(alpha, beta);
+    double lambda_sqr = lambda * lambda;
+
+    double lambda_x0 = x0 * lambda;
+    double lambda_y0 = y0 * lambda;
+    double lambda_z0 = z0 * lambda;
+
+    double lambda_x0_sqr = lambda_x0 * lambda_x0;
+    double lambda_y0_sqr = lambda_y0 * lambda_y0;
+    double lambda_z0_sqr = lambda_z0 * lambda_z0;
+
+    double lambda_x0_3 = lambda_x0_sqr * lambda_x0;
+    double lambda_y0_3 = lambda_y0_sqr * lambda_y0;
+    double lambda_z0_3 = lambda_z0_sqr * lambda_z0;
+
+    double lambda_x0_4 = lambda_x0_3 * lambda_x0;
+    double lambda_y0_4 = lambda_y0_3 * lambda_y0;
+    double lambda_z0_4 = lambda_z0_3 * lambda_z0;
+
+    double lambda_x0_5 = lambda_x0_4 * lambda_x0;
+    double lambda_y0_5 = lambda_y0_4 * lambda_y0;
+    double lambda_z0_5 = lambda_z0_4 * lambda_z0;
+
+    double lambda_x0_6 = lambda_x0_5 * lambda_x0;
+    double lambda_y0_6 = lambda_y0_5 * lambda_y0;
+    double lambda_z0_6 = lambda_z0_5 * lambda_z0;
+    
+    double lambda_x0_7 = lambda_x0_6 * lambda_x0;
+    double lambda_y0_7 = lambda_y0_6 * lambda_y0;
+    double lambda_z0_7 = lambda_z0_6 * lambda_z0;
+
+    double gamma = calc_gamma(alpha, beta);
+
+    double temp = C1 * exp( C2 * r0_sqr);
+
+    double temp_x_2 = lambda_x0_sqr + (1/(2*gamma));
+    double temp_y_2 = lambda_y0_sqr + (1/(2*gamma));
+    double temp_z_2 = lambda_z0_sqr + (1/(2*gamma));
+
+    double C3_1 = 3.0 / (2.0 * gamma);
+    double temp_x_3 = lambda_x0_3 + C3_1 * lambda_x0;
+    double temp_y_3 = lambda_y0_3 + C3_1 * lambda_y0;
+    double temp_z_3 = lambda_z0_3 + C3_1 * lambda_z0;
+
+    double C5_1 = 5.0 / gamma, C5_2 = 15.0 / (4.0 * gamma * gamma);
+    double temp_x_5 = lambda_x0_5 + C5_1 * lambda_x0_3 + C5_2 * lambda_x0;
+    double temp_y_5 = lambda_y0_5 + C5_1 * lambda_y0_3 + C5_2 * lambda_y0;
+    double temp_z_5 = lambda_z0_5 + C5_1 * lambda_z0_3 + C5_2 * lambda_z0; 
+
+    double C7_1 = 21 / (2 * gamma), C7_2 = 105 / (4 * gamma * gamma), C7_3 = 105 / (8 * gamma * gamma * gamma);
+    double temp_x_7 = lambda_x0_7 + C7_1 * lambda_x0_5 + C7_2 * lambda_x0_3 + C7_3 * lambda_x0;
+    double temp_y_7 = lambda_y0_7 + C7_1 * lambda_y0_5 + C7_2 * lambda_y0_3 + C7_3 * lambda_y0;
+    double temp_z_7 = lambda_z0_7 + C7_1 * lambda_z0_5 + C7_2 * lambda_z0_3 + C7_3 * lambda_z0;
+
+    double temp_term1_x = 34459425.0 * temp_x_7 - 42567525.0 * temp_x_5 + 14189175.0 * temp_x_3 - 1091475.0 * lambda_x0;
+    double temp_term1_y = 34459425.0 * temp_y_7 - 42567525.0 * temp_y_5 + 14189175.0 * temp_y_3 - 1091475.0 * lambda_y0;
+    double temp_term1_z = 34459425.0 * temp_z_7 - 42567525.0 * temp_z_5 + 14189175.0 * temp_z_3 - 1091475.0 * lambda_z0;
+
+    double temp_term2_x = -2027025.0 * temp_x_7 + 2837835.0 * temp_x_5 - 1091475.0 * temp_x_3 + 99225.0 * lambda_x0;
+    double temp_term2_y = -2027025.0 * temp_y_7 + 2837835.0 * temp_y_5 - 1091475.0 * temp_y_3 + 99225.0 * lambda_y0;
+    double temp_term2_z = -2027025.0 * temp_z_7 + 2837835.0 * temp_z_5 - 1091475.0 * temp_z_3 + 99225.0 * lambda_z0;
+
+    double temp_miu1 = temp_y_2 * temp_term1_x + temp_term2_x;
+    double temp_miu2 = temp_x_2 * temp_term1_y + temp_term2_y;
+    double temp_miu3 = temp_z_2 * temp_term1_x + temp_term2_x;
+    double temp_miu4 = temp_x_2 * temp_term1_z + temp_term2_z;
+    double temp_miu5 = temp_z_2 * temp_term1_y + temp_term2_y;
+    double temp_miu6 = temp_y_2 * temp_term1_z + temp_term2_z;
+
+    double miu_9_3_1 = temp * temp_miu1;
+    double miu_9_3_2 = temp * temp_miu2;
+    double miu_9_3_3 = temp * temp_miu3;
+    double miu_9_3_4 = temp * temp_miu4;
+    double miu_9_3_5 = temp * temp_miu5;
+    double miu_9_3_6 = temp * temp_miu6;
+
+    value[0] = miu_9_3_1;
+    value[1] = miu_9_3_2;
+    value[2] = miu_9_3_3;
+    value[3] = miu_9_3_4;
+    value[4] = miu_9_3_5;
+    value[5] = miu_9_3_6;
+}
+
+void calc_MCSH_9_4_noderiv(double x0, double y0, double z0, double r0_sqr, double A, double B, double alpha, double beta, double *value)
+{   
+    // double r0_sqr = x0*x0 + y0*y0 + z0*z0;
+    double C1 = calc_C1(A,B,alpha,beta);
+    double C2 = calc_C2(alpha, beta);
+    
+    double lambda = calc_lambda(alpha, beta);
+
+    double lambda_x0 = x0 * lambda;
+    double lambda_y0 = y0 * lambda;
+    double lambda_z0 = z0 * lambda;
+    
+    double lambda_x0_sqr = lambda_x0 * lambda_x0;
+    double lambda_y0_sqr = lambda_y0 * lambda_y0;
+    double lambda_z0_sqr = lambda_z0 * lambda_z0;
+
+    double lambda_x0_3 = lambda_x0_sqr * lambda_x0;
+    double lambda_y0_3 = lambda_y0_sqr * lambda_y0;
+    double lambda_z0_3 = lambda_z0_sqr * lambda_z0;
+
+    double lambda_x0_4 = lambda_x0_3 * lambda_x0;
+    double lambda_y0_4 = lambda_y0_3 * lambda_y0;
+    double lambda_z0_4 = lambda_z0_3 * lambda_z0;
+
+    double lambda_x0_5 = lambda_x0_4 * lambda_x0;
+    double lambda_y0_5 = lambda_y0_4 * lambda_y0;
+    double lambda_z0_5 = lambda_z0_4 * lambda_z0;
+
+    double lambda_x0_6 = lambda_x0_5 * lambda_x0;
+    double lambda_y0_6 = lambda_y0_5 * lambda_y0;
+    double lambda_z0_6 = lambda_z0_5 * lambda_z0;
+
+    double lambda_x0_7 = lambda_x0_6 * lambda_x0;
+    double lambda_y0_7 = lambda_y0_6 * lambda_y0;
+    double lambda_z0_7 = lambda_z0_6 * lambda_z0;
+
+    double gamma = calc_gamma(alpha, beta);
+    double C3 = (34459425.0 * 21.0 / (2.0 * gamma)) - 42567525.0;
+    double C4 = (34459425.0 * 105.0 / (4.0 * gamma * gamma)) - (42567525.0 * 5.0 / gamma) + 14189175.0;
+    double C5 = (34459425.0 * 105.0 / (8.0 * gamma * gamma * gamma)) - (42567525.0 * 15.0 / (4.0 * gamma * gamma)) + (14189175.0 * 3.0 / (2.0 * gamma)) - 1091475.0;
+
+    double temp = C1 * exp( C2 * r0_sqr);
+
+    double temp_x = 34459425.0 * lambda_x0_7 + C3 * lambda_x0_5 + C4 * lambda_x0_3 + C5 * lambda_x0;
+    double temp_y = 34459425.0 * lambda_y0_7 + C3 * lambda_y0_5 + C4 * lambda_y0_3 + C5 * lambda_y0;
+    double temp_z = 34459425.0 * lambda_z0_7 + C3 * lambda_z0_5 + C4 * lambda_z0_3 + C5 * lambda_z0;
+
+    double miu_9_4_1 = temp * lambda_y0 * lambda_z0 * temp_x;
+    double miu_9_4_2 = temp * lambda_x0 * lambda_z0 * temp_y;
+    double miu_9_4_3 = temp * lambda_x0 * lambda_y0 * temp_z;
+
+    value[0] = miu_9_4_1;
+    value[1] = miu_9_4_2;
+    value[2] = miu_9_4_3;
+}
+
+
+void calc_MCSH_9_5_noderiv(double x0, double y0, double z0, double r0_sqr, double A, double B, double alpha, double beta, double *value)
+{   
+    // double r0_sqr = x0*x0 + y0*y0 + z0*z0;
+    double C1 = calc_C1(A,B,alpha,beta);
+    double C2 = calc_C2(alpha, beta);
+    
+    double lambda = calc_lambda(alpha, beta);
+    double lambda_sqr = lambda * lambda;
+
+    double lambda_x0 = x0 * lambda;
+    double lambda_y0 = y0 * lambda;
+    double lambda_z0 = z0 * lambda;
+
+    double lambda_x0_sqr = lambda_x0 * lambda_x0;
+    double lambda_y0_sqr = lambda_y0 * lambda_y0;
+    double lambda_z0_sqr = lambda_z0 * lambda_z0;
+
+    double lambda_x0_3 = lambda_x0_sqr * lambda_x0;
+    double lambda_y0_3 = lambda_y0_sqr * lambda_y0;
+    double lambda_z0_3 = lambda_z0_sqr * lambda_z0;
+
+    double lambda_x0_4 = lambda_x0_3 * lambda_x0;
+    double lambda_y0_4 = lambda_y0_3 * lambda_y0;
+    double lambda_z0_4 = lambda_z0_3 * lambda_z0;
+
+    double lambda_x0_5 = lambda_x0_4 * lambda_x0;
+    double lambda_y0_5 = lambda_y0_4 * lambda_y0;
+    double lambda_z0_5 = lambda_z0_4 * lambda_z0;
+
+    double lambda_x0_6 = lambda_x0_5 * lambda_x0;
+    double lambda_y0_6 = lambda_y0_5 * lambda_y0;
+    double lambda_z0_6 = lambda_z0_5 * lambda_z0;
+
+    double gamma = calc_gamma(alpha, beta);
+
+    double temp = C1 * exp( C2 * r0_sqr);
+
+    double temp_x_2 = lambda_x0_sqr + (1.0/(2.0*gamma));
+    double temp_y_2 = lambda_y0_sqr + (1.0/(2.0*gamma));
+    double temp_z_2 = lambda_z0_sqr + (1.0/(2.0*gamma));
+
+    double C3_1 = 3.0 / (2.0 * gamma);
+    double temp_x_3 = lambda_x0_3 + C3_1 * lambda_x0;
+    double temp_y_3 = lambda_y0_3 + C3_1 * lambda_y0;
+    double temp_z_3 = lambda_z0_3 + C3_1 * lambda_z0;
+
+    double C4_1 = 3.0 / gamma, C4_2 = 3.0 / (4.0 * gamma * gamma);
+    double temp_x_4 = lambda_x0_4 + C4_1 * lambda_x0_sqr + C4_2;
+    double temp_y_4 = lambda_y0_4 + C4_1 * lambda_y0_sqr + C4_2;
+    double temp_z_4 = lambda_z0_4 + C4_1 * lambda_z0_sqr + C4_2;
+
+    double C6_1 = 15.0 / (2.0 * gamma), C6_2 = 45.0 / (4.0 * gamma * gamma), C6_3 =  15.0 / (8.0 * gamma * gamma * gamma);
+    double temp_x_6 = lambda_x0_6 + C6_1 * lambda_x0_4 + C6_2 * lambda_x0_sqr + C6_3;
+    double temp_y_6 = lambda_y0_6 + C6_1 * lambda_y0_4 + C6_2 * lambda_y0_sqr + C6_3;
+    double temp_z_6 = lambda_z0_6 + C6_1 * lambda_z0_4 + C6_2 * lambda_z0_sqr + C6_3;
+
+    double temp_term1_x = 34459425.0 * temp_x_6 - 30405375.0 * temp_x_4 + 6081075.0 * temp_x_2 - 155925.0;
+    double temp_term1_y = 34459425.0 * temp_y_6 - 30405375.0 * temp_y_4 + 6081075.0 * temp_y_2 - 155925.0;
+    double temp_term1_z = 34459425.0 * temp_z_6 - 30405375.0 * temp_z_4 + 6081075.0 * temp_z_2 - 155925.0;
+
+    double temp_term2_x = -6081075.0 * temp_x_6 + 6081075.0 * temp_x_4 - 1403325.0 * temp_x_2 + 42525.0;
+    double temp_term2_y = -6081075.0 * temp_y_6 + 6081075.0 * temp_y_4 - 1403325.0 * temp_x_2 + 42525.0;
+    double temp_term2_z = -6081075.0 * temp_z_6 + 6081075.0 * temp_z_4 - 1403325.0 * temp_x_2 + 42525.0;
+
+    double temp_miu1 = temp_y_3 * temp_term1_x + lambda_y0 * temp_term2_x;
+    double temp_miu2 = temp_x_3 * temp_term1_y + lambda_x0 * temp_term2_y;
+    double temp_miu3 = temp_z_3 * temp_term1_x + lambda_z0 * temp_term2_x;
+    double temp_miu4 = temp_x_3 * temp_term1_z + lambda_x0 * temp_term2_z;
+    double temp_miu5 = temp_z_3 * temp_term1_y + lambda_z0 * temp_term2_y;
+    double temp_miu6 = temp_y_3 * temp_term1_z + lambda_y0 * temp_term2_z;
+
+    double miu_9_5_1 = temp * temp_miu1;
+    double miu_9_5_2 = temp * temp_miu2;
+    double miu_9_5_3 = temp * temp_miu3;
+    double miu_9_5_4 = temp * temp_miu4;
+    double miu_9_5_5 = temp * temp_miu5;
+    double miu_9_5_6 = temp * temp_miu6;
+
+    value[0] = miu_9_5_1;
+    value[1] = miu_9_5_2;
+    value[2] = miu_9_5_3;
+    value[3] = miu_9_5_4;
+    value[4] = miu_9_5_5;
+    value[5] = miu_9_5_6;
+}
+
+
+void calc_MCSH_9_6_noderiv(double x0, double y0, double z0, double r0_sqr, double A, double B, double alpha, double beta, double *value)
+{   
+    // double r0_sqr = x0*x0 + y0*y0 + z0*z0;
+    double C1 = calc_C1(A,B,alpha,beta);
+    double C2 = calc_C2(alpha, beta);
+    
+    double lambda = calc_lambda(alpha, beta);
+
+    double lambda_x0 = x0 * lambda;
+    double lambda_y0 = y0 * lambda;
+    double lambda_z0 = z0 * lambda;
+
+    double lambda_x0_sqr = lambda_x0 * lambda_x0;
+    double lambda_y0_sqr = lambda_y0 * lambda_y0;
+    double lambda_z0_sqr = lambda_z0 * lambda_z0;
+
+    double lambda_x0_3 = lambda_x0_sqr * lambda_x0;
+    double lambda_y0_3 = lambda_y0_sqr * lambda_y0;
+    double lambda_z0_3 = lambda_z0_sqr * lambda_z0;
+
+    double lambda_x0_4 = lambda_x0_3 * lambda_x0;
+    double lambda_y0_4 = lambda_y0_3 * lambda_y0;
+    double lambda_z0_4 = lambda_z0_3 * lambda_z0;
+
+    double lambda_x0_5 = lambda_x0_4 * lambda_x0;
+    double lambda_y0_5 = lambda_y0_4 * lambda_y0;
+    double lambda_z0_5 = lambda_z0_4 * lambda_z0;
+
+    double lambda_x0_6 = lambda_x0_5 * lambda_x0;
+    double lambda_y0_6 = lambda_y0_5 * lambda_y0;
+    double lambda_z0_6 = lambda_z0_5 * lambda_z0;
+
+    double gamma = calc_gamma(alpha, beta);
+
+    double temp = C1 * exp( C2 * r0_sqr);
+
+    double temp_x_2 = lambda_x0_sqr + (1.0/(2.0*gamma));
+    double temp_y_2 = lambda_y0_sqr + (1.0/(2.0*gamma));
+    double temp_z_2 = lambda_z0_sqr + (1.0/(2.0*gamma));
+
+    double C4_1 = 3.0 / gamma, C4_2 = 3.0 / (4.0 * gamma * gamma);
+    double temp_x_4 = lambda_x0_4 + C4_1 * lambda_x0_sqr + C4_2;
+    double temp_y_4 = lambda_y0_4 + C4_1 * lambda_y0_sqr + C4_2;
+    double temp_z_4 = lambda_z0_4 + C4_1 * lambda_z0_sqr + C4_2;
+
+    double C6_1 = 15.0 / (2.0 * gamma), C6_2 = 45.0 / (4.0 * gamma * gamma), C6_3 =  15.0 / (8.0 * gamma * gamma * gamma);
+    double temp_x_6 = lambda_x0_6 + C6_1 * lambda_x0_4 + C6_2 * lambda_x0_sqr + C6_3;
+    double temp_y_6 = lambda_y0_6 + C6_1 * lambda_y0_4 + C6_2 * lambda_y0_sqr + C6_3;
+    double temp_z_6 = lambda_z0_6 + C6_1 * lambda_z0_4 + C6_2 * lambda_z0_sqr + C6_3;
+
+    double temp_term1_x = 34459425.0 * temp_x_6 - 30405375.0 * temp_x_4 + 6081075.0 * temp_x_2 - 155925.0;
+    double temp_term1_y = 34459425.0 * temp_y_6 - 30405375.0 * temp_y_4 + 6081075.0 * temp_y_2 - 155925.0;
+    double temp_term1_z = 34459425.0 * temp_z_6 - 30405375.0 * temp_z_4 + 6081075.0 * temp_z_2 - 155925.0;
+
+    double temp_term2_x = -2027025.0 * temp_x_6 + 2027025.0 * temp_x_4 - 467775.0 * temp_x_2 + 14175.0;
+    double temp_term2_y = -2027025.0 * temp_y_6 + 2027025.0 * temp_y_4 - 467775.0 * temp_x_2 + 14175.0;
+    double temp_term2_z = -2027025.0 * temp_z_6 + 2027025.0 * temp_z_4 - 467775.0 * temp_x_2 + 14175.0;
+
+    double temp_miu1 = temp_y_2 * temp_term1_x + temp_term2_x;
+    double temp_miu2 = temp_x_2 * temp_term1_y + temp_term2_y;
+    double temp_miu3 = temp_z_2 * temp_term1_x + temp_term2_x;
+    double temp_miu4 = temp_x_2 * temp_term1_z + temp_term2_z;
+    double temp_miu5 = temp_z_2 * temp_term1_y + temp_term2_y;
+    double temp_miu6 = temp_y_2 * temp_term1_z + temp_term2_z;
+
+    double miu_9_6_1 = temp * lambda_z0 * temp_miu1;
+    double miu_9_6_2 = temp * lambda_z0 * temp_miu2;
+    double miu_9_6_3 = temp * lambda_y0 * temp_miu3;
+    double miu_9_6_4 = temp * lambda_y0 * temp_miu4;
+    double miu_9_6_5 = temp * lambda_x0 * temp_miu5;
+    double miu_9_6_6 = temp * lambda_x0 * temp_miu6;
+
+    value[0] = miu_9_6_1;
+    value[1] = miu_9_6_2;
+    value[2] = miu_9_6_3;
+    value[3] = miu_9_6_4;
+    value[4] = miu_9_6_5;
+    value[5] = miu_9_6_6;
+}
+
+void calc_MCSH_9_7_noderiv(double x0, double y0, double z0, double r0_sqr, double A, double B, double alpha, double beta, double *value)
+{   
+    // double r0_sqr = x0*x0 + y0*y0 + z0*z0;
+    double C1 = calc_C1(A,B,alpha,beta);
+    double C2 = calc_C2(alpha, beta);
+    
+    double lambda = calc_lambda(alpha, beta);
+
+    double lambda_x0 = x0 * lambda;
+    double lambda_y0 = y0 * lambda;
+    double lambda_z0 = z0 * lambda;
+
+    double lambda_x0_sqr = lambda_x0 * lambda_x0;
+    double lambda_y0_sqr = lambda_y0 * lambda_y0;
+    double lambda_z0_sqr = lambda_z0 * lambda_z0;
+
+    double lambda_x0_3 = lambda_x0_sqr * lambda_x0;
+    double lambda_y0_3 = lambda_y0_sqr * lambda_y0;
+    double lambda_z0_3 = lambda_z0_sqr * lambda_z0;
+
+    double lambda_x0_4 = lambda_x0_3 * lambda_x0;
+    double lambda_y0_4 = lambda_y0_3 * lambda_y0;
+    double lambda_z0_4 = lambda_z0_3 * lambda_z0;
+
+    double lambda_x0_5 = lambda_x0_4 * lambda_x0;
+    double lambda_y0_5 = lambda_y0_4 * lambda_y0;
+    double lambda_z0_5 = lambda_z0_4 * lambda_z0;
+
+    double gamma = calc_gamma(alpha, beta);
+
+    double temp = C1 * exp( C2 * r0_sqr);
+
+    double temp_x_2 = lambda_x0_sqr + (1.0/(2.0*gamma));
+    double temp_y_2 = lambda_y0_sqr + (1.0/(2.0*gamma));
+    double temp_z_2 = lambda_z0_sqr + (1.0/(2.0*gamma));
+
+    double C3_1 = 3.0 / (2.0 * gamma);
+    double temp_x_3 = lambda_x0_3 + C3_1 * lambda_x0;
+    double temp_y_3 = lambda_y0_3 + C3_1 * lambda_y0;
+    double temp_z_3 = lambda_z0_3 + C3_1 * lambda_z0;
+
+    double C4_1 = 3.0 / gamma, C4_2 = 3.0 / (4.0 * gamma * gamma);
+    double temp_x_4 = lambda_x0_4 + C4_1 * lambda_x0_sqr + C4_2;
+    double temp_y_4 = lambda_y0_4 + C4_1 * lambda_y0_sqr + C4_2;
+    double temp_z_4 = lambda_z0_4 + C4_1 * lambda_z0_sqr + C4_2;
+
+    double C5_1 = 5.0 / gamma, C5_2 = 15.0 / (4.0 * gamma * gamma);
+    double temp_x_5 = lambda_x0_5 + C5_1 * lambda_x0_3 + C5_2 * lambda_x0;
+    double temp_y_5 = lambda_y0_5 + C5_1 * lambda_y0_3 + C5_2 * lambda_y0;
+    double temp_z_5 = lambda_z0_5 + C5_1 * lambda_z0_3 + C5_2 * lambda_z0;
+
+    double temp_term1_x = 34459425.0 * temp_x_5 - 20270250.0 * temp_x_3 + 2027025.0 * lambda_x0;
+    double temp_term1_y = 34459425.0 * temp_y_5 - 20270250.0 * temp_y_3 + 2027025.0 * lambda_y0;
+    double temp_term1_z = 34459425.0 * temp_z_5 - 20270250.0 * temp_z_3 + 2027025.0 * lambda_z0;
+
+    double temp_term2_x = -12162150.0 * temp_x_5 + 8108100.0 * temp_x_3 - 935550.0 * lambda_x0;
+    double temp_term2_y = -12162150.0 * temp_y_5 + 8108100.0 * temp_y_3 - 935550.0 * lambda_y0;
+    double temp_term2_z = -12162150.0 * temp_z_5 + 8108100.0 * temp_z_3 - 935550.0 * lambda_z0;
+
+    double temp_term3_x = 405405.0 * temp_x_5 - 311850.0 * temp_x_3 + 425425.0 * lambda_x0;
+    double temp_term3_y = 405405.0 * temp_y_5 - 311850.0 * temp_y_3 + 425425.0 * lambda_y0;
+    double temp_term3_z = 405405.0 * temp_z_5 - 311850.0 * temp_z_3 + 425425.0 * lambda_z0;
+
+    double temp_miu1 = temp_y_4 * temp_term1_x + temp_y_2 * temp_term2_x + temp_term3_x;
+    double temp_miu2 = temp_x_4 * temp_term1_y + temp_x_2 * temp_term2_y + temp_term3_y;
+    double temp_miu3 = temp_z_4 * temp_term1_x + temp_z_2 * temp_term2_x + temp_term3_x;
+    double temp_miu4 = temp_x_4 * temp_term1_z + temp_x_2 * temp_term2_z + temp_term3_z;
+    double temp_miu5 = temp_z_4 * temp_term1_y + temp_z_2 * temp_term2_y + temp_term3_y;
+    double temp_miu6 = temp_y_4 * temp_term1_z + temp_y_2 * temp_term2_z + temp_term3_z;
+
+    double miu_9_7_1 = temp * temp_miu1;
+    double miu_9_7_2 = temp * temp_miu2;
+    double miu_9_7_3 = temp * temp_miu3;
+    double miu_9_7_4 = temp * temp_miu4;
+    double miu_9_7_5 = temp * temp_miu5;
+    double miu_9_7_6 = temp * temp_miu6;
+
+    value[0] = miu_9_7_1;
+    value[1] = miu_9_7_2;
+    value[2] = miu_9_7_3;
+    value[3] = miu_9_7_4;
+    value[4] = miu_9_7_5;
+    value[5] = miu_9_7_6;
+}
+
+void calc_MCSH_9_8_noderiv(double x0, double y0, double z0, double r0_sqr, double A, double B, double alpha, double beta, double *value)
+{   
+    // double r0_sqr = x0*x0 + y0*y0 + z0*z0;
+    double C1 = calc_C1(A,B,alpha,beta);
+    double C2 = calc_C2(alpha, beta);
+    
+    double lambda = calc_lambda(alpha, beta);
+
+    double lambda_x0 = x0 * lambda;
+    double lambda_y0 = y0 * lambda;
+    double lambda_z0 = z0 * lambda;
+
+    double lambda_x0_sqr = lambda_x0 * lambda_x0;
+    double lambda_y0_sqr = lambda_y0 * lambda_y0;
+    double lambda_z0_sqr = lambda_z0 * lambda_z0;
+
+    double lambda_x0_3 = lambda_x0_sqr * lambda_x0;
+    double lambda_y0_3 = lambda_y0_sqr * lambda_y0;
+    double lambda_z0_3 = lambda_z0_sqr * lambda_z0;
+
+    double lambda_x0_4 = lambda_x0_3 * lambda_x0;
+    double lambda_y0_4 = lambda_y0_3 * lambda_y0;
+    double lambda_z0_4 = lambda_z0_3 * lambda_z0;
+
+    double lambda_x0_5 = lambda_x0_4 * lambda_x0;
+    double lambda_y0_5 = lambda_y0_4 * lambda_y0;
+    double lambda_z0_5 = lambda_z0_4 * lambda_z0;
+
+    double gamma = calc_gamma(alpha, beta);
+
+    double temp = C1 * exp( C2 * r0_sqr);
+
+    double C3_1 = 3.0 / (2.0 * gamma);
+    double temp_x_3 = lambda_x0_3 + C3_1 * lambda_x0;
+    double temp_y_3 = lambda_y0_3 + C3_1 * lambda_y0;
+    double temp_z_3 = lambda_z0_3 + C3_1 * lambda_z0;
+
+    double C5_1 = 5.0 / gamma, C5_2 = 15.0 / (4.0 * gamma * gamma);
+    double temp_x_5 = lambda_x0_5 + C5_1 * lambda_x0_3 + C5_2 * lambda_x0;
+    double temp_y_5 = lambda_y0_5 + C5_1 * lambda_y0_3 + C5_2 * lambda_y0;
+    double temp_z_5 = lambda_z0_5 + C5_1 * lambda_z0_3 + C5_2 * lambda_z0; 
+
+    double temp_term1_x = 34459425.0 * temp_x_5 - 20270250.0 * temp_x_3 + 2027025.0 * lambda_x0;
+    double temp_term1_y = 34459425.0 * temp_y_5 - 20270250.0 * temp_y_3 + 2027025.0 * lambda_y0;
+    double temp_term1_z = 34459425.0 * temp_z_5 - 20270250.0 * temp_z_3 + 2027025.0 * lambda_z0;
+
+    double temp_term2_x = -6081075.0 * temp_x_5 + 4054050.0 * temp_x_3 - 467775.0 * lambda_x0;
+    double temp_term2_y = -6081075.0 * temp_y_5 + 4054050.0 * temp_y_3 - 467775.0 * lambda_x0;
+    double temp_term2_z = -6081075.0 * temp_z_5 + 4054050.0 * temp_z_3 - 467775.0 * lambda_x0;
+
+    double temp_miu1 = temp_y_3 * temp_term1_x + lambda_y0 * temp_term2_x;
+    double temp_miu2 = temp_x_3 * temp_term1_y + lambda_x0 * temp_term2_y;
+    double temp_miu3 = temp_z_3 * temp_term1_x + lambda_z0 * temp_term2_x;
+    double temp_miu4 = temp_x_3 * temp_term1_z + lambda_x0 * temp_term2_z;
+    double temp_miu5 = temp_z_3 * temp_term1_y + lambda_z0 * temp_term2_y;
+    double temp_miu6 = temp_y_3 * temp_term1_z + lambda_y0 * temp_term2_z;
+
+    double miu_9_8_1 = temp * lambda_z0 * temp_miu1;
+    double miu_9_8_2 = temp * lambda_z0 * temp_miu2;
+    double miu_9_8_3 = temp * lambda_y0 * temp_miu3;
+    double miu_9_8_4 = temp * lambda_y0 * temp_miu4;
+    double miu_9_8_5 = temp * lambda_x0 * temp_miu5;
+    double miu_9_8_6 = temp * lambda_x0 * temp_miu6;
+
+    value[0] = miu_9_8_1;
+    value[1] = miu_9_8_2;
+    value[2] = miu_9_8_3;
+    value[3] = miu_9_8_4;
+    value[4] = miu_9_8_5;
+    value[5] = miu_9_8_6;
+}
+
+void calc_MCSH_9_9_noderiv(double x0, double y0, double z0, double r0_sqr, double A, double B, double alpha, double beta, double *value)
+{   
+    // double r0_sqr = x0*x0 + y0*y0 + z0*z0;
+    double C1 = calc_C1(A,B,alpha,beta);
+    double C2 = calc_C2(alpha, beta);
+    
+    double lambda = calc_lambda(alpha, beta);
+    double lambda_sqr = lambda * lambda;
+
+    double lambda_x0 = x0 * lambda;
+    double lambda_y0 = y0 * lambda;
+    double lambda_z0 = z0 * lambda;
+
+    double lambda_x0_sqr = lambda_x0 * lambda_x0;
+    double lambda_y0_sqr = lambda_y0 * lambda_y0;
+    double lambda_z0_sqr = lambda_z0 * lambda_z0;
+
+    double lambda_x0_3 = lambda_x0_sqr * lambda_x0;
+    double lambda_y0_3 = lambda_y0_sqr * lambda_y0;
+    double lambda_z0_3 = lambda_z0_sqr * lambda_z0;
+
+    double lambda_x0_4 = lambda_x0_3 * lambda_x0;
+    double lambda_y0_4 = lambda_y0_3 * lambda_y0;
+    double lambda_z0_4 = lambda_z0_3 * lambda_z0;
+
+    double lambda_x0_5 = lambda_x0_4 * lambda_x0;
+    double lambda_y0_5 = lambda_y0_4 * lambda_y0;
+    double lambda_z0_5 = lambda_z0_4 * lambda_z0;
+
+    double gamma = calc_gamma(alpha, beta);
+
+    double temp = C1 * exp( C2 * r0_sqr);
+
+    double temp_x_2 = lambda_x0_sqr + (1.0/(2.0*gamma));
+    double temp_y_2 = lambda_y0_sqr + (1.0/(2.0*gamma));
+    double temp_z_2 = lambda_z0_sqr + (1.0/(2.0*gamma));
+
+    double C3_1 = 3.0 / (2.0 * gamma);
+    double temp_x_3 = lambda_x0_3 + C3_1 * lambda_x0;
+    double temp_y_3 = lambda_y0_3 + C3_1 * lambda_y0;
+    double temp_z_3 = lambda_z0_3 + C3_1 * lambda_z0;
+
+    double C5_1 = 5.0 / gamma, C5_2 = 15.0 / (4.0 * gamma * gamma);
+    double temp_x_5 = lambda_x0_5 + C5_1 * lambda_x0_3 + C5_2 * lambda_x0;
+    double temp_y_5 = lambda_y0_5 + C5_1 * lambda_y0_3 + C5_2 * lambda_y0;
+    double temp_z_5 = lambda_z0_5 + C5_1 * lambda_z0_3 + C5_2 * lambda_z0; 
+
+
+    double temp_term1_x = 34459425.0 * temp_x_5 - 20270250.0 * temp_x_3 + 2027025.0 * lambda_x0;
+    double temp_term1_y = 34459425.0 * temp_y_5 - 20270250.0 * temp_y_3 + 2027025.0 * lambda_y0;
+    double temp_term1_z = 34459425.0 * temp_z_5 - 20270250.0 * temp_z_3 + 2027025.0 * lambda_z0;
+
+    double temp_term2_x = -2027025.0 * temp_x_5 + 1351350.0 * temp_x_3 - 155925.0 * lambda_x0;
+    double temp_term2_y = -2027025.0 * temp_y_5 + 1351350.0 * temp_y_3 - 155925.0 * lambda_y0;
+    double temp_term2_z = -2027025.0 * temp_z_5 + 1351350.0 * temp_z_3 - 155925.0 * lambda_z0;
+
+    double temp_term3_x = 135135.0 * temp_x_5 - 103950.0 * temp_x_3 + 14175.0 * lambda_x0;
+    double temp_term3_y = 135135.0 * temp_y_5 - 103950.0 * temp_y_3 + 14175.0 * lambda_y0;
+    double temp_term3_z = 135135.0 * temp_z_5 - 103950.0 * temp_z_3 + 14175.0 * lambda_z0;
+
+    double temp_miu1 = temp_y_2 * temp_z_2 * temp_term1_x + (temp_y_2 + temp_z_2) * temp_term2_x + temp_term3_x;
+    double temp_miu2 = temp_x_2 * temp_z_2 * temp_term1_y + (temp_x_2 + temp_z_2) * temp_term2_y + temp_term3_y;
+    double temp_miu3 = temp_x_2 * temp_y_2 * temp_term1_z + (temp_x_2 + temp_y_2) * temp_term2_z + temp_term3_z;
+
+    double miu_9_9_1 = temp * temp_miu1;
+    double miu_9_9_2 = temp * temp_miu2;
+    double miu_9_9_3 = temp * temp_miu3;
+
+    value[0] = miu_9_9_1;
+    value[1] = miu_9_9_2;
+    value[2] = miu_9_9_3;
+}
+
+
+void calc_MCSH_9_10_noderiv(double x0, double y0, double z0, double r0_sqr, double A, double B, double alpha, double beta, double *value)
+{   
+    // double r0_sqr = x0*x0 + y0*y0 + z0*z0;
+    double C1 = calc_C1(A,B,alpha,beta);
+    double C2 = calc_C2(alpha, beta);
+    
+    double lambda = calc_lambda(alpha, beta);
+
+    double lambda_x0 = x0 * lambda;
+    double lambda_y0 = y0 * lambda;
+    double lambda_z0 = z0 * lambda;
+
+    double lambda_x0_sqr = lambda_x0 * lambda_x0;
+    double lambda_y0_sqr = lambda_y0 * lambda_y0;
+    double lambda_z0_sqr = lambda_z0 * lambda_z0;
+
+    double lambda_x0_3 = lambda_x0_sqr * lambda_x0;
+    double lambda_y0_3 = lambda_y0_sqr * lambda_y0;
+    double lambda_z0_3 = lambda_z0_sqr * lambda_z0;
+
+    double lambda_x0_4 = lambda_x0_3 * lambda_x0;
+    double lambda_y0_4 = lambda_y0_3 * lambda_y0;
+    double lambda_z0_4 = lambda_z0_3 * lambda_z0;
+
+    double gamma = calc_gamma(alpha, beta);
+
+    double temp = C1 * exp( C2 * r0_sqr);
+
+    double temp_x_2 = lambda_x0_sqr + (1.0/(2.0*gamma));
+    double temp_y_2 = lambda_y0_sqr + (1.0/(2.0*gamma));
+    double temp_z_2 = lambda_z0_sqr + (1.0/(2.0*gamma));
+
+    double C4_1 = 3.0 / gamma, C4_2 = 3.0 / (4.0 * gamma * gamma);
+    double temp_x_4 = lambda_x0_4 + C4_1 * lambda_x0_sqr + C4_2;
+    double temp_y_4 = lambda_y0_4 + C4_1 * lambda_y0_sqr + C4_2;
+    double temp_z_4 = lambda_z0_4 + C4_1 * lambda_z0_sqr + C4_2;
+    
+    double temp_term1_x = 34459425.0 * temp_x_4 - 12162150.0 * temp_x_2 + 405405.0;
+    double temp_term1_y = 34459425.0 * temp_y_4 - 12162150.0 * temp_y_2 + 405405.0;
+
+    double temp_term2_x = -12162150.0 * temp_x_4 + 4864860.0 * temp_x_2 - 187110.0;
+    double temp_term2_y = -12162150.0 * temp_y_4 + 4864860.0 * temp_y_2 - 187110.0;
+
+    double temp_term3_x = 405405.0 * temp_x_4 - 187110.0 * temp_x_2 + 8505.0;
+    double temp_term3_y = 405405.0 * temp_y_4 - 187110.0 * temp_y_2 + 8505.0;
+
+    double temp_miu1 = temp_y_4 * temp_term1_x + temp_y_2 * temp_term2_x + temp_term3_x;
+    double temp_miu2 = temp_z_4 * temp_term1_x + temp_z_2 * temp_term2_x + temp_term3_x;
+    double temp_miu3 = temp_z_4 * temp_term1_y + temp_z_2 * temp_term2_y + temp_term3_y;
+
+    double miu_9_10_1 = temp * lambda_z0 * temp_miu1;
+    double miu_9_10_2 = temp * lambda_y0 * temp_miu2;
+    double miu_9_10_3 = temp * lambda_x0 * temp_miu3;
+
+    value[0] = miu_9_10_1;
+    value[1] = miu_9_10_2;
+    value[2] = miu_9_10_3;
+}
+
+void calc_MCSH_9_11_noderiv(double x0, double y0, double z0, double r0_sqr, double A, double B, double alpha, double beta, double *value)
+{   
+    // double r0_sqr = x0*x0 + y0*y0 + z0*z0;
+    double C1 = calc_C1(A,B,alpha,beta);
+    double C2 = calc_C2(alpha, beta);
+    
+    double lambda = calc_lambda(alpha, beta);
+
+    double lambda_x0 = x0 * lambda;
+    double lambda_y0 = y0 * lambda;
+    double lambda_z0 = z0 * lambda;
+
+    double lambda_x0_sqr = lambda_x0 * lambda_x0;
+    double lambda_y0_sqr = lambda_y0 * lambda_y0;
+    double lambda_z0_sqr = lambda_z0 * lambda_z0;
+
+    double lambda_x0_3 = lambda_x0_sqr * lambda_x0;
+    double lambda_y0_3 = lambda_y0_sqr * lambda_y0;
+    double lambda_z0_3 = lambda_z0_sqr * lambda_z0;
+
+    double lambda_x0_4 = lambda_x0_3 * lambda_x0;
+    double lambda_y0_4 = lambda_y0_3 * lambda_y0;
+    double lambda_z0_4 = lambda_z0_3 * lambda_z0;
+
+    double gamma = calc_gamma(alpha, beta);
+
+    double temp = C1 * exp( C2 * r0_sqr);
+
+    double temp_x_2 = lambda_x0_sqr + (1.0/(2.0*gamma));
+    double temp_y_2 = lambda_y0_sqr + (1.0/(2.0*gamma));
+    double temp_z_2 = lambda_z0_sqr + (1.0/(2.0*gamma));
+
+    double C3_1 = 3.0 / (2.0 * gamma);
+    double temp_x_3 = lambda_x0_3 + C3_1 * lambda_x0;
+    double temp_y_3 = lambda_y0_3 + C3_1 * lambda_y0;
+    double temp_z_3 = lambda_z0_3 + C3_1 * lambda_z0;
+
+    double C4_1 = 3.0 / gamma, C4_2 = 3.0 / (4.0 * gamma * gamma);
+    double temp_x_4 = lambda_x0_4 + C4_1 * lambda_x0_sqr + C4_2;
+    double temp_y_4 = lambda_y0_4 + C4_1 * lambda_y0_sqr + C4_2;
+    double temp_z_4 = lambda_z0_4 + C4_1 * lambda_z0_sqr + C4_2;
+
+    double temp_term1_x = 34459425.0 * temp_x_4 - 12162150.0 * temp_x_2 + 405405.0;
+    double temp_term1_y = 34459425.0 * temp_y_4 - 12162150.0 * temp_y_2 + 405405.0;
+    double temp_term1_z = 34459425.0 * temp_z_4 - 12162150.0 * temp_z_2 + 405405.0;
+
+    double temp_term2_x = -2027025.0 * temp_x_4 + 810810.0 * temp_x_2 - 31185.0;
+    double temp_term2_y = -2027025.0 * temp_y_4 + 810810.0 * temp_y_2 - 31185.0;
+    double temp_term2_z = -2027025.0 * temp_z_4 + 810810.0 * temp_z_2 - 31185.0;
+
+    double temp_term3_x = -6081075.0 * temp_x_4 + 2432430.0 * temp_x_2 - 93555.0;
+    double temp_term3_y = -6081075.0 * temp_y_4 + 2432430.0 * temp_y_2 - 93555.0;
+    double temp_term3_z = -6081075.0 * temp_z_4 + 2432430.0 * temp_z_2 - 93555.0;
+
+    double temp_term4_x = 405405.0 * temp_x_4 - 187110.0 * temp_x_2 + 8505.0;
+    double temp_term4_y = 405405.0 * temp_y_4 - 187110.0 * temp_y_2 + 8505.0;
+    double temp_term4_z = 405405.0 * temp_z_4 - 187110.0 * temp_z_2 + 8505.0;
+
+
+    double temp_miu1 = temp_y_3 * temp_z_2 * temp_term1_x + temp_y_3 * temp_term2_x + lambda_y0 * temp_z_2 * temp_term3_x + lambda_y0 * temp_term4_x;
+    double temp_miu2 = temp_x_3 * temp_z_2 * temp_term1_y + temp_x_3 * temp_term2_y + lambda_x0 * temp_z_2 * temp_term3_y + lambda_x0 * temp_term4_y;
+    double temp_miu3 = temp_z_3 * temp_y_2 * temp_term1_x + temp_z_3 * temp_term2_x + lambda_z0 * temp_y_2 * temp_term3_x + lambda_z0 * temp_term4_x;
+    double temp_miu4 = temp_x_3 * temp_y_2 * temp_term1_z + temp_x_3 * temp_term2_z + lambda_x0 * temp_y_2 * temp_term3_z + lambda_x0 * temp_term4_z;
+    double temp_miu5 = temp_z_3 * temp_x_2 * temp_term1_y + temp_z_3 * temp_term2_y + lambda_z0 * temp_x_2 * temp_term3_y + lambda_z0 * temp_term4_y;
+    double temp_miu6 = temp_y_3 * temp_x_2 * temp_term1_z + temp_y_3 * temp_term2_z + lambda_y0 * temp_x_2 * temp_term3_z + lambda_y0 * temp_term4_z;
+
+    double miu_9_11_1 = temp * temp_miu1;
+    double miu_9_11_2 = temp * temp_miu2;
+    double miu_9_11_3 = temp * temp_miu3;
+    double miu_9_11_4 = temp * temp_miu4;
+    double miu_9_11_5 = temp * temp_miu5;
+    double miu_9_11_6 = temp * temp_miu6;
+
+    value[0] = miu_9_11_1;
+    value[1] = miu_9_11_2;
+    value[2] = miu_9_11_3;
+    value[3] = miu_9_11_4;
+    value[4] = miu_9_11_5;
+    value[5] = miu_9_11_6;
+}
+
+
+void calc_MCSH_9_12_noderiv(double x0, double y0, double z0, double r0_sqr, double A, double B, double alpha, double beta, double *value)
+{   
+    // double r0_sqr = x0*x0 + y0*y0 + z0*z0;
+    double C1 = calc_C1(A,B,alpha,beta);
+    double C2 = calc_C2(alpha, beta);
+    
+    double lambda = calc_lambda(alpha, beta);
+
+    double lambda_x0 = x0 * lambda;
+    double lambda_y0 = y0 * lambda;
+    double lambda_z0 = z0 * lambda;
+
+    double lambda_x0_sqr = lambda_x0 * lambda_x0;
+    double lambda_y0_sqr = lambda_y0 * lambda_y0;
+    double lambda_z0_sqr = lambda_z0 * lambda_z0;
+
+    double lambda_x0_3 = lambda_x0_sqr * lambda_x0;
+    double lambda_y0_3 = lambda_y0_sqr * lambda_y0;
+    double lambda_z0_3 = lambda_z0_sqr * lambda_z0;
+
+    double gamma = calc_gamma(alpha, beta);
+
+    double temp = C1 * exp( C2 * r0_sqr);
+
+    double C3_1 = 3.0 / (2.0 * gamma);
+    double temp_x_3 = lambda_x0_3 + C3_1 * lambda_x0;
+    double temp_y_3 = lambda_y0_3 + C3_1 * lambda_y0;
+    double temp_z_3 = lambda_z0_3 + C3_1 * lambda_z0;
+
+    double t1 = 34459425.0 * temp_x_3 * temp_y_3 * temp_z_3;
+    double t2 = -6081075.0 * temp_x_3 * temp_y_3 * lambda_z0;
+    double t3 = -6081075.0 * temp_x_3 * lambda_y0 * temp_z_3;
+    double t4 = 1216215.0 * temp_x_3 * lambda_y0 * lambda_z0;
+    double t5 = -6081075.0 * lambda_x0 * temp_y_3 * temp_z_3;
+    double t6 = 1216215.0 * lambda_x0 * temp_y_3 * lambda_z0;
+    double t7 = 1216215.0 * lambda_x0 * lambda_y0 * temp_z_3;
+    double t8 = -280665.0* lambda_x0 * lambda_y0 * lambda_z0;
+
+    double sum_ts = t1 + t2 + t3 + t4 + t5 + t6 + t7 + t8;
+
+    double m_9_12 = temp * sum_ts;
+
+    value[0] = m_9_12;
+}
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 int get_mcsh_type(int mcsh_order, int group_num)
 {
     if (mcsh_order == 0) {
@@ -5836,6 +8881,142 @@ AtomisticMCSHFunction get_mcsh_function(int mcsh_order, int group_num)
             result = calc_MCSH_9_11;
         } else if (group_num == 12){
             result = calc_MCSH_9_12;
+        }
+    }
+
+    return result;
+}
+
+
+AtomisticMCSHFunctionNoderiv get_mcsh_function_noderiv(int mcsh_order, int group_num)
+{
+    AtomisticMCSHFunctionNoderiv result;
+    
+    if (mcsh_order == 0) {
+        if (group_num == 1) {
+            result = calc_MCSH_0_1_noderiv;
+        } 
+    } else if (mcsh_order == 1) {
+        if (group_num == 1) {
+            result = calc_MCSH_1_1_noderiv;
+        } 
+    } else if (mcsh_order == 2) {
+        if (group_num == 1) {
+            result = calc_MCSH_2_1_noderiv;
+        } else if (group_num == 2){
+            result = calc_MCSH_2_2_noderiv;    
+        }
+    } else if (mcsh_order == 3) {
+        if (group_num == 1) {
+            result = calc_MCSH_3_1_noderiv;
+        } else if (group_num == 2){
+            result = calc_MCSH_3_2_noderiv;
+        } else if (group_num == 3){
+            result = calc_MCSH_3_3_noderiv;
+        }
+    } else if (mcsh_order == 4) {
+        if (group_num == 1) {
+            result = calc_MCSH_4_1_noderiv;
+        } else if (group_num == 2){
+            result = calc_MCSH_4_2_noderiv;
+        } else if (group_num == 3){
+            result = calc_MCSH_4_3_noderiv;
+        } else if (group_num == 4){
+            result = calc_MCSH_4_4_noderiv;
+        }
+    } else if (mcsh_order == 5) {
+        if (group_num == 1) {
+            result = calc_MCSH_5_1_noderiv;
+        } else if (group_num == 2){
+            result = calc_MCSH_5_2_noderiv;
+        } else if (group_num == 3){
+            result = calc_MCSH_5_3_noderiv;
+        } else if (group_num == 4){
+            result = calc_MCSH_5_4_noderiv;
+        } else if (group_num == 5){
+            result = calc_MCSH_5_5_noderiv;
+        }
+    } else if (mcsh_order == 6) {
+        if (group_num == 1) {
+            result = calc_MCSH_6_1_noderiv;
+        } else if (group_num == 2){
+            result = calc_MCSH_6_2_noderiv;
+        } else if (group_num == 3){
+            result = calc_MCSH_6_3_noderiv;
+        } else if (group_num == 4){
+            result = calc_MCSH_6_4_noderiv;
+        } else if (group_num == 5){
+            result = calc_MCSH_6_5_noderiv;
+        } else if (group_num == 6){
+            result = calc_MCSH_6_6_noderiv;
+        } else if (group_num == 7){
+            result = calc_MCSH_6_7_noderiv;
+        }
+    } else if (mcsh_order == 7) {
+        if (group_num == 1) {
+            result = calc_MCSH_7_1_noderiv;
+        } else if (group_num == 2){
+            result = calc_MCSH_7_2_noderiv;
+        } else if (group_num == 3){
+            result = calc_MCSH_7_3_noderiv;
+        } else if (group_num == 4){
+            result = calc_MCSH_7_4_noderiv;
+        } else if (group_num == 5){
+            result = calc_MCSH_7_5_noderiv;
+        } else if (group_num == 6){
+            result = calc_MCSH_7_6_noderiv;
+        } else if (group_num == 7){
+            result = calc_MCSH_7_7_noderiv;
+        } else if (group_num == 8){
+            result = calc_MCSH_7_8_noderiv;
+        }
+    } else if (mcsh_order == 8) {
+        if (group_num == 1) {
+            result = calc_MCSH_8_1_noderiv;
+        } else if (group_num == 2){
+            result = calc_MCSH_8_2_noderiv;
+        } else if (group_num == 3){
+            result = calc_MCSH_8_3_noderiv;
+        } else if (group_num == 4){
+            result = calc_MCSH_8_4_noderiv;
+        } else if (group_num == 5){
+            result = calc_MCSH_8_5_noderiv;
+        } else if (group_num == 6){
+            result = calc_MCSH_8_6_noderiv;
+        } else if (group_num == 7){
+            result = calc_MCSH_8_7_noderiv;
+        } else if (group_num == 8){
+            result = calc_MCSH_8_8_noderiv;
+        } else if (group_num == 9){
+            result = calc_MCSH_8_9_noderiv;
+        } else if (group_num == 10){
+            result = calc_MCSH_8_10_noderiv;
+        }
+    } else if (mcsh_order == 9) {
+        if (group_num == 1) {
+            result = calc_MCSH_9_1_noderiv;
+        } else if (group_num == 2){
+            result = calc_MCSH_9_2_noderiv;
+        } else if (group_num == 3){
+            result = calc_MCSH_9_3_noderiv;
+        } else if (group_num == 4){
+            result = calc_MCSH_9_4_noderiv;
+        } else if (group_num == 5){
+            result = calc_MCSH_9_5_noderiv;
+        } else if (group_num == 6){
+            result = calc_MCSH_9_6_noderiv;
+        } else if (group_num == 7){
+            result = calc_MCSH_9_7_noderiv;
+        } else if (group_num == 8){
+            result = calc_MCSH_9_8_noderiv;
+        } else if (group_num == 9){
+            result = calc_MCSH_9_9_noderiv;
+        } else if (group_num == 10){
+            result = calc_MCSH_9_10_noderiv;
+        } else if (group_num == 11){
+            result = calc_MCSH_9_11_noderiv;
+        } else if (group_num == 12){
+            result = calc_MCSH_9_12_noderiv;
         }
     }
 

--- a/amptorch/descriptor/MCSH/atomistic_mcsh.cpp
+++ b/amptorch/descriptor/MCSH/atomistic_mcsh.cpp
@@ -22,17 +22,6 @@ double calc_gamma(double alpha, double beta){
     return alpha + beta;
 }
 
-double dx0dx(){
-    return 1.0;
-}
-
-double dy0dy(){
-    return 1.0;
-}
-
-double dz0dz(){
-    return 1.0;
-}
 
 void calc_MCSH_0_1(double x0, double y0, double z0, double r0_sqr, double A, double B, double alpha, double beta, double *value, double *deriv)
 {   
@@ -41,9 +30,9 @@ void calc_MCSH_0_1(double x0, double y0, double z0, double r0_sqr, double A, dou
     double C2 = calc_C2(alpha, beta);
     double m_0_1 = C1 * exp( C2 * r0_sqr);
 
-    deriv[0] = dx0dx() * m_0_1 * (2.0 * C2 * x0);
-    deriv[1] = dy0dy() * m_0_1 * (2.0 * C2 * y0);
-    deriv[2] = dz0dz() * m_0_1 * (2.0 * C2 * z0);
+    deriv[0] = m_0_1 * (2.0 * C2 * x0);
+    deriv[1] = m_0_1 * (2.0 * C2 * y0);
+    deriv[2] = m_0_1 * (2.0 * C2 * z0);
 
     value[0] = m_0_1;
 }
@@ -77,19 +66,19 @@ void calc_MCSH_1_1(double x0, double y0, double z0, double r0_sqr, double A, dou
     double const_2_C2_z = 2.0 * C2 * z0;
 
     // dmiu1 dx/dy/dz
-    deriv[0] = dx0dx() * temp * (temp_dx + const_2_C2_x * temp_x);
-    deriv[1] = dy0dy() * miu_1_1_1 * const_2_C2_y;
-    deriv[2] = dz0dz() * miu_1_1_1 * const_2_C2_z;
+    deriv[0] = temp * (temp_dx + const_2_C2_x * temp_x);
+    deriv[1] = miu_1_1_1 * const_2_C2_y;
+    deriv[2] = miu_1_1_1 * const_2_C2_z;
 
     // dmiu2 dx/dy/dz
-    deriv[3] = dx0dx() * miu_1_1_2 * const_2_C2_x;
-    deriv[4] = dy0dy() * temp * (temp_dy + const_2_C2_y * temp_y);
-    deriv[5] = dz0dz() * miu_1_1_2 * const_2_C2_z;
+    deriv[3] = miu_1_1_2 * const_2_C2_x;
+    deriv[4] = temp * (temp_dy + const_2_C2_y * temp_y);
+    deriv[5] = miu_1_1_2 * const_2_C2_z;
 
     // dmiu3 dx/dy/dz
-    deriv[6] = dx0dx() * miu_1_1_3 * const_2_C2_x;
-    deriv[7] = dy0dy() * miu_1_1_3 * const_2_C2_y;
-    deriv[8] = dz0dz() * temp * (temp_dz + const_2_C2_z * temp_z);
+    deriv[6] = miu_1_1_3 * const_2_C2_x;
+    deriv[7] = miu_1_1_3 * const_2_C2_y;
+    deriv[8] = temp * (temp_dz + const_2_C2_z * temp_z);
 
     value[0] = miu_1_1_1;
     value[1] = miu_1_1_2;
@@ -137,19 +126,19 @@ void calc_MCSH_2_1(double x0, double y0, double z0, double r0_sqr, double A, dou
     double const_2_C2_z = 2.0 * C2 * z0;
 
     // dmiu1 dx/dy/dz
-    deriv[0] = dx0dx() * temp * (temp_dx + const_2_C2_x * temp_x);
-    deriv[1] = dy0dy() * miu_2_1_1 * const_2_C2_y;
-    deriv[2] = dz0dz() * miu_2_1_1 * const_2_C2_z;
+    deriv[0] = temp * (temp_dx + const_2_C2_x * temp_x);
+    deriv[1] = miu_2_1_1 * const_2_C2_y;
+    deriv[2] = miu_2_1_1 * const_2_C2_z;
 
     // dmiu2 dx/dy/dz
-    deriv[3] = dx0dx() * miu_2_1_2 * const_2_C2_x;
-    deriv[4] = dy0dy() * temp * (temp_dy + const_2_C2_y * temp_y);
-    deriv[5] = dz0dz() * miu_2_1_2 * const_2_C2_z;
+    deriv[3] = miu_2_1_2 * const_2_C2_x;
+    deriv[4] = temp * (temp_dy + const_2_C2_y * temp_y);
+    deriv[5] = miu_2_1_2 * const_2_C2_z;
 
     // dmiu3 dx/dy/dz
-    deriv[6] = dx0dx() * miu_2_1_3 * const_2_C2_x;
-    deriv[7] = dy0dy() * miu_2_1_3 * const_2_C2_y;
-    deriv[8] = dz0dz() * temp * (temp_dz + const_2_C2_z * temp_z);
+    deriv[6] = miu_2_1_3 * const_2_C2_x;
+    deriv[7] = miu_2_1_3 * const_2_C2_y;
+    deriv[8] = temp * (temp_dz + const_2_C2_z * temp_z);
 
     value[0] = miu_2_1_1;
     value[1] = miu_2_1_2;
@@ -183,19 +172,19 @@ void calc_MCSH_2_2(double x0, double y0, double z0, double r0_sqr, double A, dou
     double const_1_p_2_C2_z2 = 1.0 + 2.0 * C2 * z0_sqr;
 
     // dmiu1 dx/dy/dz
-    deriv[0] = dx0dx() * temp * y0 * const_1_p_2_C2_x2;
-    deriv[1] = dy0dy() * temp * x0 * const_1_p_2_C2_y2; 
-    deriv[2] = dz0dz() * miu_2_2_1 * const_2_C2_z;
+    deriv[0] = temp * y0 * const_1_p_2_C2_x2;
+    deriv[1] = temp * x0 * const_1_p_2_C2_y2; 
+    deriv[2] = miu_2_2_1 * const_2_C2_z;
 
     // dmiu2 dx/dy/dz
-    deriv[3] = dx0dx() * temp * z0 * const_1_p_2_C2_x2;
-    deriv[4] = dy0dy() * miu_2_2_2 * const_2_C2_y; 
-    deriv[5] = dz0dz() * temp * x0 * const_1_p_2_C2_z2;
+    deriv[3] = temp * z0 * const_1_p_2_C2_x2;
+    deriv[4] = miu_2_2_2 * const_2_C2_y; 
+    deriv[5] = temp * x0 * const_1_p_2_C2_z2;
 
     // dmiu3 dx/dy/dz
-    deriv[6] = dx0dx() * miu_2_2_3 * const_2_C2_x;
-    deriv[7] = dy0dy() * temp * z0 * const_1_p_2_C2_y2;
-    deriv[8] = dz0dz() * temp * y0 * const_1_p_2_C2_z2;
+    deriv[6] = miu_2_2_3 * const_2_C2_x;
+    deriv[7] = temp * z0 * const_1_p_2_C2_y2;
+    deriv[8] = temp * y0 * const_1_p_2_C2_z2;
 
     value[0] = miu_2_2_1;
     value[1] = miu_2_2_2;
@@ -245,19 +234,19 @@ void calc_MCSH_3_1(double x0, double y0, double z0, double r0_sqr, double A, dou
     double const_2_C2_z = 2.0 * C2 * z0;
 
     // dmiu1 dx/dy/dz
-    deriv[0] = dx0dx() * temp * (temp_dx + const_2_C2_x * temp_x);
-    deriv[1] = dy0dy() * miu_3_1_1 * const_2_C2_y;
-    deriv[2] = dz0dz() * miu_3_1_1 * const_2_C2_z;
+    deriv[0] = temp * (temp_dx + const_2_C2_x * temp_x);
+    deriv[1] = miu_3_1_1 * const_2_C2_y;
+    deriv[2] = miu_3_1_1 * const_2_C2_z;
 
     // dmiu2 dx/dy/dz
-    deriv[3] = dx0dx() * miu_3_1_2 * const_2_C2_x;
-    deriv[4] = dy0dy() * temp * (temp_dy + const_2_C2_y * temp_y);
-    deriv[5] = dz0dz() * miu_3_1_2 * const_2_C2_z;
+    deriv[3] = miu_3_1_2 * const_2_C2_x;
+    deriv[4] = temp * (temp_dy + const_2_C2_y * temp_y);
+    deriv[5] = miu_3_1_2 * const_2_C2_z;
 
     // dmiu3 dx/dy/dz
-    deriv[6] = dx0dx() * miu_3_1_3 * const_2_C2_x;
-    deriv[7] = dy0dy() * miu_3_1_3 * const_2_C2_y;
-    deriv[8] = dz0dz() * temp * (temp_dz + const_2_C2_z * temp_z);
+    deriv[6] = miu_3_1_3 * const_2_C2_x;
+    deriv[7] = miu_3_1_3 * const_2_C2_y;
+    deriv[8] = temp * (temp_dz + const_2_C2_z * temp_z);
 
     value[0] = miu_3_1_1;
     value[1] = miu_3_1_2;
@@ -313,34 +302,34 @@ void calc_MCSH_3_2(double x0, double y0, double z0, double r0_sqr, double A, dou
     double const_1_p_2_C2_z2 = 1.0 + 2.0 * C2 * z0_sqr;
 
     // dmiu1 dx/dy/dz
-    deriv[0] = dx0dx() * temp * lambda_y0 * (temp_dx + const_2_C2_x * temp_x);
-    deriv[1] = dy0dy() * temp * lambda * temp_x * const_1_p_2_C2_y2;
-    deriv[2] = dz0dz() * miu_3_2_1 * const_2_C2_z;
+    deriv[0] = temp * lambda_y0 * (temp_dx + const_2_C2_x * temp_x);
+    deriv[1] = temp * lambda * temp_x * const_1_p_2_C2_y2;
+    deriv[2] = miu_3_2_1 * const_2_C2_z;
 
     // dmiu2 dx/dy/dz
-    deriv[3] = dx0dx() * temp * lambda * temp_y * const_1_p_2_C2_x2;
-    deriv[4] = dy0dy() * temp * lambda_x0 * (temp_dy + const_2_C2_y * temp_y);
-    deriv[5] = dz0dz() * miu_3_2_2 * const_2_C2_z;
+    deriv[3] = temp * lambda * temp_y * const_1_p_2_C2_x2;
+    deriv[4] = temp * lambda_x0 * (temp_dy + const_2_C2_y * temp_y);
+    deriv[5] = miu_3_2_2 * const_2_C2_z;
 
     // dmiu3 dx/dy/dz
-    deriv[6] = dx0dx() * temp * lambda_z0 * (temp_dx + const_2_C2_x * temp_x);
-    deriv[7] = dy0dy() * miu_3_2_3 * const_2_C2_y;
-    deriv[8] = dz0dz() * temp * lambda * temp_x * const_1_p_2_C2_z2;
+    deriv[6] = temp * lambda_z0 * (temp_dx + const_2_C2_x * temp_x);
+    deriv[7] = miu_3_2_3 * const_2_C2_y;
+    deriv[8] = temp * lambda * temp_x * const_1_p_2_C2_z2;
 
     // dmiu4 dx/dy/dz
-    deriv[9] = dx0dx() * temp * lambda * temp_z * const_1_p_2_C2_x2;
-    deriv[10] = dy0dy() * miu_3_2_4 * const_2_C2_y;
-    deriv[11] = dz0dz() * temp * lambda_x0 * (temp_dz + const_2_C2_z * temp_z);
+    deriv[9] = temp * lambda * temp_z * const_1_p_2_C2_x2;
+    deriv[10] = miu_3_2_4 * const_2_C2_y;
+    deriv[11] = temp * lambda_x0 * (temp_dz + const_2_C2_z * temp_z);
 
     // dmiu5 dx/dy/dz
-    deriv[12] = dx0dx() * miu_3_2_5 * const_2_C2_x;
-    deriv[13] = dy0dy() * temp * lambda_z0 * (temp_dy + const_2_C2_y * temp_y);
-    deriv[14] = dz0dz() * temp * lambda * temp_y * const_1_p_2_C2_z2;
+    deriv[12] = miu_3_2_5 * const_2_C2_x;
+    deriv[13] = temp * lambda_z0 * (temp_dy + const_2_C2_y * temp_y);
+    deriv[14] = temp * lambda * temp_y * const_1_p_2_C2_z2;
 
     // dmiu6 dx/dy/dz
-    deriv[15] = dx0dx() * miu_3_2_6 * const_2_C2_x;
-    deriv[16] = dy0dy() * temp * lambda * temp_z * const_1_p_2_C2_y2;
-    deriv[17] = dz0dz() * temp * lambda_y0 * (temp_dz + const_2_C2_z * temp_z);
+    deriv[15] = miu_3_2_6 * const_2_C2_x;
+    deriv[16] = temp * lambda * temp_z * const_1_p_2_C2_y2;
+    deriv[17] = temp * lambda_y0 * (temp_dz + const_2_C2_z * temp_z);
 
     value[0] = miu_3_2_1;
     value[1] = miu_3_2_2;
@@ -360,9 +349,9 @@ void calc_MCSH_3_3(double x0, double y0, double z0, double r0_sqr, double A, dou
     double temp =  C1 * exp( C2 * r0_sqr) * lambda * lambda * lambda * 15.0;
     double m_3_3 = temp * x0 * y0 * z0;
 
-    deriv[0] = dx0dx() * temp * y0 * z0 * (1.0 + 2.0*C2*x0*x0);
-    deriv[1] = dy0dy() * temp * x0 * z0 * (1.0 + 2.0*C2*y0*y0);
-    deriv[2] = dz0dz() * temp * x0 * y0 * (1.0 + 2.0*C2*z0*z0);
+    deriv[0] = temp * y0 * z0 * (1.0 + 2.0*C2*x0*x0);
+    deriv[1] = temp * x0 * z0 * (1.0 + 2.0*C2*y0*y0);
+    deriv[2] = temp * x0 * y0 * (1.0 + 2.0*C2*z0*z0);
 
     value[0] = m_3_3;
 }
@@ -415,19 +404,19 @@ void calc_MCSH_4_1(double x0, double y0, double z0, double r0_sqr, double A, dou
     double const_2_C2_z = 2.0 * C2 * z0;
 
     // dmiu1 dx/dy/dz
-    deriv[0] = dx0dx() * temp * (temp_dx + const_2_C2_x * temp_x);
-    deriv[1] = dy0dy() * miu_4_1_1 * const_2_C2_y;
-    deriv[2] = dz0dz() * miu_4_1_1 * const_2_C2_z;
+    deriv[0] = temp * (temp_dx + const_2_C2_x * temp_x);
+    deriv[1] = miu_4_1_1 * const_2_C2_y;
+    deriv[2] = miu_4_1_1 * const_2_C2_z;
 
     // dmiu2 dx/dy/dz
-    deriv[3] = dx0dx() * miu_4_1_2 * const_2_C2_x;
-    deriv[4] = dy0dy() * temp * (temp_dy + const_2_C2_y * temp_y);
-    deriv[5] = dz0dz() * miu_4_1_2 * const_2_C2_z;
+    deriv[3] = miu_4_1_2 * const_2_C2_x;
+    deriv[4] = temp * (temp_dy + const_2_C2_y * temp_y);
+    deriv[5] = miu_4_1_2 * const_2_C2_z;
 
     // dmiu3 dx/dy/dz
-    deriv[6] = dx0dx() * miu_4_1_3 * const_2_C2_x;
-    deriv[7] = dy0dy() * miu_4_1_3 * const_2_C2_y;
-    deriv[8] = dz0dz() * temp * (temp_dz + const_2_C2_z * temp_z);
+    deriv[6] = miu_4_1_3 * const_2_C2_x;
+    deriv[7] = miu_4_1_3 * const_2_C2_y;
+    deriv[8] = temp * (temp_dz + const_2_C2_z * temp_z);
 
     value[0] = miu_4_1_1;
     value[1] = miu_4_1_2;
@@ -488,34 +477,34 @@ void calc_MCSH_4_2(double x0, double y0, double z0, double r0_sqr, double A, dou
     double const_1_p_2_C2_z2 = 1.0 + 2.0 * C2 * z0_sqr;
 
     // dmiu1 dx/dy/dz
-    deriv[0] = dx0dx() * temp * lambda_y0 * (temp_dx + const_2_C2_x * temp_x);
-    deriv[1] = dy0dy() * temp * lambda * temp_x * const_1_p_2_C2_y2;
-    deriv[2] = dz0dz() * miu_4_2_1 * const_2_C2_z;
+    deriv[0] = temp * lambda_y0 * (temp_dx + const_2_C2_x * temp_x);
+    deriv[1] = temp * lambda * temp_x * const_1_p_2_C2_y2;
+    deriv[2] = miu_4_2_1 * const_2_C2_z;
 
     // dmiu2 dx/dy/dz
-    deriv[3] = dx0dx() * temp * lambda * temp_y * const_1_p_2_C2_x2;
-    deriv[4] = dy0dy() * temp * lambda_x0 * (temp_dy + const_2_C2_y * temp_y);
-    deriv[5] = dz0dz() * miu_4_2_2 * const_2_C2_z;
+    deriv[3] = temp * lambda * temp_y * const_1_p_2_C2_x2;
+    deriv[4] = temp * lambda_x0 * (temp_dy + const_2_C2_y * temp_y);
+    deriv[5] = miu_4_2_2 * const_2_C2_z;
 
     // dmiu3 dx/dy/dz
-    deriv[6] = dx0dx() * temp * lambda_z0 * (temp_dx + const_2_C2_x * temp_x);
-    deriv[7] = dy0dy() * miu_4_2_3 * const_2_C2_y;
-    deriv[8] = dz0dz() * temp * lambda * temp_x * const_1_p_2_C2_z2;
+    deriv[6] = temp * lambda_z0 * (temp_dx + const_2_C2_x * temp_x);
+    deriv[7] = miu_4_2_3 * const_2_C2_y;
+    deriv[8] = temp * lambda * temp_x * const_1_p_2_C2_z2;
 
     // dmiu4 dx/dy/dz
-    deriv[9] = dx0dx() * temp * lambda * temp_z * const_1_p_2_C2_x2;
-    deriv[10] = dy0dy() * miu_4_2_4 * const_2_C2_y;
-    deriv[11] = dz0dz() * temp * lambda_x0 * (temp_dz + const_2_C2_z * temp_z);
+    deriv[9] = temp * lambda * temp_z * const_1_p_2_C2_x2;
+    deriv[10] = miu_4_2_4 * const_2_C2_y;
+    deriv[11] = temp * lambda_x0 * (temp_dz + const_2_C2_z * temp_z);
 
     // dmiu5 dx/dy/dz
-    deriv[12] = dx0dx() * miu_4_2_5 * const_2_C2_x;
-    deriv[13] = dy0dy() * temp * lambda_z0 * (temp_dy + const_2_C2_y * temp_y);
-    deriv[14] = dz0dz() * temp * lambda * temp_y * const_1_p_2_C2_z2;
+    deriv[12] = miu_4_2_5 * const_2_C2_x;
+    deriv[13] = temp * lambda_z0 * (temp_dy + const_2_C2_y * temp_y);
+    deriv[14] = temp * lambda * temp_y * const_1_p_2_C2_z2;
 
     // dmiu6 dx/dy/dz
-    deriv[15] = dx0dx() * miu_4_2_6 * const_2_C2_x;
-    deriv[16] = dy0dy() * temp * lambda * temp_z * const_1_p_2_C2_y2;
-    deriv[17] = dz0dz() * temp * lambda_y0 * (temp_dz + const_2_C2_z * temp_z);
+    deriv[15] = miu_4_2_6 * const_2_C2_x;
+    deriv[16] = temp * lambda * temp_z * const_1_p_2_C2_y2;
+    deriv[17] = temp * lambda_y0 * (temp_dz + const_2_C2_z * temp_z);
 
     value[0] = miu_4_2_1;
     value[1] = miu_4_2_2;
@@ -593,19 +582,19 @@ void calc_MCSH_4_3(double x0, double y0, double z0, double r0_sqr, double A, dou
     double const_2_C2_z = 2.0 * C2 * z0;
 
     // dmiu1 dx/dy/dz
-    deriv[0] = dx0dx() * temp * (temp_dmiu1_dx + const_2_C2_x * temp_miu1);
-    deriv[1] = dy0dy() * temp * (temp_dmiu1_dy + const_2_C2_y * temp_miu1);
-    deriv[2] = dz0dz() * miu_4_3_1 * const_2_C2_z;
+    deriv[0] = temp * (temp_dmiu1_dx + const_2_C2_x * temp_miu1);
+    deriv[1] = temp * (temp_dmiu1_dy + const_2_C2_y * temp_miu1);
+    deriv[2] = miu_4_3_1 * const_2_C2_z;
 
     // dmiu2 dx/dy/dz
-    deriv[3] = dx0dx() * temp * (temp_dmiu2_dx + const_2_C2_x * temp_miu2);
-    deriv[4] = dy0dy() * miu_4_3_2 * const_2_C2_y;
-    deriv[5] = dz0dz() * temp * (temp_dmiu2_dz + const_2_C2_z * temp_miu2);
+    deriv[3] = temp * (temp_dmiu2_dx + const_2_C2_x * temp_miu2);
+    deriv[4] = miu_4_3_2 * const_2_C2_y;
+    deriv[5] = temp * (temp_dmiu2_dz + const_2_C2_z * temp_miu2);
 
     // dmiu3 dx/dy/dz
-    deriv[6] = dx0dx() * miu_4_3_3 * const_2_C2_x;
-    deriv[7] = dy0dy() * temp * (temp_dmiu3_dy + const_2_C2_y * temp_miu3);
-    deriv[8] = dz0dz() * temp * (temp_dmiu3_dz + const_2_C2_z * temp_miu3);
+    deriv[6] = miu_4_3_3 * const_2_C2_x;
+    deriv[7] = temp * (temp_dmiu3_dy + const_2_C2_y * temp_miu3);
+    deriv[8] = temp * (temp_dmiu3_dz + const_2_C2_z * temp_miu3);
 
     value[0] = miu_4_3_1;
     value[1] = miu_4_3_2;
@@ -659,19 +648,19 @@ void calc_MCSH_4_4(double x0, double y0, double z0, double r0_sqr, double A, dou
     double const_1_p_2_C2_z2 = 1.0 + 2.0 * C2 * z0_sqr;
 
     // dmiu1 dx/dy/dz
-    deriv[0] = dx0dx() * temp * lambda_y0 * lambda_z0 * (temp_dx + const_2_C2_x * temp_x);
-    deriv[1] = dy0dy() * temp * lambda_z0 * temp_x * lambda * const_1_p_2_C2_y2;
-    deriv[2] = dz0dz() * temp * lambda_y0 * temp_x * lambda * const_1_p_2_C2_z2;
+    deriv[0] = temp * lambda_y0 * lambda_z0 * (temp_dx + const_2_C2_x * temp_x);
+    deriv[1] = temp * lambda_z0 * temp_x * lambda * const_1_p_2_C2_y2;
+    deriv[2] = temp * lambda_y0 * temp_x * lambda * const_1_p_2_C2_z2;
 
     // dmiu2 dx/dy/dz
-    deriv[3] = dx0dx() * temp * lambda_z0 * temp_y * lambda * const_1_p_2_C2_x2;
-    deriv[4] = dy0dy() * temp * lambda_x0 * lambda_z0 * (temp_dy + const_2_C2_y * temp_y);
-    deriv[5] = dz0dz() * temp * lambda_x0 * temp_y * lambda * const_1_p_2_C2_z2;
+    deriv[3] = temp * lambda_z0 * temp_y * lambda * const_1_p_2_C2_x2;
+    deriv[4] = temp * lambda_x0 * lambda_z0 * (temp_dy + const_2_C2_y * temp_y);
+    deriv[5] = temp * lambda_x0 * temp_y * lambda * const_1_p_2_C2_z2;
 
     // dmiu3 dx/dy/dz
-    deriv[6] = dx0dx() * temp * lambda_y0 * temp_z * lambda * const_1_p_2_C2_x2;
-    deriv[7] = dy0dy() * temp * lambda_x0 * temp_z * lambda * const_1_p_2_C2_y2;
-    deriv[8] = dz0dz() * temp * lambda_x0 * lambda_y0 * (temp_dz + const_2_C2_z * temp_z);
+    deriv[6] = temp * lambda_y0 * temp_z * lambda * const_1_p_2_C2_x2;
+    deriv[7] = temp * lambda_x0 * temp_z * lambda * const_1_p_2_C2_y2;
+    deriv[8] = temp * lambda_x0 * lambda_y0 * (temp_dz + const_2_C2_z * temp_z);
 
     value[0] = miu_4_4_1;
     value[1] = miu_4_4_2;
@@ -732,19 +721,19 @@ void calc_MCSH_5_1(double x0, double y0, double z0, double r0_sqr, double A, dou
     double const_2_C2_z = 2.0 * C2 * z0;
 
     // dmiu1 dx/dy/dz
-    deriv[0] = dx0dx() * temp * (temp_dx + const_2_C2_x * temp_x);
-    deriv[1] = dy0dy() * miu_5_1_1 * const_2_C2_y;
-    deriv[2] = dz0dz() * miu_5_1_1 * const_2_C2_z;
+    deriv[0] = temp * (temp_dx + const_2_C2_x * temp_x);
+    deriv[1] = miu_5_1_1 * const_2_C2_y;
+    deriv[2] = miu_5_1_1 * const_2_C2_z;
 
     // dmiu2 dx/dy/dz
-    deriv[3] = dx0dx() * miu_5_1_2 * const_2_C2_x;
-    deriv[4] = dy0dy() * temp * (temp_dy + const_2_C2_y * temp_y);
-    deriv[5] = dz0dz() * miu_5_1_2 * const_2_C2_z;
+    deriv[3] = miu_5_1_2 * const_2_C2_x;
+    deriv[4] = temp * (temp_dy + const_2_C2_y * temp_y);
+    deriv[5] = miu_5_1_2 * const_2_C2_z;
 
     // dmiu3 dx/dy/dz
-    deriv[6] = dx0dx() * miu_5_1_3 * const_2_C2_x;
-    deriv[7] = dy0dy() * miu_5_1_3 * const_2_C2_y;
-    deriv[8] = dz0dz() * temp * (temp_dz + const_2_C2_z * temp_z);
+    deriv[6] = miu_5_1_3 * const_2_C2_x;
+    deriv[7] = miu_5_1_3 * const_2_C2_y;
+    deriv[8] = temp * (temp_dz + const_2_C2_z * temp_z);
 
     value[0] = miu_5_1_1;
     value[1] = miu_5_1_2;
@@ -812,34 +801,34 @@ void calc_MCSH_5_2(double x0, double y0, double z0, double r0_sqr, double A, dou
     double const_1_p_2_C2_z2 = 1.0 + 2.0 * C2 * z0_sqr;
 
     // dmiu1 dx/dy/dz
-    deriv[0] = dx0dx() * temp * lambda_y0 * (temp_dx + const_2_C2_x * temp_x);
-    deriv[1] = dy0dy() * temp * lambda * temp_x * const_1_p_2_C2_y2;
-    deriv[2] = dz0dz() * miu_5_2_1 * const_2_C2_z;
+    deriv[0] = temp * lambda_y0 * (temp_dx + const_2_C2_x * temp_x);
+    deriv[1] = temp * lambda * temp_x * const_1_p_2_C2_y2;
+    deriv[2] = miu_5_2_1 * const_2_C2_z;
 
     // dmiu2 dx/dy/dz
-    deriv[3] = dx0dx() * temp * lambda * temp_y * const_1_p_2_C2_x2;
-    deriv[4] = dy0dy() * temp * lambda_x0 * (temp_dy + const_2_C2_y * temp_y);
-    deriv[5] = dz0dz() * miu_5_2_2 * const_2_C2_z;
+    deriv[3] = temp * lambda * temp_y * const_1_p_2_C2_x2;
+    deriv[4] = temp * lambda_x0 * (temp_dy + const_2_C2_y * temp_y);
+    deriv[5] = miu_5_2_2 * const_2_C2_z;
 
     // dmiu3 dx/dy/dz
-    deriv[6] = dx0dx() * temp * lambda_z0 * (temp_dx + const_2_C2_x * temp_x);
-    deriv[7] = dy0dy() * miu_5_2_3 * const_2_C2_y;
-    deriv[8] = dz0dz() * temp * lambda * temp_x * const_1_p_2_C2_z2;
+    deriv[6] = temp * lambda_z0 * (temp_dx + const_2_C2_x * temp_x);
+    deriv[7] = miu_5_2_3 * const_2_C2_y;
+    deriv[8] = temp * lambda * temp_x * const_1_p_2_C2_z2;
 
     // dmiu4 dx/dy/dz
-    deriv[9] = dx0dx() * temp * lambda * temp_z * const_1_p_2_C2_x2;
-    deriv[10] = dy0dy() * miu_5_2_4 * const_2_C2_y;
-    deriv[11] = dz0dz() * temp * lambda_x0 * (temp_dz + const_2_C2_z * temp_z);
+    deriv[9] = temp * lambda * temp_z * const_1_p_2_C2_x2;
+    deriv[10] = miu_5_2_4 * const_2_C2_y;
+    deriv[11] = temp * lambda_x0 * (temp_dz + const_2_C2_z * temp_z);
 
     // dmiu5 dx/dy/dz
-    deriv[12] = dx0dx() * miu_5_2_5 * const_2_C2_x;
-    deriv[13] = dy0dy() * temp * lambda_z0 * (temp_dy + const_2_C2_y * temp_y);
-    deriv[14] = dz0dz() * temp * lambda * temp_y * const_1_p_2_C2_z2;
+    deriv[12] = miu_5_2_5 * const_2_C2_x;
+    deriv[13] = temp * lambda_z0 * (temp_dy + const_2_C2_y * temp_y);
+    deriv[14] = temp * lambda * temp_y * const_1_p_2_C2_z2;
 
     // dmiu6 dx/dy/dz
-    deriv[15] = dx0dx() * miu_5_2_6 * const_2_C2_x;
-    deriv[16] = dy0dy() * temp * lambda * temp_z * const_1_p_2_C2_y2;
-    deriv[17] = dz0dz() * temp * lambda_y0 * (temp_dz + const_2_C2_z * temp_z);
+    deriv[15] = miu_5_2_6 * const_2_C2_x;
+    deriv[16] = temp * lambda * temp_z * const_1_p_2_C2_y2;
+    deriv[17] = temp * lambda_y0 * (temp_dz + const_2_C2_z * temp_z);
 
     value[0] = miu_5_2_1;
     value[1] = miu_5_2_2;
@@ -951,34 +940,34 @@ void calc_MCSH_5_3(double x0, double y0, double z0, double r0_sqr, double A, dou
     double const_2_C2_z = 2.0 * C2 * z0;
 
     // dmiu1 dx/dy/dz
-    deriv[0] = dx0dx() * temp * (temp_dmiu1_dx + const_2_C2_x * temp_miu1);
-    deriv[1] = dy0dy() * temp * (temp_dmiu1_dy + const_2_C2_y * temp_miu1);
-    deriv[2] = dz0dz() * miu_5_3_1 * const_2_C2_z;
+    deriv[0] = temp * (temp_dmiu1_dx + const_2_C2_x * temp_miu1);
+    deriv[1] = temp * (temp_dmiu1_dy + const_2_C2_y * temp_miu1);
+    deriv[2] = miu_5_3_1 * const_2_C2_z;
 
     // dmiu2 dx/dy/dz
-    deriv[3] = dx0dx() * temp * (temp_dmiu2_dx + const_2_C2_x * temp_miu2);
-    deriv[4] = dy0dy() * temp * (temp_dmiu2_dy + const_2_C2_y * temp_miu2);
-    deriv[5] = dz0dz() * miu_5_3_2 * const_2_C2_z;
+    deriv[3] = temp * (temp_dmiu2_dx + const_2_C2_x * temp_miu2);
+    deriv[4] = temp * (temp_dmiu2_dy + const_2_C2_y * temp_miu2);
+    deriv[5] = miu_5_3_2 * const_2_C2_z;
 
     // dmiu3 dx/dy/dz
-    deriv[6] = dx0dx() * temp * (temp_dmiu3_dx + const_2_C2_x * temp_miu3);
-    deriv[7] = dy0dy() * miu_5_3_3 * const_2_C2_y;
-    deriv[8] = dz0dz() * temp * (temp_dmiu3_dz + const_2_C2_z * temp_miu3);
+    deriv[6] = temp * (temp_dmiu3_dx + const_2_C2_x * temp_miu3);
+    deriv[7] = miu_5_3_3 * const_2_C2_y;
+    deriv[8] = temp * (temp_dmiu3_dz + const_2_C2_z * temp_miu3);
 
     // dmiu4 dx/dy/dz
-    deriv[9] = dx0dx() * temp * (temp_dmiu4_dx + const_2_C2_x * temp_miu4);
-    deriv[10] = dy0dy() * miu_5_3_4 * const_2_C2_y;
-    deriv[11] = dz0dz() * temp * (temp_dmiu4_dz + const_2_C2_z * temp_miu4);
+    deriv[9] = temp * (temp_dmiu4_dx + const_2_C2_x * temp_miu4);
+    deriv[10] = miu_5_3_4 * const_2_C2_y;
+    deriv[11] = temp * (temp_dmiu4_dz + const_2_C2_z * temp_miu4);
 
     // dmiu5 dx/dy/dz
-    deriv[12] = dx0dx() * miu_5_3_5 * const_2_C2_x;
-    deriv[13] = dy0dy() * temp * (temp_dmiu5_dy + const_2_C2_y * temp_miu5);
-    deriv[14] = dz0dz() * temp * (temp_dmiu5_dz + const_2_C2_z * temp_miu5);
+    deriv[12] = miu_5_3_5 * const_2_C2_x;
+    deriv[13] = temp * (temp_dmiu5_dy + const_2_C2_y * temp_miu5);
+    deriv[14] = temp * (temp_dmiu5_dz + const_2_C2_z * temp_miu5);
 
     // dmiu6 dx/dy/dz
-    deriv[15] = dx0dx() * miu_5_3_6 * const_2_C2_x;
-    deriv[16] = dy0dy() * temp * (temp_dmiu6_dy + const_2_C2_y * temp_miu6);
-    deriv[17] = dz0dz() * temp * (temp_dmiu6_dz + const_2_C2_z * temp_miu6);
+    deriv[15] = miu_5_3_6 * const_2_C2_x;
+    deriv[16] = temp * (temp_dmiu6_dy + const_2_C2_y * temp_miu6);
+    deriv[17] = temp * (temp_dmiu6_dz + const_2_C2_z * temp_miu6);
 
     value[0] = miu_5_3_1;
     value[1] = miu_5_3_2;
@@ -1039,19 +1028,19 @@ void calc_MCSH_5_4(double x0, double y0, double z0, double r0_sqr, double A, dou
     double const_1_p_2_C2_z2 = 1.0 + 2.0 * C2 * z0_sqr;
 
     // dmiu1 dx/dy/dz
-    deriv[0] = dx0dx() * temp * lambda_y0 * lambda_z0 * (temp_dx + const_2_C2_x * temp_x);
-    deriv[1] = dy0dy() * temp * lambda_z0 * temp_x * lambda * const_1_p_2_C2_y2;
-    deriv[2] = dz0dz() * temp * lambda_y0 * temp_x * lambda * const_1_p_2_C2_z2;
+    deriv[0] = temp * lambda_y0 * lambda_z0 * (temp_dx + const_2_C2_x * temp_x);
+    deriv[1] = temp * lambda_z0 * temp_x * lambda * const_1_p_2_C2_y2;
+    deriv[2] = temp * lambda_y0 * temp_x * lambda * const_1_p_2_C2_z2;
 
     // dmiu2 dx/dy/dz
-    deriv[3] = dx0dx() * temp * lambda_z0 * temp_y * lambda * const_1_p_2_C2_x2;
-    deriv[4] = dy0dy() * temp * lambda_x0 * lambda_z0 * (temp_dy + const_2_C2_y * temp_y);
-    deriv[5] = dz0dz() * temp * lambda_x0 * temp_y * lambda * const_1_p_2_C2_z2;
+    deriv[3] = temp * lambda_z0 * temp_y * lambda * const_1_p_2_C2_x2;
+    deriv[4] = temp * lambda_x0 * lambda_z0 * (temp_dy + const_2_C2_y * temp_y);
+    deriv[5] = temp * lambda_x0 * temp_y * lambda * const_1_p_2_C2_z2;
 
     // dmiu3 dx/dy/dz
-    deriv[6] = dx0dx() * temp * lambda_y0 * temp_z * lambda * const_1_p_2_C2_x2;
-    deriv[7] = dy0dy() * temp * lambda_x0 * temp_z * lambda * const_1_p_2_C2_y2;
-    deriv[8] = dz0dz() * temp * lambda_x0 * lambda_y0 * (temp_dz + const_2_C2_z * temp_z);
+    deriv[6] = temp * lambda_y0 * temp_z * lambda * const_1_p_2_C2_x2;
+    deriv[7] = temp * lambda_x0 * temp_z * lambda * const_1_p_2_C2_y2;
+    deriv[8] = temp * lambda_x0 * lambda_y0 * (temp_dz + const_2_C2_z * temp_z);
 
     value[0] = miu_5_4_1;
     value[1] = miu_5_4_2;
@@ -1118,19 +1107,19 @@ void calc_MCSH_5_5(double x0, double y0, double z0, double r0_sqr, double A, dou
     double const_1_p_2_C2_z2 = 1.0 + 2.0 * C2 * z0_sqr;
 
     // dmiu1 dx/dy/dz
-    deriv[0] = dx0dx() * temp * lambda_z0 * (temp_dmiu1_dx + const_2_C2_x * temp_miu1);
-    deriv[1] = dy0dy() * temp * lambda_z0 * (temp_dmiu1_dy + const_2_C2_y * temp_miu1);
-    deriv[2] = dz0dz() * temp * temp_miu1 * lambda * const_1_p_2_C2_z2;
+    deriv[0] = temp * lambda_z0 * (temp_dmiu1_dx + const_2_C2_x * temp_miu1);
+    deriv[1] = temp * lambda_z0 * (temp_dmiu1_dy + const_2_C2_y * temp_miu1);
+    deriv[2] = temp * temp_miu1 * lambda * const_1_p_2_C2_z2;
 
     // dmiu3 dx/dy/dz
-    deriv[3] = dx0dx() * temp * lambda_y0 * (temp_dmiu2_dx + const_2_C2_x * temp_miu2);
-    deriv[4] = dy0dy() * temp * temp_miu2 * lambda * const_1_p_2_C2_y2;
-    deriv[5] = dz0dz() * temp * lambda_y0 * (temp_dmiu2_dz + const_2_C2_z * temp_miu2);
+    deriv[3] = temp * lambda_y0 * (temp_dmiu2_dx + const_2_C2_x * temp_miu2);
+    deriv[4] = temp * temp_miu2 * lambda * const_1_p_2_C2_y2;
+    deriv[5] = temp * lambda_y0 * (temp_dmiu2_dz + const_2_C2_z * temp_miu2);
 
     // dmiu5 dx/dy/dz
-    deriv[6] = dx0dx() * temp * temp_miu3 * lambda * const_1_p_2_C2_x2;
-    deriv[7] = dy0dy() * temp * lambda_x0 * (temp_dmiu3_dy + const_2_C2_y * temp_miu3);
-    deriv[8] = dz0dz() * temp * lambda_x0 * (temp_dmiu3_dz + const_2_C2_z * temp_miu3);
+    deriv[6] = temp * temp_miu3 * lambda * const_1_p_2_C2_x2;
+    deriv[7] = temp * lambda_x0 * (temp_dmiu3_dy + const_2_C2_y * temp_miu3);
+    deriv[8] = temp * lambda_x0 * (temp_dmiu3_dz + const_2_C2_z * temp_miu3);
 
     value[0] = miu_5_5_1;
     value[1] = miu_5_5_2;
@@ -1198,19 +1187,19 @@ void calc_MCSH_6_1(double x0, double y0, double z0, double r0_sqr, double A, dou
     double const_2_C2_z = 2.0 * C2 * z0;
 
     // dmiu1 dx/dy/dz
-    deriv[0] = dx0dx() * temp * (temp_dx + const_2_C2_x * temp_x);
-    deriv[1] = dy0dy() * miu_6_1_1 * const_2_C2_y;
-    deriv[2] = dz0dz() * miu_6_1_1 * const_2_C2_z;
+    deriv[0] = temp * (temp_dx + const_2_C2_x * temp_x);
+    deriv[1] = miu_6_1_1 * const_2_C2_y;
+    deriv[2] = miu_6_1_1 * const_2_C2_z;
 
     // dmiu2 dx/dy/dz
-    deriv[3] = dx0dx() * miu_6_1_2 * const_2_C2_x;
-    deriv[4] = dy0dy() * temp * (temp_dy + const_2_C2_y * temp_y);
-    deriv[5] = dz0dz() * miu_6_1_2 * const_2_C2_z;
+    deriv[3] = miu_6_1_2 * const_2_C2_x;
+    deriv[4] = temp * (temp_dy + const_2_C2_y * temp_y);
+    deriv[5] = miu_6_1_2 * const_2_C2_z;
 
     // dmiu3 dx/dy/dz
-    deriv[6] = dx0dx() * miu_6_1_3 * const_2_C2_x;
-    deriv[7] = dy0dy() * miu_6_1_3 * const_2_C2_y;
-    deriv[8] = dz0dz() * temp * (temp_dz + const_2_C2_z * temp_z);
+    deriv[6] = miu_6_1_3 * const_2_C2_x;
+    deriv[7] = miu_6_1_3 * const_2_C2_y;
+    deriv[8] = temp * (temp_dz + const_2_C2_z * temp_z);
 
     value[0] = miu_6_1_1;
     value[1] = miu_6_1_2;
@@ -1280,34 +1269,34 @@ void calc_MCSH_6_2(double x0, double y0, double z0, double r0_sqr, double A, dou
     double const_1_p_2_C2_z2 = 1.0 + 2.0 * C2 * z0_sqr;
 
     // dmiu1 dx/dy/dz
-    deriv[0] = dx0dx() * temp * lambda_y0 * (temp_dx + const_2_C2_x * temp_x);
-    deriv[1] = dy0dy() * temp * lambda * temp_x * const_1_p_2_C2_y2;
-    deriv[2] = dz0dz() * miu_6_2_1 * const_2_C2_z;
+    deriv[0] = temp * lambda_y0 * (temp_dx + const_2_C2_x * temp_x);
+    deriv[1] = temp * lambda * temp_x * const_1_p_2_C2_y2;
+    deriv[2] = miu_6_2_1 * const_2_C2_z;
 
     // dmiu2 dx/dy/dz
-    deriv[3] = dx0dx() * temp * lambda * temp_y * const_1_p_2_C2_x2;
-    deriv[4] = dy0dy() * temp * lambda_x0 * (temp_dy + const_2_C2_y * temp_y);
-    deriv[5] = dz0dz() * miu_6_2_2 * const_2_C2_z;
+    deriv[3] = temp * lambda * temp_y * const_1_p_2_C2_x2;
+    deriv[4] = temp * lambda_x0 * (temp_dy + const_2_C2_y * temp_y);
+    deriv[5] = miu_6_2_2 * const_2_C2_z;
 
     // dmiu3 dx/dy/dz
-    deriv[6] = dx0dx() * temp * lambda_z0 * (temp_dx + const_2_C2_x * temp_x);
-    deriv[7] = dy0dy() * miu_6_2_3 * const_2_C2_y;
-    deriv[8] = dz0dz() * temp * lambda * temp_x * const_1_p_2_C2_z2;
+    deriv[6] = temp * lambda_z0 * (temp_dx + const_2_C2_x * temp_x);
+    deriv[7] = miu_6_2_3 * const_2_C2_y;
+    deriv[8] = temp * lambda * temp_x * const_1_p_2_C2_z2;
 
     // dmiu4 dx/dy/dz
-    deriv[9] = dx0dx() * temp * lambda * temp_z * const_1_p_2_C2_x2;
-    deriv[10] = dy0dy() * miu_6_2_4 * const_2_C2_y;
-    deriv[11] = dz0dz() * temp * lambda_x0 * (temp_dz + const_2_C2_z * temp_z);
+    deriv[9] = temp * lambda * temp_z * const_1_p_2_C2_x2;
+    deriv[10] = miu_6_2_4 * const_2_C2_y;
+    deriv[11] = temp * lambda_x0 * (temp_dz + const_2_C2_z * temp_z);
 
     // dmiu5 dx/dy/dz
-    deriv[12] = dx0dx() * miu_6_2_5 * const_2_C2_x;
-    deriv[13] = dy0dy() * temp * lambda_z0 * (temp_dy + const_2_C2_y * temp_y);
-    deriv[14] = dz0dz() * temp * lambda * temp_y * const_1_p_2_C2_z2;
+    deriv[12] = miu_6_2_5 * const_2_C2_x;
+    deriv[13] = temp * lambda_z0 * (temp_dy + const_2_C2_y * temp_y);
+    deriv[14] = temp * lambda * temp_y * const_1_p_2_C2_z2;
 
     // dmiu6 dx/dy/dz
-    deriv[15] = dx0dx() * miu_6_2_6 * const_2_C2_x;
-    deriv[16] = dy0dy() * temp * lambda * temp_z * const_1_p_2_C2_y2;
-    deriv[17] = dz0dz() * temp * lambda_y0 * (temp_dz + const_2_C2_z * temp_z);
+    deriv[15] = miu_6_2_6 * const_2_C2_x;
+    deriv[16] = temp * lambda * temp_z * const_1_p_2_C2_y2;
+    deriv[17] = temp * lambda_y0 * (temp_dz + const_2_C2_z * temp_z);
 
     value[0] = miu_6_2_1;
     value[1] = miu_6_2_2;
@@ -1417,34 +1406,34 @@ void calc_MCSH_6_3(double x0, double y0, double z0, double r0_sqr, double A, dou
     double const_2_C2_z = 2.0 * C2 * z0;
 
     // dmiu1 dx/dy/dz
-    deriv[0] = dx0dx() * temp * (temp_dmiu1_dx + const_2_C2_x * temp_miu1);
-    deriv[1] = dy0dy() * temp * (temp_dmiu1_dy + const_2_C2_y * temp_miu1);
-    deriv[2] = dz0dz() * miu_6_3_1 * const_2_C2_z;
+    deriv[0] = temp * (temp_dmiu1_dx + const_2_C2_x * temp_miu1);
+    deriv[1] = temp * (temp_dmiu1_dy + const_2_C2_y * temp_miu1);
+    deriv[2] = miu_6_3_1 * const_2_C2_z;
 
     // dmiu2 dx/dy/dz
-    deriv[3] = dx0dx() * temp * (temp_dmiu2_dx + const_2_C2_x * temp_miu2);
-    deriv[4] = dy0dy() * temp * (temp_dmiu2_dy + const_2_C2_y * temp_miu2);
-    deriv[5] = dz0dz() * miu_6_3_2 * const_2_C2_z;
+    deriv[3] = temp * (temp_dmiu2_dx + const_2_C2_x * temp_miu2);
+    deriv[4] = temp * (temp_dmiu2_dy + const_2_C2_y * temp_miu2);
+    deriv[5] = miu_6_3_2 * const_2_C2_z;
 
     // dmiu3 dx/dy/dz
-    deriv[6] = dx0dx() * temp * (temp_dmiu3_dx + const_2_C2_x * temp_miu3);
-    deriv[7] = dy0dy() * miu_6_3_3 * const_2_C2_y;
-    deriv[8] = dz0dz() * temp * (temp_dmiu3_dz + const_2_C2_z * temp_miu3);
+    deriv[6] = temp * (temp_dmiu3_dx + const_2_C2_x * temp_miu3);
+    deriv[7] = miu_6_3_3 * const_2_C2_y;
+    deriv[8] = temp * (temp_dmiu3_dz + const_2_C2_z * temp_miu3);
 
     // dmiu4 dx/dy/dz
-    deriv[9] = dx0dx() * temp * (temp_dmiu4_dx + const_2_C2_x * temp_miu4);
-    deriv[10] = dy0dy() * miu_6_3_4 * const_2_C2_y;
-    deriv[11] = dz0dz() * temp * (temp_dmiu4_dz + const_2_C2_z * temp_miu4);
+    deriv[9] = temp * (temp_dmiu4_dx + const_2_C2_x * temp_miu4);
+    deriv[10] = miu_6_3_4 * const_2_C2_y;
+    deriv[11] = temp * (temp_dmiu4_dz + const_2_C2_z * temp_miu4);
 
     // dmiu5 dx/dy/dz
-    deriv[12] = dx0dx() * miu_6_3_5 * const_2_C2_x;
-    deriv[13] = dy0dy() * temp * (temp_dmiu5_dy + const_2_C2_y * temp_miu5);
-    deriv[14] = dz0dz() * temp * (temp_dmiu5_dz + const_2_C2_z * temp_miu5);
+    deriv[12] = miu_6_3_5 * const_2_C2_x;
+    deriv[13] = temp * (temp_dmiu5_dy + const_2_C2_y * temp_miu5);
+    deriv[14] = temp * (temp_dmiu5_dz + const_2_C2_z * temp_miu5);
 
     // dmiu6 dx/dy/dz
-    deriv[15] = dx0dx() * miu_6_3_6 * const_2_C2_x;
-    deriv[16] = dy0dy() * temp * (temp_dmiu6_dy + const_2_C2_y * temp_miu6);
-    deriv[17] = dz0dz() * temp * (temp_dmiu6_dz + const_2_C2_z * temp_miu6);
+    deriv[15] = miu_6_3_6 * const_2_C2_x;
+    deriv[16] = temp * (temp_dmiu6_dy + const_2_C2_y * temp_miu6);
+    deriv[17] = temp * (temp_dmiu6_dz + const_2_C2_z * temp_miu6);
 
     value[0] = miu_6_3_1;
     value[1] = miu_6_3_2;
@@ -1511,19 +1500,19 @@ void calc_MCSH_6_4(double x0, double y0, double z0, double r0_sqr, double A, dou
     double const_1_p_2_C2_z2 = 1.0 + 2.0 * C2 * z0_sqr;
 
     // dmiu1 dx/dy/dz
-    deriv[0] = dx0dx() * temp * lambda_y0 * lambda_z0 * (temp_dx + const_2_C2_x * temp_x);
-    deriv[1] = dy0dy() * temp * lambda_z0 * temp_x * lambda * const_1_p_2_C2_y2;
-    deriv[2] = dz0dz() * temp * lambda_y0 * temp_x * lambda * const_1_p_2_C2_z2;
+    deriv[0] = temp * lambda_y0 * lambda_z0 * (temp_dx + const_2_C2_x * temp_x);
+    deriv[1] = temp * lambda_z0 * temp_x * lambda * const_1_p_2_C2_y2;
+    deriv[2] = temp * lambda_y0 * temp_x * lambda * const_1_p_2_C2_z2;
 
     // dmiu2 dx/dy/dz
-    deriv[3] = dx0dx() * temp * lambda_z0 * temp_y * lambda * const_1_p_2_C2_x2;
-    deriv[4] = dy0dy() * temp * lambda_x0 * lambda_z0 * (temp_dy + const_2_C2_y * temp_y);
-    deriv[5] = dz0dz() * temp * lambda_x0 * temp_y * lambda * const_1_p_2_C2_z2;
+    deriv[3] = temp * lambda_z0 * temp_y * lambda * const_1_p_2_C2_x2;
+    deriv[4] = temp * lambda_x0 * lambda_z0 * (temp_dy + const_2_C2_y * temp_y);
+    deriv[5] = temp * lambda_x0 * temp_y * lambda * const_1_p_2_C2_z2;
 
     // dmiu3 dx/dy/dz
-    deriv[6] = dx0dx() * temp * lambda_y0 * temp_z * lambda * const_1_p_2_C2_x2;
-    deriv[7] = dy0dy() * temp * lambda_x0 * temp_z * lambda * const_1_p_2_C2_y2;
-    deriv[8] = dz0dz() * temp * lambda_x0 * lambda_y0 * (temp_dz + const_2_C2_z * temp_z);
+    deriv[6] = temp * lambda_y0 * temp_z * lambda * const_1_p_2_C2_x2;
+    deriv[7] = temp * lambda_x0 * temp_z * lambda * const_1_p_2_C2_y2;
+    deriv[8] = temp * lambda_x0 * lambda_y0 * (temp_dz + const_2_C2_z * temp_z);
 
     value[0] = miu_6_4_1;
     value[1] = miu_6_4_2;
@@ -1587,19 +1576,19 @@ void calc_MCSH_6_5(double x0, double y0, double z0, double r0_sqr, double A, dou
     double const_2_C2_z = 2.0 * C2 * z0;
 
     // dmiu1 dx/dy/dz
-    deriv[0] = dx0dx() * temp * (temp_dmiu1_dx + const_2_C2_x * temp_miu1);
-    deriv[1] = dy0dy() * temp * (temp_dmiu1_dy + const_2_C2_y * temp_miu1);
-    deriv[2] = dz0dz() * miu_6_5_1 * const_2_C2_z;
+    deriv[0] = temp * (temp_dmiu1_dx + const_2_C2_x * temp_miu1);
+    deriv[1] = temp * (temp_dmiu1_dy + const_2_C2_y * temp_miu1);
+    deriv[2] = miu_6_5_1 * const_2_C2_z;
 
     // dmiu2 dx/dy/dz
-    deriv[3] = dx0dx() * temp * (temp_dmiu2_dx + const_2_C2_x * temp_miu2);
-    deriv[4] = dy0dy() * miu_6_5_2 * const_2_C2_y;
-    deriv[5] = dz0dz() * temp * (temp_dmiu2_dz + const_2_C2_z * temp_miu2);
+    deriv[3] = temp * (temp_dmiu2_dx + const_2_C2_x * temp_miu2);
+    deriv[4] = miu_6_5_2 * const_2_C2_y;
+    deriv[5] = temp * (temp_dmiu2_dz + const_2_C2_z * temp_miu2);
 
     // dmiu3 dx/dy/dz
-    deriv[6] = dx0dx() * miu_6_5_3 * const_2_C2_x;
-    deriv[7] = dy0dy() * temp * (temp_dmiu3_dy + const_2_C2_y * temp_miu3);
-    deriv[8] = dz0dz() * temp * (temp_dmiu3_dz + const_2_C2_z * temp_miu3);
+    deriv[6] = miu_6_5_3 * const_2_C2_x;
+    deriv[7] = temp * (temp_dmiu3_dy + const_2_C2_y * temp_miu3);
+    deriv[8] = temp * (temp_dmiu3_dz + const_2_C2_z * temp_miu3);
 
     value[0] = miu_6_5_1;
     value[1] = miu_6_5_2;
@@ -1709,34 +1698,34 @@ void calc_MCSH_6_6(double x0, double y0, double z0, double r0_sqr, double A, dou
     double const_1_p_2_C2_z2 = 1.0 + 2.0 * C2 * z0_sqr;
 
     // dmiu1 dx/dy/dz
-    deriv[0] = dx0dx() * temp * lambda_z0 * (temp_dmiu1_dx + const_2_C2_x * temp_miu1);
-    deriv[1] = dy0dy() * temp * lambda_z0 * (temp_dmiu1_dy + const_2_C2_y * temp_miu1);
-    deriv[2] = dz0dz() * temp * temp_miu1 * lambda * const_1_p_2_C2_z2;
+    deriv[0] = temp * lambda_z0 * (temp_dmiu1_dx + const_2_C2_x * temp_miu1);
+    deriv[1] = temp * lambda_z0 * (temp_dmiu1_dy + const_2_C2_y * temp_miu1);
+    deriv[2] = temp * temp_miu1 * lambda * const_1_p_2_C2_z2;
 
     // dmiu2 dx/dy/dz
-    deriv[3] = dx0dx() * temp * lambda_z0 * (temp_dmiu2_dx + const_2_C2_x * temp_miu2);
-    deriv[4] = dy0dy() * temp * lambda_z0 * (temp_dmiu2_dy + const_2_C2_y * temp_miu2);
-    deriv[5] = dz0dz() * temp * temp_miu2 * lambda * const_1_p_2_C2_z2;
+    deriv[3] = temp * lambda_z0 * (temp_dmiu2_dx + const_2_C2_x * temp_miu2);
+    deriv[4] = temp * lambda_z0 * (temp_dmiu2_dy + const_2_C2_y * temp_miu2);
+    deriv[5] = temp * temp_miu2 * lambda * const_1_p_2_C2_z2;
 
     // dmiu3 dx/dy/dz
-    deriv[6] = dx0dx() * temp * lambda_y0 * (temp_dmiu3_dx + const_2_C2_x * temp_miu3);
-    deriv[7] = dy0dy() * temp * temp_miu3 * lambda * const_1_p_2_C2_y2;
-    deriv[8] = dz0dz() * temp * lambda_y0 * (temp_dmiu3_dz + const_2_C2_z * temp_miu3);
+    deriv[6] = temp * lambda_y0 * (temp_dmiu3_dx + const_2_C2_x * temp_miu3);
+    deriv[7] = temp * temp_miu3 * lambda * const_1_p_2_C2_y2;
+    deriv[8] = temp * lambda_y0 * (temp_dmiu3_dz + const_2_C2_z * temp_miu3);
 
     // dmiu4 dx/dy/dz
-    deriv[9] = dx0dx() * temp * lambda_y0 * (temp_dmiu4_dx + const_2_C2_x * temp_miu4);
-    deriv[10] = dy0dy() * temp * temp_miu4 * lambda * const_1_p_2_C2_y2;
-    deriv[11] = dz0dz() * temp * lambda_y0 * (temp_dmiu4_dz + const_2_C2_z * temp_miu4);
+    deriv[9] = temp * lambda_y0 * (temp_dmiu4_dx + const_2_C2_x * temp_miu4);
+    deriv[10] = temp * temp_miu4 * lambda * const_1_p_2_C2_y2;
+    deriv[11] = temp * lambda_y0 * (temp_dmiu4_dz + const_2_C2_z * temp_miu4);
 
     // dmiu5 dx/dy/dz
-    deriv[12] = dx0dx() * temp * temp_miu5 * lambda * const_1_p_2_C2_x2;
-    deriv[13] = dy0dy() * temp * lambda_x0 * (temp_dmiu5_dy + const_2_C2_y * temp_miu5);
-    deriv[14] = dz0dz() * temp * lambda_x0 * (temp_dmiu5_dz + const_2_C2_z * temp_miu5);
+    deriv[12] = temp * temp_miu5 * lambda * const_1_p_2_C2_x2;
+    deriv[13] = temp * lambda_x0 * (temp_dmiu5_dy + const_2_C2_y * temp_miu5);
+    deriv[14] = temp * lambda_x0 * (temp_dmiu5_dz + const_2_C2_z * temp_miu5);
 
     // dmiu6 dx/dy/dz
-    deriv[15] = dx0dx() * temp * temp_miu6 * lambda * const_1_p_2_C2_x2;
-    deriv[16] = dy0dy() * temp * lambda_x0 * (temp_dmiu6_dy + const_2_C2_y * temp_miu6);
-    deriv[17] = dz0dz() * temp * lambda_x0 * (temp_dmiu6_dz + const_2_C2_z * temp_miu6);
+    deriv[15] = temp * temp_miu6 * lambda * const_1_p_2_C2_x2;
+    deriv[16] = temp * lambda_x0 * (temp_dmiu6_dy + const_2_C2_y * temp_miu6);
+    deriv[17] = temp * lambda_x0 * (temp_dmiu6_dz + const_2_C2_z * temp_miu6);
 
     value[0] = miu_6_6_1;
     value[1] = miu_6_6_2;
@@ -1791,9 +1780,9 @@ void calc_MCSH_6_7(double x0, double y0, double z0, double r0_sqr, double A, dou
     double temp =  C1 * exp( C2 * r0_sqr);
     double m_6_7 = temp * sum_ts;
 
-    deriv[0] = dx0dx() * temp * (2.0 * C2 * x0 * sum_ts + sum_dtdx);
-    deriv[1] = dy0dy() * temp * (2.0 * C2 * y0 * sum_ts + sum_dtdy);
-    deriv[2] = dz0dz() * temp * (2.0 * C2 * z0 * sum_ts + sum_dtdz);
+    deriv[0] = temp * (2.0 * C2 * x0 * sum_ts + sum_dtdx);
+    deriv[1] = temp * (2.0 * C2 * y0 * sum_ts + sum_dtdy);
+    deriv[2] = temp * (2.0 * C2 * z0 * sum_ts + sum_dtdz);
 
     value[0] = m_6_7;
 }
@@ -1861,19 +1850,19 @@ void calc_MCSH_7_1(double x0, double y0, double z0, double r0_sqr, double A, dou
     double const_2_C2_z = 2.0 * C2 * z0;
 
     // dmiu1 dx/dy/dz
-    deriv[0] = dx0dx() * temp * (temp_dx + const_2_C2_x * temp_x);
-    deriv[1] = dy0dy() * miu_7_1_1 * const_2_C2_y;
-    deriv[2] = dz0dz() * miu_7_1_1 * const_2_C2_z;
+    deriv[0] = temp * (temp_dx + const_2_C2_x * temp_x);
+    deriv[1] = miu_7_1_1 * const_2_C2_y;
+    deriv[2] = miu_7_1_1 * const_2_C2_z;
 
     // dmiu2 dx/dy/dz
-    deriv[3] = dx0dx() * miu_7_1_2 * const_2_C2_x;
-    deriv[4] = dy0dy() * temp * (temp_dy + const_2_C2_y * temp_y);
-    deriv[5] = dz0dz() * miu_7_1_2 * const_2_C2_z;
+    deriv[3] = miu_7_1_2 * const_2_C2_x;
+    deriv[4] = temp * (temp_dy + const_2_C2_y * temp_y);
+    deriv[5] = miu_7_1_2 * const_2_C2_z;
 
     // dmiu3 dx/dy/dz
-    deriv[6] = dx0dx() * miu_7_1_3 * const_2_C2_x;
-    deriv[7] = dy0dy() * miu_7_1_3 * const_2_C2_y;
-    deriv[8] = dz0dz() * temp * (temp_dz + const_2_C2_z * temp_z);
+    deriv[6] = miu_7_1_3 * const_2_C2_x;
+    deriv[7] = miu_7_1_3 * const_2_C2_y;
+    deriv[8] = temp * (temp_dz + const_2_C2_z * temp_z);
 
     value[0] = miu_7_1_1;
     value[1] = miu_7_1_2;
@@ -1948,34 +1937,34 @@ void calc_MCSH_7_2(double x0, double y0, double z0, double r0_sqr, double A, dou
     double const_1_p_2_C2_z2 = 1.0 + 2.0 * C2 * z0_sqr;
 
     // dmiu1 dx/dy/dz
-    deriv[0] = dx0dx() * temp * lambda_y0 * (temp_dx + const_2_C2_x * temp_x);
-    deriv[1] = dy0dy() * temp * lambda * temp_x * const_1_p_2_C2_y2;
-    deriv[2] = dz0dz() * miu_7_2_1 * const_2_C2_z;
+    deriv[0] = temp * lambda_y0 * (temp_dx + const_2_C2_x * temp_x);
+    deriv[1] = temp * lambda * temp_x * const_1_p_2_C2_y2;
+    deriv[2] = miu_7_2_1 * const_2_C2_z;
 
     // dmiu2 dx/dy/dz
-    deriv[3] = dx0dx() * temp * lambda * temp_y * const_1_p_2_C2_x2;
-    deriv[4] = dy0dy() * temp * lambda_x0 * (temp_dy + const_2_C2_y * temp_y);
-    deriv[5] = dz0dz() * miu_7_2_2 * const_2_C2_z;
+    deriv[3] = temp * lambda * temp_y * const_1_p_2_C2_x2;
+    deriv[4] = temp * lambda_x0 * (temp_dy + const_2_C2_y * temp_y);
+    deriv[5] = miu_7_2_2 * const_2_C2_z;
 
     // dmiu3 dx/dy/dz
-    deriv[6] = dx0dx() * temp * lambda_z0 * (temp_dx + const_2_C2_x * temp_x);
-    deriv[7] = dy0dy() * miu_7_2_3 * const_2_C2_y;
-    deriv[8] = dz0dz() * temp * lambda * temp_x * const_1_p_2_C2_z2;
+    deriv[6] = temp * lambda_z0 * (temp_dx + const_2_C2_x * temp_x);
+    deriv[7] = miu_7_2_3 * const_2_C2_y;
+    deriv[8] = temp * lambda * temp_x * const_1_p_2_C2_z2;
 
     // dmiu4 dx/dy/dz
-    deriv[9] = dx0dx() * temp * lambda * temp_z * const_1_p_2_C2_x2;
-    deriv[10] = dy0dy() * miu_7_2_4 * const_2_C2_y;
-    deriv[11] = dz0dz() * temp * lambda_x0 * (temp_dz + const_2_C2_z * temp_z);
+    deriv[9] = temp * lambda * temp_z * const_1_p_2_C2_x2;
+    deriv[10] = miu_7_2_4 * const_2_C2_y;
+    deriv[11] = temp * lambda_x0 * (temp_dz + const_2_C2_z * temp_z);
 
     // dmiu5 dx/dy/dz
-    deriv[12] = dx0dx() * miu_7_2_5 * const_2_C2_x;
-    deriv[13] = dy0dy() * temp * lambda_z0 * (temp_dy + const_2_C2_y * temp_y);
-    deriv[14] = dz0dz() * temp * lambda * temp_y * const_1_p_2_C2_z2;
+    deriv[12] = miu_7_2_5 * const_2_C2_x;
+    deriv[13] = temp * lambda_z0 * (temp_dy + const_2_C2_y * temp_y);
+    deriv[14] = temp * lambda * temp_y * const_1_p_2_C2_z2;
 
     // dmiu6 dx/dy/dz
-    deriv[15] = dx0dx() * miu_7_2_6 * const_2_C2_x;
-    deriv[16] = dy0dy() * temp * lambda * temp_z * const_1_p_2_C2_y2;
-    deriv[17] = dz0dz() * temp * lambda_y0 * (temp_dz + const_2_C2_z * temp_z);
+    deriv[15] = miu_7_2_6 * const_2_C2_x;
+    deriv[16] = temp * lambda * temp_z * const_1_p_2_C2_y2;
+    deriv[17] = temp * lambda_y0 * (temp_dz + const_2_C2_z * temp_z);
 
     value[0] = miu_7_2_1;
     value[1] = miu_7_2_2;
@@ -2099,34 +2088,34 @@ void calc_MCSH_7_3(double x0, double y0, double z0, double r0_sqr, double A, dou
     double const_2_C2_z = 2.0 * C2 * z0;
 
     // dmiu1 dx/dy/dz
-    deriv[0] = dx0dx() * temp * (temp_dmiu1_dx + const_2_C2_x * temp_miu1);
-    deriv[1] = dy0dy() * temp * (temp_dmiu1_dy + const_2_C2_y * temp_miu1);
-    deriv[2] = dz0dz() * miu_7_3_1 * const_2_C2_z;
+    deriv[0] = temp * (temp_dmiu1_dx + const_2_C2_x * temp_miu1);
+    deriv[1] = temp * (temp_dmiu1_dy + const_2_C2_y * temp_miu1);
+    deriv[2] = miu_7_3_1 * const_2_C2_z;
 
     // dmiu2 dx/dy/dz
-    deriv[3] = dx0dx() * temp * (temp_dmiu2_dx + const_2_C2_x * temp_miu2);
-    deriv[4] = dy0dy() * temp * (temp_dmiu2_dy + const_2_C2_y * temp_miu2);
-    deriv[5] = dz0dz() * miu_7_3_2 * const_2_C2_z;
+    deriv[3] = temp * (temp_dmiu2_dx + const_2_C2_x * temp_miu2);
+    deriv[4] = temp * (temp_dmiu2_dy + const_2_C2_y * temp_miu2);
+    deriv[5] = miu_7_3_2 * const_2_C2_z;
 
     // dmiu3 dx/dy/dz
-    deriv[6] = dx0dx() * temp * (temp_dmiu3_dx + const_2_C2_x * temp_miu3);
-    deriv[7] = dy0dy() * miu_7_3_3 * const_2_C2_y;
-    deriv[8] = dz0dz() * temp * (temp_dmiu3_dz + const_2_C2_z * temp_miu3);
+    deriv[6] = temp * (temp_dmiu3_dx + const_2_C2_x * temp_miu3);
+    deriv[7] = miu_7_3_3 * const_2_C2_y;
+    deriv[8] = temp * (temp_dmiu3_dz + const_2_C2_z * temp_miu3);
 
     // dmiu4 dx/dy/dz
-    deriv[9] = dx0dx() * temp * (temp_dmiu4_dx + const_2_C2_x * temp_miu4);
-    deriv[10] = dy0dy() * miu_7_3_4 * const_2_C2_y;
-    deriv[11] = dz0dz() * temp * (temp_dmiu4_dz + const_2_C2_z * temp_miu4);
+    deriv[9] = temp * (temp_dmiu4_dx + const_2_C2_x * temp_miu4);
+    deriv[10] = miu_7_3_4 * const_2_C2_y;
+    deriv[11] = temp * (temp_dmiu4_dz + const_2_C2_z * temp_miu4);
 
     // dmiu5 dx/dy/dz
-    deriv[12] = dx0dx() * miu_7_3_5 * const_2_C2_x;
-    deriv[13] = dy0dy() * temp * (temp_dmiu5_dy + const_2_C2_y * temp_miu5);
-    deriv[14] = dz0dz() * temp * (temp_dmiu5_dz + const_2_C2_z * temp_miu5);
+    deriv[12] = miu_7_3_5 * const_2_C2_x;
+    deriv[13] = temp * (temp_dmiu5_dy + const_2_C2_y * temp_miu5);
+    deriv[14] = temp * (temp_dmiu5_dz + const_2_C2_z * temp_miu5);
 
     // dmiu6 dx/dy/dz
-    deriv[15] = dx0dx() * miu_7_3_6 * const_2_C2_x;
-    deriv[16] = dy0dy() * temp * (temp_dmiu6_dy + const_2_C2_y * temp_miu6);
-    deriv[17] = dz0dz() * temp * (temp_dmiu6_dz + const_2_C2_z * temp_miu6);
+    deriv[15] = miu_7_3_6 * const_2_C2_x;
+    deriv[16] = temp * (temp_dmiu6_dy + const_2_C2_y * temp_miu6);
+    deriv[17] = temp * (temp_dmiu6_dz + const_2_C2_z * temp_miu6);
 
     value[0] = miu_7_3_1;
     value[1] = miu_7_3_2;
@@ -2197,19 +2186,19 @@ void calc_MCSH_7_4(double x0, double y0, double z0, double r0_sqr, double A, dou
     double const_1_p_2_C2_z2 = 1.0 + 2.0 * C2 * z0_sqr;
 
     // dmiu1 dx/dy/dz
-    deriv[0] = dx0dx() * temp * lambda_y0 * lambda_z0 * (temp_dx + const_2_C2_x * temp_x);
-    deriv[1] = dy0dy() * temp * lambda_z0 * temp_x * lambda * const_1_p_2_C2_y2;
-    deriv[2] = dz0dz() * temp * lambda_y0 * temp_x * lambda * const_1_p_2_C2_z2;
+    deriv[0] = temp * lambda_y0 * lambda_z0 * (temp_dx + const_2_C2_x * temp_x);
+    deriv[1] = temp * lambda_z0 * temp_x * lambda * const_1_p_2_C2_y2;
+    deriv[2] = temp * lambda_y0 * temp_x * lambda * const_1_p_2_C2_z2;
 
     // dmiu2 dx/dy/dz
-    deriv[3] = dx0dx() * temp * lambda_z0 * temp_y * lambda * const_1_p_2_C2_x2;
-    deriv[4] = dy0dy() * temp * lambda_x0 * lambda_z0 * (temp_dy + const_2_C2_y * temp_y);
-    deriv[5] = dz0dz() * temp * lambda_x0 * temp_y * lambda * const_1_p_2_C2_z2;
+    deriv[3] = temp * lambda_z0 * temp_y * lambda * const_1_p_2_C2_x2;
+    deriv[4] = temp * lambda_x0 * lambda_z0 * (temp_dy + const_2_C2_y * temp_y);
+    deriv[5] = temp * lambda_x0 * temp_y * lambda * const_1_p_2_C2_z2;
 
     // dmiu3 dx/dy/dz
-    deriv[6] = dx0dx() * temp * lambda_y0 * temp_z * lambda * const_1_p_2_C2_x2;
-    deriv[7] = dy0dy() * temp * lambda_x0 * temp_z * lambda * const_1_p_2_C2_y2;
-    deriv[8] = dz0dz() * temp * lambda_x0 * lambda_y0 * (temp_dz + const_2_C2_z * temp_z);
+    deriv[6] = temp * lambda_y0 * temp_z * lambda * const_1_p_2_C2_x2;
+    deriv[7] = temp * lambda_x0 * temp_z * lambda * const_1_p_2_C2_y2;
+    deriv[8] = temp * lambda_x0 * lambda_y0 * (temp_dz + const_2_C2_z * temp_z);
 
     value[0] = miu_7_4_1;
     value[1] = miu_7_4_2;
@@ -2326,34 +2315,34 @@ void calc_MCSH_7_5(double x0, double y0, double z0, double r0_sqr, double A, dou
     double const_2_C2_z = 2.0 * C2 * z0;
 
     // dmiu1 dx/dy/dz
-    deriv[0] = dx0dx() * temp * (temp_dmiu1_dx + const_2_C2_x * temp_miu1);
-    deriv[1] = dy0dy() * temp * (temp_dmiu1_dy + const_2_C2_y * temp_miu1);
-    deriv[2] = dz0dz() * miu_7_5_1 * const_2_C2_z;
+    deriv[0] = temp * (temp_dmiu1_dx + const_2_C2_x * temp_miu1);
+    deriv[1] = temp * (temp_dmiu1_dy + const_2_C2_y * temp_miu1);
+    deriv[2] = miu_7_5_1 * const_2_C2_z;
 
     // dmiu2 dx/dy/dz
-    deriv[3] = dx0dx() * temp * (temp_dmiu2_dx + const_2_C2_x * temp_miu2);
-    deriv[4] = dy0dy() * temp * (temp_dmiu2_dy + const_2_C2_y * temp_miu2);
-    deriv[5] = dz0dz() * miu_7_5_2 * const_2_C2_z;
+    deriv[3] = temp * (temp_dmiu2_dx + const_2_C2_x * temp_miu2);
+    deriv[4] = temp * (temp_dmiu2_dy + const_2_C2_y * temp_miu2);
+    deriv[5] = miu_7_5_2 * const_2_C2_z;
 
     // dmiu3 dx/dy/dz
-    deriv[6] = dx0dx() * temp * (temp_dmiu3_dx + const_2_C2_x * temp_miu3);
-    deriv[7] = dy0dy() * miu_7_5_3 * const_2_C2_y;
-    deriv[8] = dz0dz() * temp * (temp_dmiu3_dz + const_2_C2_z * temp_miu3);
+    deriv[6] = temp * (temp_dmiu3_dx + const_2_C2_x * temp_miu3);
+    deriv[7] = miu_7_5_3 * const_2_C2_y;
+    deriv[8] = temp * (temp_dmiu3_dz + const_2_C2_z * temp_miu3);
 
     // dmiu4 dx/dy/dz
-    deriv[9] = dx0dx() * temp * (temp_dmiu4_dx + const_2_C2_x * temp_miu4);
-    deriv[10] = dy0dy() * miu_7_5_4 * const_2_C2_y;
-    deriv[11] = dz0dz() * temp * (temp_dmiu4_dz + const_2_C2_z * temp_miu4);
+    deriv[9] = temp * (temp_dmiu4_dx + const_2_C2_x * temp_miu4);
+    deriv[10] = miu_7_5_4 * const_2_C2_y;
+    deriv[11] = temp * (temp_dmiu4_dz + const_2_C2_z * temp_miu4);
 
     // dmiu5 dx/dy/dz
-    deriv[12] = dx0dx() * miu_7_5_5 * const_2_C2_x;
-    deriv[13] = dy0dy() * temp * (temp_dmiu5_dy + const_2_C2_y * temp_miu5);
-    deriv[14] = dz0dz() * temp * (temp_dmiu5_dz + const_2_C2_z * temp_miu5);
+    deriv[12] = miu_7_5_5 * const_2_C2_x;
+    deriv[13] = temp * (temp_dmiu5_dy + const_2_C2_y * temp_miu5);
+    deriv[14] = temp * (temp_dmiu5_dz + const_2_C2_z * temp_miu5);
 
     // dmiu6 dx/dy/dz
-    deriv[15] = dx0dx() * miu_7_5_6 * const_2_C2_x;
-    deriv[16] = dy0dy() * temp * (temp_dmiu6_dy + const_2_C2_y * temp_miu6);
-    deriv[17] = dz0dz() * temp * (temp_dmiu6_dz + const_2_C2_z * temp_miu6);
+    deriv[15] = miu_7_5_6 * const_2_C2_x;
+    deriv[16] = temp * (temp_dmiu6_dy + const_2_C2_y * temp_miu6);
+    deriv[17] = temp * (temp_dmiu6_dz + const_2_C2_z * temp_miu6);
 
     value[0] = miu_7_5_1;
     value[1] = miu_7_5_2;
@@ -2470,34 +2459,34 @@ void calc_MCSH_7_6(double x0, double y0, double z0, double r0_sqr, double A, dou
     double const_1_p_2_C2_z2 = 1.0 + 2.0 * C2 * z0_sqr;
 
     // dmiu1 dx/dy/dz
-    deriv[0] = dx0dx() * temp * lambda_z0 * (temp_dmiu1_dx + const_2_C2_x * temp_miu1);
-    deriv[1] = dy0dy() * temp * lambda_z0 * (temp_dmiu1_dy + const_2_C2_y * temp_miu1);
-    deriv[2] = dz0dz() * temp * temp_miu1 * lambda * const_1_p_2_C2_z2;
+    deriv[0] = temp * lambda_z0 * (temp_dmiu1_dx + const_2_C2_x * temp_miu1);
+    deriv[1] = temp * lambda_z0 * (temp_dmiu1_dy + const_2_C2_y * temp_miu1);
+    deriv[2] = temp * temp_miu1 * lambda * const_1_p_2_C2_z2;
 
     // dmiu2 dx/dy/dz
-    deriv[3] = dx0dx() * temp * lambda_z0 * (temp_dmiu2_dx + const_2_C2_x * temp_miu2);
-    deriv[4] = dy0dy() * temp * lambda_z0 * (temp_dmiu2_dy + const_2_C2_y * temp_miu2);
-    deriv[5] = dz0dz() * temp * temp_miu2 * lambda * const_1_p_2_C2_z2;
+    deriv[3] = temp * lambda_z0 * (temp_dmiu2_dx + const_2_C2_x * temp_miu2);
+    deriv[4] = temp * lambda_z0 * (temp_dmiu2_dy + const_2_C2_y * temp_miu2);
+    deriv[5] = temp * temp_miu2 * lambda * const_1_p_2_C2_z2;
 
     // dmiu3 dx/dy/dz
-    deriv[6] = dx0dx() * temp * lambda_y0 * (temp_dmiu3_dx + const_2_C2_x * temp_miu3);
-    deriv[7] = dy0dy() * temp * temp_miu3 * lambda * const_1_p_2_C2_y2;
-    deriv[8] = dz0dz() * temp * lambda_y0 * (temp_dmiu3_dz + const_2_C2_z * temp_miu3);
+    deriv[6] = temp * lambda_y0 * (temp_dmiu3_dx + const_2_C2_x * temp_miu3);
+    deriv[7] = temp * temp_miu3 * lambda * const_1_p_2_C2_y2;
+    deriv[8] = temp * lambda_y0 * (temp_dmiu3_dz + const_2_C2_z * temp_miu3);
 
     // dmiu4 dx/dy/dz
-    deriv[9] = dx0dx() * temp * lambda_y0 * (temp_dmiu4_dx + const_2_C2_x * temp_miu4);
-    deriv[10] = dy0dy() * temp * temp_miu4 * lambda * const_1_p_2_C2_y2;
-    deriv[11] = dz0dz() * temp * lambda_y0 * (temp_dmiu4_dz + const_2_C2_z * temp_miu4);
+    deriv[9] = temp * lambda_y0 * (temp_dmiu4_dx + const_2_C2_x * temp_miu4);
+    deriv[10] = temp * temp_miu4 * lambda * const_1_p_2_C2_y2;
+    deriv[11] = temp * lambda_y0 * (temp_dmiu4_dz + const_2_C2_z * temp_miu4);
 
     // dmiu5 dx/dy/dz
-    deriv[12] = dx0dx() * temp * temp_miu5 * lambda * const_1_p_2_C2_x2;
-    deriv[13] = dy0dy() * temp * lambda_x0 * (temp_dmiu5_dy + const_2_C2_y * temp_miu5);
-    deriv[14] = dz0dz() * temp * lambda_x0 * (temp_dmiu5_dz + const_2_C2_z * temp_miu5);
+    deriv[12] = temp * temp_miu5 * lambda * const_1_p_2_C2_x2;
+    deriv[13] = temp * lambda_x0 * (temp_dmiu5_dy + const_2_C2_y * temp_miu5);
+    deriv[14] = temp * lambda_x0 * (temp_dmiu5_dz + const_2_C2_z * temp_miu5);
 
     // dmiu6 dx/dy/dz
-    deriv[15] = dx0dx() * temp * temp_miu6 * lambda * const_1_p_2_C2_x2;
-    deriv[16] = dy0dy() * temp * lambda_x0 * (temp_dmiu6_dy + const_2_C2_y * temp_miu6);
-    deriv[17] = dz0dz() * temp * lambda_x0 * (temp_dmiu6_dz + const_2_C2_z * temp_miu6);
+    deriv[15] = temp * temp_miu6 * lambda * const_1_p_2_C2_x2;
+    deriv[16] = temp * lambda_x0 * (temp_dmiu6_dy + const_2_C2_y * temp_miu6);
+    deriv[17] = temp * lambda_x0 * (temp_dmiu6_dz + const_2_C2_z * temp_miu6);
 
     value[0] = miu_7_6_1;
     value[1] = miu_7_6_2;
@@ -2586,19 +2575,19 @@ void calc_MCSH_7_7(double x0, double y0, double z0, double r0_sqr, double A, dou
     double const_1_p_2_C2_z2 = 1.0 + 2.0 * C2 * z0_sqr;
 
     // dmiu1 dx/dy/dz
-    deriv[0] = dx0dx() * temp * lambda_z0 * (temp_dmiu1_dx + const_2_C2_x * temp_miu1);
-    deriv[1] = dy0dy() * temp * lambda_z0 * (temp_dmiu1_dy + const_2_C2_y * temp_miu1);
-    deriv[2] = dz0dz() * temp * temp_miu1 * lambda * const_1_p_2_C2_z2;
+    deriv[0] = temp * lambda_z0 * (temp_dmiu1_dx + const_2_C2_x * temp_miu1);
+    deriv[1] = temp * lambda_z0 * (temp_dmiu1_dy + const_2_C2_y * temp_miu1);
+    deriv[2] = temp * temp_miu1 * lambda * const_1_p_2_C2_z2;
 
     // dmiu3 dx/dy/dz
-    deriv[3] = dx0dx() * temp * lambda_y0 * (temp_dmiu2_dx + const_2_C2_x * temp_miu2);
-    deriv[4] = dy0dy() * temp * temp_miu2 * lambda * const_1_p_2_C2_y2;
-    deriv[5] = dz0dz() * temp * lambda_y0 * (temp_dmiu2_dz + const_2_C2_z * temp_miu2);
+    deriv[3] = temp * lambda_y0 * (temp_dmiu2_dx + const_2_C2_x * temp_miu2);
+    deriv[4] = temp * temp_miu2 * lambda * const_1_p_2_C2_y2;
+    deriv[5] = temp * lambda_y0 * (temp_dmiu2_dz + const_2_C2_z * temp_miu2);
 
     // dmiu5 dx/dy/dz
-    deriv[6] = dx0dx() * temp * temp_miu3 * lambda * const_1_p_2_C2_x2;
-    deriv[7] = dy0dy() * temp * lambda_x0 * (temp_dmiu3_dy + const_2_C2_y * temp_miu3);
-    deriv[8] = dz0dz() * temp * lambda_x0 * (temp_dmiu3_dz + const_2_C2_z * temp_miu3);
+    deriv[6] = temp * temp_miu3 * lambda * const_1_p_2_C2_x2;
+    deriv[7] = temp * lambda_x0 * (temp_dmiu3_dy + const_2_C2_y * temp_miu3);
+    deriv[8] = temp * lambda_x0 * (temp_dmiu3_dz + const_2_C2_z * temp_miu3);
 
     value[0] = miu_7_7_1;
     value[1] = miu_7_7_2;
@@ -2698,19 +2687,19 @@ void calc_MCSH_7_8(double x0, double y0, double z0, double r0_sqr, double A, dou
     double const_2_C2_z = 2.0 * C2 * z0;
 
     // dmiu1 dx/dy/dz
-    deriv[0] = dx0dx() * temp * (temp_dmiu1_dx + const_2_C2_x * temp_miu1);
-    deriv[1] = dy0dy() * temp * (temp_dmiu1_dy + const_2_C2_y * temp_miu1);
-    deriv[2] = dz0dz() * temp * (temp_dmiu1_dz + const_2_C2_z * temp_miu1);
+    deriv[0] = temp * (temp_dmiu1_dx + const_2_C2_x * temp_miu1);
+    deriv[1] = temp * (temp_dmiu1_dy + const_2_C2_y * temp_miu1);
+    deriv[2] = temp * (temp_dmiu1_dz + const_2_C2_z * temp_miu1);
 
     // dmiu2 dx/dy/dz
-    deriv[3] = dx0dx() * temp * (temp_dmiu2_dx + const_2_C2_x * temp_miu2);
-    deriv[4] = dy0dy() * temp * (temp_dmiu2_dy + const_2_C2_y * temp_miu2);
-    deriv[5] = dz0dz() * temp * (temp_dmiu2_dz + const_2_C2_z * temp_miu2);
+    deriv[3] = temp * (temp_dmiu2_dx + const_2_C2_x * temp_miu2);
+    deriv[4] = temp * (temp_dmiu2_dy + const_2_C2_y * temp_miu2);
+    deriv[5] = temp * (temp_dmiu2_dz + const_2_C2_z * temp_miu2);
 
     // dmiu3 dx/dy/dz
-    deriv[6] = dx0dx() * temp * (temp_dmiu3_dx + const_2_C2_x * temp_miu3);
-    deriv[7] = dy0dy() * temp * (temp_dmiu3_dy + const_2_C2_y * temp_miu3);
-    deriv[8] = dz0dz() * temp * (temp_dmiu3_dz + const_2_C2_z * temp_miu3);
+    deriv[6] = temp * (temp_dmiu3_dx + const_2_C2_x * temp_miu3);
+    deriv[7] = temp * (temp_dmiu3_dy + const_2_C2_y * temp_miu3);
+    deriv[8] = temp * (temp_dmiu3_dz + const_2_C2_z * temp_miu3);
 
     value[0] = miu_7_8_1;
     value[1] = miu_7_8_2;
@@ -2787,19 +2776,19 @@ void calc_MCSH_8_1(double x0, double y0, double z0, double r0_sqr, double A, dou
     double const_2_C2_z = 2.0 * C2 * z0;
 
     // dmiu1 dx/dy/dz
-    deriv[0] = dx0dx() * temp * (temp_dx + const_2_C2_x * temp_x);
-    deriv[1] = dy0dy() * miu_8_1_1 * const_2_C2_y;
-    deriv[2] = dz0dz() * miu_8_1_1 * const_2_C2_z;
+    deriv[0] = temp * (temp_dx + const_2_C2_x * temp_x);
+    deriv[1] = miu_8_1_1 * const_2_C2_y;
+    deriv[2] = miu_8_1_1 * const_2_C2_z;
 
     // dmiu2 dx/dy/dz
-    deriv[3] = dx0dx() * miu_8_1_2 * const_2_C2_x;
-    deriv[4] = dy0dy() * temp * (temp_dy + const_2_C2_y * temp_y);
-    deriv[5] = dz0dz() * miu_8_1_2 * const_2_C2_z;
+    deriv[3] = miu_8_1_2 * const_2_C2_x;
+    deriv[4] = temp * (temp_dy + const_2_C2_y * temp_y);
+    deriv[5] = miu_8_1_2 * const_2_C2_z;
 
     // dmiu3 dx/dy/dz
-    deriv[6] = dx0dx() * miu_8_1_3 * const_2_C2_x;
-    deriv[7] = dy0dy() * miu_8_1_3 * const_2_C2_y;
-    deriv[8] = dz0dz() * temp * (temp_dz + const_2_C2_z * temp_z);
+    deriv[6] = miu_8_1_3 * const_2_C2_x;
+    deriv[7] = miu_8_1_3 * const_2_C2_y;
+    deriv[8] = temp * (temp_dz + const_2_C2_z * temp_z);
 
     value[0] = miu_8_1_1;
     value[1] = miu_8_1_2;
@@ -2879,34 +2868,34 @@ void calc_MCSH_8_2(double x0, double y0, double z0, double r0_sqr, double A, dou
     double const_1_p_2_C2_z2 = 1.0 + 2.0 * C2 * z0_sqr;
 
     // dmiu1 dx/dy/dz
-    deriv[0] = dx0dx() * temp * lambda_y0 * (temp_dx + const_2_C2_x * temp_x);
-    deriv[1] = dy0dy() * temp * lambda * temp_x * const_1_p_2_C2_y2;
-    deriv[2] = dz0dz() * miu_8_2_1 * const_2_C2_z;
+    deriv[0] = temp * lambda_y0 * (temp_dx + const_2_C2_x * temp_x);
+    deriv[1] = temp * lambda * temp_x * const_1_p_2_C2_y2;
+    deriv[2] = miu_8_2_1 * const_2_C2_z;
 
     // dmiu2 dx/dy/dz
-    deriv[3] = dx0dx() * temp * lambda * temp_y * const_1_p_2_C2_x2;
-    deriv[4] = dy0dy() * temp * lambda_x0 * (temp_dy + const_2_C2_y * temp_y);
-    deriv[5] = dz0dz() * miu_8_2_2 * const_2_C2_z;
+    deriv[3] = temp * lambda * temp_y * const_1_p_2_C2_x2;
+    deriv[4] = temp * lambda_x0 * (temp_dy + const_2_C2_y * temp_y);
+    deriv[5] = miu_8_2_2 * const_2_C2_z;
 
     // dmiu3 dx/dy/dz
-    deriv[6] = dx0dx() * temp * lambda_z0 * (temp_dx + const_2_C2_x * temp_x);
-    deriv[7] = dy0dy() * miu_8_2_3 * const_2_C2_y;
-    deriv[8] = dz0dz() * temp * lambda * temp_x * const_1_p_2_C2_z2;
+    deriv[6] = temp * lambda_z0 * (temp_dx + const_2_C2_x * temp_x);
+    deriv[7] = miu_8_2_3 * const_2_C2_y;
+    deriv[8] = temp * lambda * temp_x * const_1_p_2_C2_z2;
 
     // dmiu4 dx/dy/dz
-    deriv[9] = dx0dx() * temp * lambda * temp_z * const_1_p_2_C2_x2;
-    deriv[10] = dy0dy() * miu_8_2_4 * const_2_C2_y;
-    deriv[11] = dz0dz() * temp * lambda_x0 * (temp_dz + const_2_C2_z * temp_z);
+    deriv[9] = temp * lambda * temp_z * const_1_p_2_C2_x2;
+    deriv[10] = miu_8_2_4 * const_2_C2_y;
+    deriv[11] = temp * lambda_x0 * (temp_dz + const_2_C2_z * temp_z);
 
     // dmiu5 dx/dy/dz
-    deriv[12] = dx0dx() * miu_8_2_5 * const_2_C2_x;
-    deriv[13] = dy0dy() * temp * lambda_z0 * (temp_dy + const_2_C2_y * temp_y);
-    deriv[14] = dz0dz() * temp * lambda * temp_y * const_1_p_2_C2_z2;
+    deriv[12] = miu_8_2_5 * const_2_C2_x;
+    deriv[13] = temp * lambda_z0 * (temp_dy + const_2_C2_y * temp_y);
+    deriv[14] = temp * lambda * temp_y * const_1_p_2_C2_z2;
 
     // dmiu6 dx/dy/dz
-    deriv[15] = dx0dx() * miu_8_2_6 * const_2_C2_x;
-    deriv[16] = dy0dy() * temp * lambda * temp_z * const_1_p_2_C2_y2;
-    deriv[17] = dz0dz() * temp * lambda_y0 * (temp_dz + const_2_C2_z * temp_z);
+    deriv[15] = miu_8_2_6 * const_2_C2_x;
+    deriv[16] = temp * lambda * temp_z * const_1_p_2_C2_y2;
+    deriv[17] = temp * lambda_y0 * (temp_dz + const_2_C2_z * temp_z);
 
     value[0] = miu_8_2_1;
     value[1] = miu_8_2_2;
@@ -3034,34 +3023,34 @@ void calc_MCSH_8_3(double x0, double y0, double z0, double r0_sqr, double A, dou
     double const_2_C2_z = 2.0 * C2 * z0;
 
     // dmiu1 dx/dy/dz
-    deriv[0] = dx0dx() * temp * (temp_dmiu1_dx + const_2_C2_x * temp_miu1);
-    deriv[1] = dy0dy() * temp * (temp_dmiu1_dy + const_2_C2_y * temp_miu1);
-    deriv[2] = dz0dz() * miu_8_3_1 * const_2_C2_z;
+    deriv[0] = temp * (temp_dmiu1_dx + const_2_C2_x * temp_miu1);
+    deriv[1] = temp * (temp_dmiu1_dy + const_2_C2_y * temp_miu1);
+    deriv[2] = miu_8_3_1 * const_2_C2_z;
 
     // dmiu2 dx/dy/dz
-    deriv[3] = dx0dx() * temp * (temp_dmiu2_dx + const_2_C2_x * temp_miu2);
-    deriv[4] = dy0dy() * temp * (temp_dmiu2_dy + const_2_C2_y * temp_miu2);
-    deriv[5] = dz0dz() * miu_8_3_2 * const_2_C2_z;
+    deriv[3] = temp * (temp_dmiu2_dx + const_2_C2_x * temp_miu2);
+    deriv[4] = temp * (temp_dmiu2_dy + const_2_C2_y * temp_miu2);
+    deriv[5] = miu_8_3_2 * const_2_C2_z;
 
     // dmiu3 dx/dy/dz
-    deriv[6] = dx0dx() * temp * (temp_dmiu3_dx + const_2_C2_x * temp_miu3);
-    deriv[7] = dy0dy() * miu_8_3_3 * const_2_C2_y;
-    deriv[8] = dz0dz() * temp * (temp_dmiu3_dz + const_2_C2_z * temp_miu3);
+    deriv[6] = temp * (temp_dmiu3_dx + const_2_C2_x * temp_miu3);
+    deriv[7] = miu_8_3_3 * const_2_C2_y;
+    deriv[8] = temp * (temp_dmiu3_dz + const_2_C2_z * temp_miu3);
 
     // dmiu4 dx/dy/dz
-    deriv[9] = dx0dx() * temp * (temp_dmiu4_dx + const_2_C2_x * temp_miu4);
-    deriv[10] = dy0dy() * miu_8_3_4 * const_2_C2_y;
-    deriv[11] = dz0dz() * temp * (temp_dmiu4_dz + const_2_C2_z * temp_miu4);
+    deriv[9] = temp * (temp_dmiu4_dx + const_2_C2_x * temp_miu4);
+    deriv[10] = miu_8_3_4 * const_2_C2_y;
+    deriv[11] = temp * (temp_dmiu4_dz + const_2_C2_z * temp_miu4);
 
     // dmiu5 dx/dy/dz
-    deriv[12] = dx0dx() * miu_8_3_5 * const_2_C2_x;
-    deriv[13] = dy0dy() * temp * (temp_dmiu5_dy + const_2_C2_y * temp_miu5);
-    deriv[14] = dz0dz() * temp * (temp_dmiu5_dz + const_2_C2_z * temp_miu5);
+    deriv[12] = miu_8_3_5 * const_2_C2_x;
+    deriv[13] = temp * (temp_dmiu5_dy + const_2_C2_y * temp_miu5);
+    deriv[14] = temp * (temp_dmiu5_dz + const_2_C2_z * temp_miu5);
 
     // dmiu6 dx/dy/dz
-    deriv[15] = dx0dx() * miu_8_3_6 * const_2_C2_x;
-    deriv[16] = dy0dy() * temp * (temp_dmiu6_dy + const_2_C2_y * temp_miu6);
-    deriv[17] = dz0dz() * temp * (temp_dmiu6_dz + const_2_C2_z * temp_miu6);
+    deriv[15] = miu_8_3_6 * const_2_C2_x;
+    deriv[16] = temp * (temp_dmiu6_dy + const_2_C2_y * temp_miu6);
+    deriv[17] = temp * (temp_dmiu6_dz + const_2_C2_z * temp_miu6);
 
     value[0] = miu_8_3_1;
     value[1] = miu_8_3_2;
@@ -3137,19 +3126,19 @@ void calc_MCSH_8_4(double x0, double y0, double z0, double r0_sqr, double A, dou
     double const_1_p_2_C2_z2 = 1.0 + 2.0 * C2 * z0_sqr;
 
     // dmiu1 dx/dy/dz
-    deriv[0] = dx0dx() * temp * lambda_y0 * lambda_z0 * (temp_dx + const_2_C2_x * temp_x);
-    deriv[1] = dy0dy() * temp * lambda_z0 * temp_x * lambda * const_1_p_2_C2_y2;
-    deriv[2] = dz0dz() * temp * lambda_y0 * temp_x * lambda * const_1_p_2_C2_z2;
+    deriv[0] = temp * lambda_y0 * lambda_z0 * (temp_dx + const_2_C2_x * temp_x);
+    deriv[1] = temp * lambda_z0 * temp_x * lambda * const_1_p_2_C2_y2;
+    deriv[2] = temp * lambda_y0 * temp_x * lambda * const_1_p_2_C2_z2;
 
     // dmiu2 dx/dy/dz
-    deriv[3] = dx0dx() * temp * lambda_z0 * temp_y * lambda * const_1_p_2_C2_x2;
-    deriv[4] = dy0dy() * temp * lambda_x0 * lambda_z0 * (temp_dy + const_2_C2_y * temp_y);
-    deriv[5] = dz0dz() * temp * lambda_x0 * temp_y * lambda * const_1_p_2_C2_z2;
+    deriv[3] = temp * lambda_z0 * temp_y * lambda * const_1_p_2_C2_x2;
+    deriv[4] = temp * lambda_x0 * lambda_z0 * (temp_dy + const_2_C2_y * temp_y);
+    deriv[5] = temp * lambda_x0 * temp_y * lambda * const_1_p_2_C2_z2;
 
     // dmiu3 dx/dy/dz
-    deriv[6] = dx0dx() * temp * lambda_y0 * temp_z * lambda * const_1_p_2_C2_x2;
-    deriv[7] = dy0dy() * temp * lambda_x0 * temp_z * lambda * const_1_p_2_C2_y2;
-    deriv[8] = dz0dz() * temp * lambda_x0 * lambda_y0 * (temp_dz + const_2_C2_z * temp_z);
+    deriv[6] = temp * lambda_y0 * temp_z * lambda * const_1_p_2_C2_x2;
+    deriv[7] = temp * lambda_x0 * temp_z * lambda * const_1_p_2_C2_y2;
+    deriv[8] = temp * lambda_x0 * lambda_y0 * (temp_dz + const_2_C2_z * temp_z);
 
     value[0] = miu_8_4_1;
     value[1] = miu_8_4_2;
@@ -3263,34 +3252,34 @@ void calc_MCSH_8_5(double x0, double y0, double z0, double r0_sqr, double A, dou
     double const_2_C2_z = 2.0 * C2 * z0;
 
     // dmiu1 dx/dy/dz
-    deriv[0] = dx0dx() * temp * (temp_dmiu1_dx + const_2_C2_x * temp_miu1);
-    deriv[1] = dy0dy() * temp * (temp_dmiu1_dy + const_2_C2_y * temp_miu1);
-    deriv[2] = dz0dz() * miu_8_5_1 * const_2_C2_z;
+    deriv[0] = temp * (temp_dmiu1_dx + const_2_C2_x * temp_miu1);
+    deriv[1] = temp * (temp_dmiu1_dy + const_2_C2_y * temp_miu1);
+    deriv[2] = miu_8_5_1 * const_2_C2_z;
 
     // dmiu2 dx/dy/dz
-    deriv[3] = dx0dx() * temp * (temp_dmiu2_dx + const_2_C2_x * temp_miu2);
-    deriv[4] = dy0dy() * temp * (temp_dmiu2_dy + const_2_C2_y * temp_miu2);
-    deriv[5] = dz0dz() * miu_8_5_2 * const_2_C2_z;
+    deriv[3] = temp * (temp_dmiu2_dx + const_2_C2_x * temp_miu2);
+    deriv[4] = temp * (temp_dmiu2_dy + const_2_C2_y * temp_miu2);
+    deriv[5] = miu_8_5_2 * const_2_C2_z;
 
     // dmiu3 dx/dy/dz
-    deriv[6] = dx0dx() * temp * (temp_dmiu3_dx + const_2_C2_x * temp_miu3);
-    deriv[7] = dy0dy() * miu_8_5_3 * const_2_C2_y;
-    deriv[8] = dz0dz() * temp * (temp_dmiu3_dz + const_2_C2_z * temp_miu3);
+    deriv[6] = temp * (temp_dmiu3_dx + const_2_C2_x * temp_miu3);
+    deriv[7] = miu_8_5_3 * const_2_C2_y;
+    deriv[8] = temp * (temp_dmiu3_dz + const_2_C2_z * temp_miu3);
 
     // dmiu4 dx/dy/dz
-    deriv[9] = dx0dx() * temp * (temp_dmiu4_dx + const_2_C2_x * temp_miu4);
-    deriv[10] = dy0dy() * miu_8_5_4 * const_2_C2_y;
-    deriv[11] = dz0dz() * temp * (temp_dmiu4_dz + const_2_C2_z * temp_miu4);
+    deriv[9] = temp * (temp_dmiu4_dx + const_2_C2_x * temp_miu4);
+    deriv[10] = miu_8_5_4 * const_2_C2_y;
+    deriv[11] = temp * (temp_dmiu4_dz + const_2_C2_z * temp_miu4);
 
     // dmiu5 dx/dy/dz
-    deriv[12] = dx0dx() * miu_8_5_5 * const_2_C2_x;
-    deriv[13] = dy0dy() * temp * (temp_dmiu5_dy + const_2_C2_y * temp_miu5);
-    deriv[14] = dz0dz() * temp * (temp_dmiu5_dz + const_2_C2_z * temp_miu5);
+    deriv[12] = miu_8_5_5 * const_2_C2_x;
+    deriv[13] = temp * (temp_dmiu5_dy + const_2_C2_y * temp_miu5);
+    deriv[14] = temp * (temp_dmiu5_dz + const_2_C2_z * temp_miu5);
 
     // dmiu6 dx/dy/dz
-    deriv[15] = dx0dx() * miu_8_5_6 * const_2_C2_x;
-    deriv[16] = dy0dy() * temp * (temp_dmiu6_dy + const_2_C2_y * temp_miu6);
-    deriv[17] = dz0dz() * temp * (temp_dmiu6_dz + const_2_C2_z * temp_miu6);
+    deriv[15] = miu_8_5_6 * const_2_C2_x;
+    deriv[16] = temp * (temp_dmiu6_dy + const_2_C2_y * temp_miu6);
+    deriv[17] = temp * (temp_dmiu6_dz + const_2_C2_z * temp_miu6);
 
     value[0] = miu_8_5_1;
     value[1] = miu_8_5_2;
@@ -3423,34 +3412,34 @@ void calc_MCSH_8_6(double x0, double y0, double z0, double r0_sqr, double A, dou
     double const_1_p_2_C2_z2 = 1.0 + 2.0 * C2 * z0_sqr;
 
     // dmiu1 dx/dy/dz
-    deriv[0] = dx0dx() * temp * lambda_z0 * (temp_dmiu1_dx + const_2_C2_x * temp_miu1);
-    deriv[1] = dy0dy() * temp * lambda_z0 * (temp_dmiu1_dy + const_2_C2_y * temp_miu1);
-    deriv[2] = dz0dz() * temp * temp_miu1 * lambda * const_1_p_2_C2_z2;
+    deriv[0] = temp * lambda_z0 * (temp_dmiu1_dx + const_2_C2_x * temp_miu1);
+    deriv[1] = temp * lambda_z0 * (temp_dmiu1_dy + const_2_C2_y * temp_miu1);
+    deriv[2] = temp * temp_miu1 * lambda * const_1_p_2_C2_z2;
 
     // dmiu2 dx/dy/dz
-    deriv[3] = dx0dx() * temp * lambda_z0 * (temp_dmiu2_dx + const_2_C2_x * temp_miu2);
-    deriv[4] = dy0dy() * temp * lambda_z0 * (temp_dmiu2_dy + const_2_C2_y * temp_miu2);
-    deriv[5] = dz0dz() * temp * temp_miu2 * lambda * const_1_p_2_C2_z2;
+    deriv[3] = temp * lambda_z0 * (temp_dmiu2_dx + const_2_C2_x * temp_miu2);
+    deriv[4] = temp * lambda_z0 * (temp_dmiu2_dy + const_2_C2_y * temp_miu2);
+    deriv[5] = temp * temp_miu2 * lambda * const_1_p_2_C2_z2;
 
     // dmiu3 dx/dy/dz
-    deriv[6] = dx0dx() * temp * lambda_y0 * (temp_dmiu3_dx + const_2_C2_x * temp_miu3);
-    deriv[7] = dy0dy() * temp * temp_miu3 * lambda * const_1_p_2_C2_y2;
-    deriv[8] = dz0dz() * temp * lambda_y0 * (temp_dmiu3_dz + const_2_C2_z * temp_miu3);
+    deriv[6] = temp * lambda_y0 * (temp_dmiu3_dx + const_2_C2_x * temp_miu3);
+    deriv[7] = temp * temp_miu3 * lambda * const_1_p_2_C2_y2;
+    deriv[8] = temp * lambda_y0 * (temp_dmiu3_dz + const_2_C2_z * temp_miu3);
 
     // dmiu4 dx/dy/dz
-    deriv[9] = dx0dx() * temp * lambda_y0 * (temp_dmiu4_dx + const_2_C2_x * temp_miu4);
-    deriv[10] = dy0dy() * temp * temp_miu4 * lambda * const_1_p_2_C2_y2;
-    deriv[11] = dz0dz() * temp * lambda_y0 * (temp_dmiu4_dz + const_2_C2_z * temp_miu4);
+    deriv[9] = temp * lambda_y0 * (temp_dmiu4_dx + const_2_C2_x * temp_miu4);
+    deriv[10] = temp * temp_miu4 * lambda * const_1_p_2_C2_y2;
+    deriv[11] = temp * lambda_y0 * (temp_dmiu4_dz + const_2_C2_z * temp_miu4);
 
     // dmiu5 dx/dy/dz
-    deriv[12] = dx0dx() * temp * temp_miu5 * lambda * const_1_p_2_C2_x2;
-    deriv[13] = dy0dy() * temp * lambda_x0 * (temp_dmiu5_dy + const_2_C2_y * temp_miu5);
-    deriv[14] = dz0dz() * temp * lambda_x0 * (temp_dmiu5_dz + const_2_C2_z * temp_miu5);
+    deriv[12] = temp * temp_miu5 * lambda * const_1_p_2_C2_x2;
+    deriv[13] = temp * lambda_x0 * (temp_dmiu5_dy + const_2_C2_y * temp_miu5);
+    deriv[14] = temp * lambda_x0 * (temp_dmiu5_dz + const_2_C2_z * temp_miu5);
 
     // dmiu6 dx/dy/dz
-    deriv[15] = dx0dx() * temp * temp_miu6 * lambda * const_1_p_2_C2_x2;
-    deriv[16] = dy0dy() * temp * lambda_x0 * (temp_dmiu6_dy + const_2_C2_y * temp_miu6);
-    deriv[17] = dz0dz() * temp * lambda_x0 * (temp_dmiu6_dz + const_2_C2_z * temp_miu6);
+    deriv[15] = temp * temp_miu6 * lambda * const_1_p_2_C2_x2;
+    deriv[16] = temp * lambda_x0 * (temp_dmiu6_dy + const_2_C2_y * temp_miu6);
+    deriv[17] = temp * lambda_x0 * (temp_dmiu6_dz + const_2_C2_z * temp_miu6);
 
     value[0] = miu_8_6_1;
     value[1] = miu_8_6_2;
@@ -3554,19 +3543,19 @@ void calc_MCSH_8_7(double x0, double y0, double z0, double r0_sqr, double A, dou
     double const_2_C2_z = 2.0 * C2 * z0;
 
     // dmiu1 dx/dy/dz
-    deriv[0] = dx0dx() * temp * (temp_dmiu1_dx + const_2_C2_x * temp_miu1);
-    deriv[1] = dy0dy() * temp * (temp_dmiu1_dy + const_2_C2_y * temp_miu1);
-    deriv[2] = dz0dz() * miu_8_7_1 * const_2_C2_z;
+    deriv[0] = temp * (temp_dmiu1_dx + const_2_C2_x * temp_miu1);
+    deriv[1] = temp * (temp_dmiu1_dy + const_2_C2_y * temp_miu1);
+    deriv[2] = miu_8_7_1 * const_2_C2_z;
 
     // dmiu2 dx/dy/dz
-    deriv[3] = dx0dx() * temp * (temp_dmiu2_dx + const_2_C2_x * temp_miu2);
-    deriv[4] = dy0dy() * miu_8_7_2 * const_2_C2_y;
-    deriv[5] = dz0dz() * temp * (temp_dmiu2_dz + const_2_C2_z * temp_miu2);
+    deriv[3] = temp * (temp_dmiu2_dx + const_2_C2_x * temp_miu2);
+    deriv[4] = miu_8_7_2 * const_2_C2_y;
+    deriv[5] = temp * (temp_dmiu2_dz + const_2_C2_z * temp_miu2);
 
     // dmiu3 dx/dy/dz
-    deriv[6] = dx0dx() * miu_8_7_3 * const_2_C2_x;
-    deriv[7] = dy0dy() * temp * (temp_dmiu3_dy + const_2_C2_y * temp_miu3);
-    deriv[8] = dz0dz() * temp * (temp_dmiu3_dz + const_2_C2_z * temp_miu3);
+    deriv[6] = miu_8_7_3 * const_2_C2_x;
+    deriv[7] = temp * (temp_dmiu3_dy + const_2_C2_y * temp_miu3);
+    deriv[8] = temp * (temp_dmiu3_dz + const_2_C2_z * temp_miu3);
 
     value[0] = miu_8_7_1;
     value[1] = miu_8_7_2;
@@ -3691,34 +3680,34 @@ void calc_MCSH_8_8(double x0, double y0, double z0, double r0_sqr, double A, dou
     double const_1_p_2_C2_z2 = 1.0 + 2.0 * C2 * z0_sqr;
 
     // dmiu1 dx/dy/dz
-    deriv[0] = dx0dx() * temp * lambda_z0 * (temp_dmiu1_dx + const_2_C2_x * temp_miu1);
-    deriv[1] = dy0dy() * temp * lambda_z0 * (temp_dmiu1_dy + const_2_C2_y * temp_miu1);
-    deriv[2] = dz0dz() * temp * temp_miu1 * lambda * const_1_p_2_C2_z2;
+    deriv[0] = temp * lambda_z0 * (temp_dmiu1_dx + const_2_C2_x * temp_miu1);
+    deriv[1] = temp * lambda_z0 * (temp_dmiu1_dy + const_2_C2_y * temp_miu1);
+    deriv[2] = temp * temp_miu1 * lambda * const_1_p_2_C2_z2;
 
     // dmiu2 dx/dy/dz
-    deriv[3] = dx0dx() * temp * lambda_z0 * (temp_dmiu2_dx + const_2_C2_x * temp_miu2);
-    deriv[4] = dy0dy() * temp * lambda_z0 * (temp_dmiu2_dy + const_2_C2_y * temp_miu2);
-    deriv[5] = dz0dz() * temp * temp_miu2 * lambda * const_1_p_2_C2_z2;
+    deriv[3] = temp * lambda_z0 * (temp_dmiu2_dx + const_2_C2_x * temp_miu2);
+    deriv[4] = temp * lambda_z0 * (temp_dmiu2_dy + const_2_C2_y * temp_miu2);
+    deriv[5] = temp * temp_miu2 * lambda * const_1_p_2_C2_z2;
 
     // dmiu3 dx/dy/dz
-    deriv[6] = dx0dx() * temp * lambda_y0 * (temp_dmiu3_dx + const_2_C2_x * temp_miu3);
-    deriv[7] = dy0dy() * temp * temp_miu3 * lambda * const_1_p_2_C2_y2;
-    deriv[8] = dz0dz() * temp * lambda_y0 * (temp_dmiu3_dz + const_2_C2_z * temp_miu3);
+    deriv[6] = temp * lambda_y0 * (temp_dmiu3_dx + const_2_C2_x * temp_miu3);
+    deriv[7] = temp * temp_miu3 * lambda * const_1_p_2_C2_y2;
+    deriv[8] = temp * lambda_y0 * (temp_dmiu3_dz + const_2_C2_z * temp_miu3);
 
     // dmiu4 dx/dy/dz
-    deriv[9] = dx0dx() * temp * lambda_y0 * (temp_dmiu4_dx + const_2_C2_x * temp_miu4);
-    deriv[10] = dy0dy() * temp * temp_miu4 * lambda * const_1_p_2_C2_y2;
-    deriv[11] = dz0dz() * temp * lambda_y0 * (temp_dmiu4_dz + const_2_C2_z * temp_miu4);
+    deriv[9] = temp * lambda_y0 * (temp_dmiu4_dx + const_2_C2_x * temp_miu4);
+    deriv[10] = temp * temp_miu4 * lambda * const_1_p_2_C2_y2;
+    deriv[11] = temp * lambda_y0 * (temp_dmiu4_dz + const_2_C2_z * temp_miu4);
 
     // dmiu5 dx/dy/dz
-    deriv[12] = dx0dx() * temp * temp_miu5 * lambda * const_1_p_2_C2_x2;
-    deriv[13] = dy0dy() * temp * lambda_x0 * (temp_dmiu5_dy + const_2_C2_y * temp_miu5);
-    deriv[14] = dz0dz() * temp * lambda_x0 * (temp_dmiu5_dz + const_2_C2_z * temp_miu5);
+    deriv[12] = temp * temp_miu5 * lambda * const_1_p_2_C2_x2;
+    deriv[13] = temp * lambda_x0 * (temp_dmiu5_dy + const_2_C2_y * temp_miu5);
+    deriv[14] = temp * lambda_x0 * (temp_dmiu5_dz + const_2_C2_z * temp_miu5);
 
     // dmiu6 dx/dy/dz
-    deriv[15] = dx0dx() * temp * temp_miu6 * lambda * const_1_p_2_C2_x2;
-    deriv[16] = dy0dy() * temp * lambda_x0 * (temp_dmiu6_dy + const_2_C2_y * temp_miu6);
-    deriv[17] = dz0dz() * temp * lambda_x0 * (temp_dmiu6_dz + const_2_C2_z * temp_miu6);
+    deriv[15] = temp * temp_miu6 * lambda * const_1_p_2_C2_x2;
+    deriv[16] = temp * lambda_x0 * (temp_dmiu6_dy + const_2_C2_y * temp_miu6);
+    deriv[17] = temp * lambda_x0 * (temp_dmiu6_dz + const_2_C2_z * temp_miu6);
 
     value[0] = miu_8_8_1;
     value[1] = miu_8_8_2;
@@ -3826,19 +3815,19 @@ void calc_MCSH_8_9(double x0, double y0, double z0, double r0_sqr, double A, dou
     double const_2_C2_z = 2.0 * C2 * z0;
 
     // dmiu1 dx/dy/dz
-    deriv[0] = dx0dx() * temp * (temp_dmiu1_dx + const_2_C2_x * temp_miu1);
-    deriv[1] = dy0dy() * temp * (temp_dmiu1_dy + const_2_C2_y * temp_miu1);
-    deriv[2] = dz0dz() * temp * (temp_dmiu1_dz + const_2_C2_z * temp_miu1);
+    deriv[0] = temp * (temp_dmiu1_dx + const_2_C2_x * temp_miu1);
+    deriv[1] = temp * (temp_dmiu1_dy + const_2_C2_y * temp_miu1);
+    deriv[2] = temp * (temp_dmiu1_dz + const_2_C2_z * temp_miu1);
 
     // dmiu2 dx/dy/dz
-    deriv[3] = dx0dx() * temp * (temp_dmiu2_dx + const_2_C2_x * temp_miu2);
-    deriv[4] = dy0dy() * temp * (temp_dmiu2_dy + const_2_C2_y * temp_miu2);
-    deriv[5] = dz0dz() * temp * (temp_dmiu2_dz + const_2_C2_z * temp_miu2);
+    deriv[3] = temp * (temp_dmiu2_dx + const_2_C2_x * temp_miu2);
+    deriv[4] = temp * (temp_dmiu2_dy + const_2_C2_y * temp_miu2);
+    deriv[5] = temp * (temp_dmiu2_dz + const_2_C2_z * temp_miu2);
 
     // dmiu3 dx/dy/dz
-    deriv[6] = dx0dx() * temp * (temp_dmiu3_dx + const_2_C2_x * temp_miu3);
-    deriv[7] = dy0dy() * temp * (temp_dmiu3_dy + const_2_C2_y * temp_miu3);
-    deriv[8] = dz0dz() * temp * (temp_dmiu3_dz + const_2_C2_z * temp_miu3);
+    deriv[6] = temp * (temp_dmiu3_dx + const_2_C2_x * temp_miu3);
+    deriv[7] = temp * (temp_dmiu3_dy + const_2_C2_y * temp_miu3);
+    deriv[8] = temp * (temp_dmiu3_dz + const_2_C2_z * temp_miu3);
 
     value[0] = miu_8_9_1;
     value[1] = miu_8_9_2;
@@ -3948,19 +3937,19 @@ void calc_MCSH_8_10(double x0, double y0, double z0, double r0_sqr, double A, do
     double const_2_C2_z = 2.0 * C2 * z0;
 
     // dmiu1 dx/dy/dz
-    deriv[0] = dx0dx() * temp * (temp_dmiu1_dx + const_2_C2_x * temp_miu1);
-    deriv[1] = dy0dy() * temp * (temp_dmiu1_dy + const_2_C2_y * temp_miu1);
-    deriv[2] = dz0dz() * temp * (temp_dmiu1_dz + const_2_C2_z * temp_miu1);
+    deriv[0] = temp * (temp_dmiu1_dx + const_2_C2_x * temp_miu1);
+    deriv[1] = temp * (temp_dmiu1_dy + const_2_C2_y * temp_miu1);
+    deriv[2] = temp * (temp_dmiu1_dz + const_2_C2_z * temp_miu1);
 
     // dmiu2 dx/dy/dz
-    deriv[3] = dx0dx() * temp * (temp_dmiu2_dx + const_2_C2_x * temp_miu2);
-    deriv[4] = dy0dy() * temp * (temp_dmiu2_dy + const_2_C2_y * temp_miu2);
-    deriv[5] = dz0dz() * temp * (temp_dmiu2_dz + const_2_C2_z * temp_miu2);
+    deriv[3] = temp * (temp_dmiu2_dx + const_2_C2_x * temp_miu2);
+    deriv[4] = temp * (temp_dmiu2_dy + const_2_C2_y * temp_miu2);
+    deriv[5] = temp * (temp_dmiu2_dz + const_2_C2_z * temp_miu2);
 
     // dmiu3 dx/dy/dz
-    deriv[6] = dx0dx() * temp * (temp_dmiu3_dx + const_2_C2_x * temp_miu3);
-    deriv[7] = dy0dy() * temp * (temp_dmiu3_dy + const_2_C2_y * temp_miu3);
-    deriv[8] = dz0dz() * temp * (temp_dmiu3_dz + const_2_C2_z * temp_miu3);
+    deriv[6] = temp * (temp_dmiu3_dx + const_2_C2_x * temp_miu3);
+    deriv[7] = temp * (temp_dmiu3_dy + const_2_C2_y * temp_miu3);
+    deriv[8] = temp * (temp_dmiu3_dz + const_2_C2_z * temp_miu3);
 
     value[0] = miu_8_10_1;
     value[1] = miu_8_10_2;
@@ -4041,19 +4030,19 @@ void calc_MCSH_9_1(double x0, double y0, double z0, double r0_sqr, double A, dou
     double const_2_C2_z = 2.0 * C2 * z0;
 
     // dmiu1 dx/dy/dz
-    deriv[0] = dx0dx() * temp * (temp_dx + const_2_C2_x * temp_x);
-    deriv[1] = dy0dy() * miu_9_1_1 * const_2_C2_y;
-    deriv[2] = dz0dz() * miu_9_1_1 * const_2_C2_z;
+    deriv[0] = temp * (temp_dx + const_2_C2_x * temp_x);
+    deriv[1] = miu_9_1_1 * const_2_C2_y;
+    deriv[2] = miu_9_1_1 * const_2_C2_z;
 
     // dmiu2 dx/dy/dz
-    deriv[3] = dx0dx() * miu_9_1_2 * const_2_C2_x;
-    deriv[4] = dy0dy() * temp * (temp_dy + const_2_C2_y * temp_y);
-    deriv[5] = dz0dz() * miu_9_1_2 * const_2_C2_z;
+    deriv[3] = miu_9_1_2 * const_2_C2_x;
+    deriv[4] = temp * (temp_dy + const_2_C2_y * temp_y);
+    deriv[5] = miu_9_1_2 * const_2_C2_z;
 
     // dmiu3 dx/dy/dz
-    deriv[6] = dx0dx() * miu_9_1_3 * const_2_C2_x;
-    deriv[7] = dy0dy() * miu_9_1_3 * const_2_C2_y;
-    deriv[8] = dz0dz() * temp * (temp_dz + const_2_C2_z * temp_z);
+    deriv[6] = miu_9_1_3 * const_2_C2_x;
+    deriv[7] = miu_9_1_3 * const_2_C2_y;
+    deriv[8] = temp * (temp_dz + const_2_C2_z * temp_z);
 
     value[0] = miu_9_1_1;
     value[1] = miu_9_1_2;
@@ -4138,34 +4127,34 @@ void calc_MCSH_9_2(double x0, double y0, double z0, double r0_sqr, double A, dou
     double const_1_p_2_C2_z2 = 1.0 + 2.0 * C2 * z0_sqr;
 
     // dmiu1 dx/dy/dz
-    deriv[0] = dx0dx() * temp * lambda_y0 * (temp_dx + const_2_C2_x * temp_x);
-    deriv[1] = dy0dy() * temp * lambda * temp_x * const_1_p_2_C2_y2;
-    deriv[2] = dz0dz() * miu_9_2_1 * const_2_C2_z;
+    deriv[0] = temp * lambda_y0 * (temp_dx + const_2_C2_x * temp_x);
+    deriv[1] = temp * lambda * temp_x * const_1_p_2_C2_y2;
+    deriv[2] = miu_9_2_1 * const_2_C2_z;
 
     // dmiu2 dx/dy/dz
-    deriv[3] = dx0dx() * temp * lambda * temp_y * const_1_p_2_C2_x2;
-    deriv[4] = dy0dy() * temp * lambda_x0 * (temp_dy + const_2_C2_y * temp_y);
-    deriv[5] = dz0dz() * miu_9_2_2 * const_2_C2_z;
+    deriv[3] = temp * lambda * temp_y * const_1_p_2_C2_x2;
+    deriv[4] = temp * lambda_x0 * (temp_dy + const_2_C2_y * temp_y);
+    deriv[5] = miu_9_2_2 * const_2_C2_z;
 
     // dmiu3 dx/dy/dz
-    deriv[6] = dx0dx() * temp * lambda_z0 * (temp_dx + const_2_C2_x * temp_x);
-    deriv[7] = dy0dy() * miu_9_2_3 * const_2_C2_y;
-    deriv[8] = dz0dz() * temp * lambda * temp_x * const_1_p_2_C2_z2;
+    deriv[6] = temp * lambda_z0 * (temp_dx + const_2_C2_x * temp_x);
+    deriv[7] = miu_9_2_3 * const_2_C2_y;
+    deriv[8] = temp * lambda * temp_x * const_1_p_2_C2_z2;
 
     // dmiu4 dx/dy/dz
-    deriv[9] = dx0dx() * temp * lambda * temp_z * const_1_p_2_C2_x2;
-    deriv[10] = dy0dy() * miu_9_2_4 * const_2_C2_y;
-    deriv[11] = dz0dz() * temp * lambda_x0 * (temp_dz + const_2_C2_z * temp_z);
+    deriv[9] = temp * lambda * temp_z * const_1_p_2_C2_x2;
+    deriv[10] = miu_9_2_4 * const_2_C2_y;
+    deriv[11] = temp * lambda_x0 * (temp_dz + const_2_C2_z * temp_z);
 
     // dmiu5 dx/dy/dz
-    deriv[12] = dx0dx() * miu_9_2_5 * const_2_C2_x;
-    deriv[13] = dy0dy() * temp * lambda_z0 * (temp_dy + const_2_C2_y * temp_y);
-    deriv[14] = dz0dz() * temp * lambda * temp_y * const_1_p_2_C2_z2;
+    deriv[12] = miu_9_2_5 * const_2_C2_x;
+    deriv[13] = temp * lambda_z0 * (temp_dy + const_2_C2_y * temp_y);
+    deriv[14] = temp * lambda * temp_y * const_1_p_2_C2_z2;
 
     // dmiu6 dx/dy/dz
-    deriv[15] = dx0dx() * miu_9_2_6 * const_2_C2_x;
-    deriv[16] = dy0dy() * temp * lambda * temp_z * const_1_p_2_C2_y2;
-    deriv[17] = dz0dz() * temp * lambda_y0 * (temp_dz + const_2_C2_z * temp_z);
+    deriv[15] = miu_9_2_6 * const_2_C2_x;
+    deriv[16] = temp * lambda * temp_z * const_1_p_2_C2_y2;
+    deriv[17] = temp * lambda_y0 * (temp_dz + const_2_C2_z * temp_z);
 
     value[0] = miu_9_2_1;
     value[1] = miu_9_2_2;
@@ -4306,34 +4295,34 @@ void calc_MCSH_9_3(double x0, double y0, double z0, double r0_sqr, double A, dou
     double const_2_C2_z = 2.0 * C2 * z0;
 
     // dmiu1 dx/dy/dz
-    deriv[0] = dx0dx() * temp * (temp_dmiu1_dx + const_2_C2_x * temp_miu1);
-    deriv[1] = dy0dy() * temp * (temp_dmiu1_dy + const_2_C2_y * temp_miu1);
-    deriv[2] = dz0dz() * miu_9_3_1 * const_2_C2_z;
+    deriv[0] = temp * (temp_dmiu1_dx + const_2_C2_x * temp_miu1);
+    deriv[1] = temp * (temp_dmiu1_dy + const_2_C2_y * temp_miu1);
+    deriv[2] = miu_9_3_1 * const_2_C2_z;
 
     // dmiu2 dx/dy/dz
-    deriv[3] = dx0dx() * temp * (temp_dmiu2_dx + const_2_C2_x * temp_miu2);
-    deriv[4] = dy0dy() * temp * (temp_dmiu2_dy + const_2_C2_y * temp_miu2);
-    deriv[5] = dz0dz() * miu_9_3_2 * const_2_C2_z;
+    deriv[3] = temp * (temp_dmiu2_dx + const_2_C2_x * temp_miu2);
+    deriv[4] = temp * (temp_dmiu2_dy + const_2_C2_y * temp_miu2);
+    deriv[5] = miu_9_3_2 * const_2_C2_z;
 
     // dmiu3 dx/dy/dz
-    deriv[6] = dx0dx() * temp * (temp_dmiu3_dx + const_2_C2_x * temp_miu3);
-    deriv[7] = dy0dy() * miu_9_3_3 * const_2_C2_y;
-    deriv[8] = dz0dz() * temp * (temp_dmiu3_dz + const_2_C2_z * temp_miu3);
+    deriv[6] = temp * (temp_dmiu3_dx + const_2_C2_x * temp_miu3);
+    deriv[7] = miu_9_3_3 * const_2_C2_y;
+    deriv[8] = temp * (temp_dmiu3_dz + const_2_C2_z * temp_miu3);
 
     // dmiu4 dx/dy/dz
-    deriv[9] = dx0dx() * temp * (temp_dmiu4_dx + const_2_C2_x * temp_miu4);
-    deriv[10] = dy0dy() * miu_9_3_4 * const_2_C2_y;
-    deriv[11] = dz0dz() * temp * (temp_dmiu4_dz + const_2_C2_z * temp_miu4);
+    deriv[9] = temp * (temp_dmiu4_dx + const_2_C2_x * temp_miu4);
+    deriv[10] = miu_9_3_4 * const_2_C2_y;
+    deriv[11] = temp * (temp_dmiu4_dz + const_2_C2_z * temp_miu4);
 
     // dmiu5 dx/dy/dz
-    deriv[12] = dx0dx() * miu_9_3_5 * const_2_C2_x;
-    deriv[13] = dy0dy() * temp * (temp_dmiu5_dy + const_2_C2_y * temp_miu5);
-    deriv[14] = dz0dz() * temp * (temp_dmiu5_dz + const_2_C2_z * temp_miu5);
+    deriv[12] = miu_9_3_5 * const_2_C2_x;
+    deriv[13] = temp * (temp_dmiu5_dy + const_2_C2_y * temp_miu5);
+    deriv[14] = temp * (temp_dmiu5_dz + const_2_C2_z * temp_miu5);
 
     // dmiu6 dx/dy/dz
-    deriv[15] = dx0dx() * miu_9_3_6 * const_2_C2_x;
-    deriv[16] = dy0dy() * temp * (temp_dmiu6_dy + const_2_C2_y * temp_miu6);
-    deriv[17] = dz0dz() * temp * (temp_dmiu6_dz + const_2_C2_z * temp_miu6);
+    deriv[15] = miu_9_3_6 * const_2_C2_x;
+    deriv[16] = temp * (temp_dmiu6_dy + const_2_C2_y * temp_miu6);
+    deriv[17] = temp * (temp_dmiu6_dz + const_2_C2_z * temp_miu6);
 
     value[0] = miu_9_3_1;
     value[1] = miu_9_3_2;
@@ -4412,19 +4401,19 @@ void calc_MCSH_9_4(double x0, double y0, double z0, double r0_sqr, double A, dou
     double const_1_p_2_C2_z2 = 1.0 + 2.0 * C2 * z0_sqr;
 
     // dmiu1 dx/dy/dz
-    deriv[0] = dx0dx() * temp * lambda_y0 * lambda_z0 * (temp_dx + const_2_C2_x * temp_x);
-    deriv[1] = dy0dy() * temp * lambda_z0 * temp_x * lambda * const_1_p_2_C2_y2;
-    deriv[2] = dz0dz() * temp * lambda_y0 * temp_x * lambda * const_1_p_2_C2_z2;
+    deriv[0] = temp * lambda_y0 * lambda_z0 * (temp_dx + const_2_C2_x * temp_x);
+    deriv[1] = temp * lambda_z0 * temp_x * lambda * const_1_p_2_C2_y2;
+    deriv[2] = temp * lambda_y0 * temp_x * lambda * const_1_p_2_C2_z2;
 
     // dmiu2 dx/dy/dz
-    deriv[3] = dx0dx() * temp * lambda_z0 * temp_y * lambda * const_1_p_2_C2_x2;
-    deriv[4] = dy0dy() * temp * lambda_x0 * lambda_z0 * (temp_dy + const_2_C2_y * temp_y);
-    deriv[5] = dz0dz() * temp * lambda_x0 * temp_y * lambda * const_1_p_2_C2_z2;
+    deriv[3] = temp * lambda_z0 * temp_y * lambda * const_1_p_2_C2_x2;
+    deriv[4] = temp * lambda_x0 * lambda_z0 * (temp_dy + const_2_C2_y * temp_y);
+    deriv[5] = temp * lambda_x0 * temp_y * lambda * const_1_p_2_C2_z2;
 
     // dmiu3 dx/dy/dz
-    deriv[6] = dx0dx() * temp * lambda_y0 * temp_z * lambda * const_1_p_2_C2_x2;
-    deriv[7] = dy0dy() * temp * lambda_x0 * temp_z * lambda * const_1_p_2_C2_y2;
-    deriv[8] = dz0dz() * temp * lambda_x0 * lambda_y0 * (temp_dz + const_2_C2_z * temp_z);
+    deriv[6] = temp * lambda_y0 * temp_z * lambda * const_1_p_2_C2_x2;
+    deriv[7] = temp * lambda_x0 * temp_z * lambda * const_1_p_2_C2_y2;
+    deriv[8] = temp * lambda_x0 * lambda_y0 * (temp_dz + const_2_C2_z * temp_z);
 
     value[0] = miu_9_4_1;
     value[1] = miu_9_4_2;
@@ -4559,34 +4548,34 @@ void calc_MCSH_9_5(double x0, double y0, double z0, double r0_sqr, double A, dou
     double const_2_C2_z = 2.0 * C2 * z0;
 
     // dmiu1 dx/dy/dz
-    deriv[0] = dx0dx() * temp * (temp_dmiu1_dx + const_2_C2_x * temp_miu1);
-    deriv[1] = dy0dy() * temp * (temp_dmiu1_dy + const_2_C2_y * temp_miu1);
-    deriv[2] = dz0dz() * miu_9_5_1 * const_2_C2_z;
+    deriv[0] = temp * (temp_dmiu1_dx + const_2_C2_x * temp_miu1);
+    deriv[1] = temp * (temp_dmiu1_dy + const_2_C2_y * temp_miu1);
+    deriv[2] = miu_9_5_1 * const_2_C2_z;
 
     // dmiu2 dx/dy/dz
-    deriv[3] = dx0dx() * temp * (temp_dmiu2_dx + const_2_C2_x * temp_miu2);
-    deriv[4] = dy0dy() * temp * (temp_dmiu2_dy + const_2_C2_y * temp_miu2);
-    deriv[5] = dz0dz() * miu_9_5_2 * const_2_C2_z;
+    deriv[3] = temp * (temp_dmiu2_dx + const_2_C2_x * temp_miu2);
+    deriv[4] = temp * (temp_dmiu2_dy + const_2_C2_y * temp_miu2);
+    deriv[5] = miu_9_5_2 * const_2_C2_z;
 
     // dmiu3 dx/dy/dz
-    deriv[6] = dx0dx() * temp * (temp_dmiu3_dx + const_2_C2_x * temp_miu3);
-    deriv[7] = dy0dy() * miu_9_5_3 * const_2_C2_y;
-    deriv[8] = dz0dz() * temp * (temp_dmiu3_dz + const_2_C2_z * temp_miu3);
+    deriv[6] = temp * (temp_dmiu3_dx + const_2_C2_x * temp_miu3);
+    deriv[7] = miu_9_5_3 * const_2_C2_y;
+    deriv[8] = temp * (temp_dmiu3_dz + const_2_C2_z * temp_miu3);
 
     // dmiu4 dx/dy/dz
-    deriv[9] = dx0dx() * temp * (temp_dmiu4_dx + const_2_C2_x * temp_miu4);
-    deriv[10] = dy0dy() * miu_9_5_4 * const_2_C2_y;
-    deriv[11] = dz0dz() * temp * (temp_dmiu4_dz + const_2_C2_z * temp_miu4);
+    deriv[9] = temp * (temp_dmiu4_dx + const_2_C2_x * temp_miu4);
+    deriv[10] = miu_9_5_4 * const_2_C2_y;
+    deriv[11] = temp * (temp_dmiu4_dz + const_2_C2_z * temp_miu4);
 
     // dmiu5 dx/dy/dz
-    deriv[12] = dx0dx() * miu_9_5_5 * const_2_C2_x;
-    deriv[13] = dy0dy() * temp * (temp_dmiu5_dy + const_2_C2_y * temp_miu5);
-    deriv[14] = dz0dz() * temp * (temp_dmiu5_dz + const_2_C2_z * temp_miu5);
+    deriv[12] = miu_9_5_5 * const_2_C2_x;
+    deriv[13] = temp * (temp_dmiu5_dy + const_2_C2_y * temp_miu5);
+    deriv[14] = temp * (temp_dmiu5_dz + const_2_C2_z * temp_miu5);
 
     // dmiu6 dx/dy/dz
-    deriv[15] = dx0dx() * miu_9_5_6 * const_2_C2_x;
-    deriv[16] = dy0dy() * temp * (temp_dmiu6_dy + const_2_C2_y * temp_miu6);
-    deriv[17] = dz0dz() * temp * (temp_dmiu6_dz + const_2_C2_z * temp_miu6);
+    deriv[15] = miu_9_5_6 * const_2_C2_x;
+    deriv[16] = temp * (temp_dmiu6_dy + const_2_C2_y * temp_miu6);
+    deriv[17] = temp * (temp_dmiu6_dz + const_2_C2_z * temp_miu6);
 
     value[0] = miu_9_5_1;
     value[1] = miu_9_5_2;
@@ -4722,34 +4711,34 @@ void calc_MCSH_9_6(double x0, double y0, double z0, double r0_sqr, double A, dou
     double const_1_p_2_C2_z2 = 1.0 + 2.0 * C2 * z0_sqr;
 
     // dmiu1 dx/dy/dz
-    deriv[0] = dx0dx() * temp * lambda_z0 * (temp_dmiu1_dx + const_2_C2_x * temp_miu1);
-    deriv[1] = dy0dy() * temp * lambda_z0 * (temp_dmiu1_dy + const_2_C2_y * temp_miu1);
-    deriv[2] = dz0dz() * temp * temp_miu1 * lambda * const_1_p_2_C2_z2;
+    deriv[0] = temp * lambda_z0 * (temp_dmiu1_dx + const_2_C2_x * temp_miu1);
+    deriv[1] = temp * lambda_z0 * (temp_dmiu1_dy + const_2_C2_y * temp_miu1);
+    deriv[2] = temp * temp_miu1 * lambda * const_1_p_2_C2_z2;
 
     // dmiu2 dx/dy/dz
-    deriv[3] = dx0dx() * temp * lambda_z0 * (temp_dmiu2_dx + const_2_C2_x * temp_miu2);
-    deriv[4] = dy0dy() * temp * lambda_z0 * (temp_dmiu2_dy + const_2_C2_y * temp_miu2);
-    deriv[5] = dz0dz() * temp * temp_miu2 * lambda * const_1_p_2_C2_z2;
+    deriv[3] = temp * lambda_z0 * (temp_dmiu2_dx + const_2_C2_x * temp_miu2);
+    deriv[4] = temp * lambda_z0 * (temp_dmiu2_dy + const_2_C2_y * temp_miu2);
+    deriv[5] = temp * temp_miu2 * lambda * const_1_p_2_C2_z2;
 
     // dmiu3 dx/dy/dz
-    deriv[6] = dx0dx() * temp * lambda_y0 * (temp_dmiu3_dx + const_2_C2_x * temp_miu3);
-    deriv[7] = dy0dy() * temp * temp_miu3 * lambda * const_1_p_2_C2_y2;
-    deriv[8] = dz0dz() * temp * lambda_y0 * (temp_dmiu3_dz + const_2_C2_z * temp_miu3);
+    deriv[6] = temp * lambda_y0 * (temp_dmiu3_dx + const_2_C2_x * temp_miu3);
+    deriv[7] = temp * temp_miu3 * lambda * const_1_p_2_C2_y2;
+    deriv[8] = temp * lambda_y0 * (temp_dmiu3_dz + const_2_C2_z * temp_miu3);
 
     // dmiu4 dx/dy/dz
-    deriv[9] = dx0dx() * temp * lambda_y0 * (temp_dmiu4_dx + const_2_C2_x * temp_miu4);
-    deriv[10] = dy0dy() * temp * temp_miu4 * lambda * const_1_p_2_C2_y2;
-    deriv[11] = dz0dz() * temp * lambda_y0 * (temp_dmiu4_dz + const_2_C2_z * temp_miu4);
+    deriv[9] = temp * lambda_y0 * (temp_dmiu4_dx + const_2_C2_x * temp_miu4);
+    deriv[10] = temp * temp_miu4 * lambda * const_1_p_2_C2_y2;
+    deriv[11] = temp * lambda_y0 * (temp_dmiu4_dz + const_2_C2_z * temp_miu4);
 
     // dmiu5 dx/dy/dz
-    deriv[12] = dx0dx() * temp * temp_miu5 * lambda * const_1_p_2_C2_x2;
-    deriv[13] = dy0dy() * temp * lambda_x0 * (temp_dmiu5_dy + const_2_C2_y * temp_miu5);
-    deriv[14] = dz0dz() * temp * lambda_x0 * (temp_dmiu5_dz + const_2_C2_z * temp_miu5);
+    deriv[12] = temp * temp_miu5 * lambda * const_1_p_2_C2_x2;
+    deriv[13] = temp * lambda_x0 * (temp_dmiu5_dy + const_2_C2_y * temp_miu5);
+    deriv[14] = temp * lambda_x0 * (temp_dmiu5_dz + const_2_C2_z * temp_miu5);
 
     // dmiu6 dx/dy/dz
-    deriv[15] = dx0dx() * temp * temp_miu6 * lambda * const_1_p_2_C2_x2;
-    deriv[16] = dy0dy() * temp * lambda_x0 * (temp_dmiu6_dy + const_2_C2_y * temp_miu6);
-    deriv[17] = dz0dz() * temp * lambda_x0 * (temp_dmiu6_dz + const_2_C2_z * temp_miu6);
+    deriv[15] = temp * temp_miu6 * lambda * const_1_p_2_C2_x2;
+    deriv[16] = temp * lambda_x0 * (temp_dmiu6_dy + const_2_C2_y * temp_miu6);
+    deriv[17] = temp * lambda_x0 * (temp_dmiu6_dz + const_2_C2_z * temp_miu6);
 
     value[0] = miu_9_6_1;
     value[1] = miu_9_6_2;
@@ -4893,34 +4882,34 @@ void calc_MCSH_9_7(double x0, double y0, double z0, double r0_sqr, double A, dou
     double const_2_C2_z = 2.0 * C2 * z0;
 
     // dmiu1 dx/dy/dz
-    deriv[0] = dx0dx() * temp * (temp_dmiu1_dx + const_2_C2_x * temp_miu1);
-    deriv[1] = dy0dy() * temp * (temp_dmiu1_dy + const_2_C2_y * temp_miu1);
-    deriv[2] = dz0dz() * miu_9_7_1 * const_2_C2_z;
+    deriv[0] = temp * (temp_dmiu1_dx + const_2_C2_x * temp_miu1);
+    deriv[1] = temp * (temp_dmiu1_dy + const_2_C2_y * temp_miu1);
+    deriv[2] = miu_9_7_1 * const_2_C2_z;
 
     // dmiu2 dx/dy/dz
-    deriv[3] = dx0dx() * temp * (temp_dmiu2_dx + const_2_C2_x * temp_miu2);
-    deriv[4] = dy0dy() * temp * (temp_dmiu2_dy + const_2_C2_y * temp_miu2);
-    deriv[5] = dz0dz() * miu_9_7_2 * const_2_C2_z;
+    deriv[3] = temp * (temp_dmiu2_dx + const_2_C2_x * temp_miu2);
+    deriv[4] = temp * (temp_dmiu2_dy + const_2_C2_y * temp_miu2);
+    deriv[5] = miu_9_7_2 * const_2_C2_z;
 
     // dmiu3 dx/dy/dz
-    deriv[6] = dx0dx() * temp * (temp_dmiu3_dx + const_2_C2_x * temp_miu3);
-    deriv[7] = dy0dy() * miu_9_7_3 * const_2_C2_y;
-    deriv[8] = dz0dz() * temp * (temp_dmiu3_dz + const_2_C2_z * temp_miu3);
+    deriv[6] = temp * (temp_dmiu3_dx + const_2_C2_x * temp_miu3);
+    deriv[7] = miu_9_7_3 * const_2_C2_y;
+    deriv[8] = temp * (temp_dmiu3_dz + const_2_C2_z * temp_miu3);
 
     // dmiu4 dx/dy/dz
-    deriv[9] = dx0dx() * temp * (temp_dmiu4_dx + const_2_C2_x * temp_miu4);
-    deriv[10] = dy0dy() * miu_9_7_4 * const_2_C2_y;
-    deriv[11] = dz0dz() * temp * (temp_dmiu4_dz + const_2_C2_z * temp_miu4);
+    deriv[9] = temp * (temp_dmiu4_dx + const_2_C2_x * temp_miu4);
+    deriv[10] = miu_9_7_4 * const_2_C2_y;
+    deriv[11] = temp * (temp_dmiu4_dz + const_2_C2_z * temp_miu4);
 
     // dmiu5 dx/dy/dz
-    deriv[12] = dx0dx() * miu_9_7_5 * const_2_C2_x;
-    deriv[13] = dy0dy() * temp * (temp_dmiu5_dy + const_2_C2_y * temp_miu5);
-    deriv[14] = dz0dz() * temp * (temp_dmiu5_dz + const_2_C2_z * temp_miu5);
+    deriv[12] = miu_9_7_5 * const_2_C2_x;
+    deriv[13] = temp * (temp_dmiu5_dy + const_2_C2_y * temp_miu5);
+    deriv[14] = temp * (temp_dmiu5_dz + const_2_C2_z * temp_miu5);
 
     // dmiu6 dx/dy/dz
-    deriv[15] = dx0dx() * miu_9_7_6 * const_2_C2_x;
-    deriv[16] = dy0dy() * temp * (temp_dmiu6_dy + const_2_C2_y * temp_miu6);
-    deriv[17] = dz0dz() * temp * (temp_dmiu6_dz + const_2_C2_z * temp_miu6);
+    deriv[15] = miu_9_7_6 * const_2_C2_x;
+    deriv[16] = temp * (temp_dmiu6_dy + const_2_C2_y * temp_miu6);
+    deriv[17] = temp * (temp_dmiu6_dz + const_2_C2_z * temp_miu6);
 
     value[0] = miu_9_7_1;
     value[1] = miu_9_7_2;
@@ -5044,34 +5033,34 @@ void calc_MCSH_9_8(double x0, double y0, double z0, double r0_sqr, double A, dou
     double const_1_p_2_C2_z2 = 1.0 + 2.0 * C2 * z0_sqr;
 
     // dmiu1 dx/dy/dz
-    deriv[0] = dx0dx() * temp * lambda_z0 * (temp_dmiu1_dx + const_2_C2_x * temp_miu1);
-    deriv[1] = dy0dy() * temp * lambda_z0 * (temp_dmiu1_dy + const_2_C2_y * temp_miu1);
-    deriv[2] = dz0dz() * temp * temp_miu1 * lambda * const_1_p_2_C2_z2;
+    deriv[0] = temp * lambda_z0 * (temp_dmiu1_dx + const_2_C2_x * temp_miu1);
+    deriv[1] = temp * lambda_z0 * (temp_dmiu1_dy + const_2_C2_y * temp_miu1);
+    deriv[2] = temp * temp_miu1 * lambda * const_1_p_2_C2_z2;
 
     // dmiu2 dx/dy/dz
-    deriv[3] = dx0dx() * temp * lambda_z0 * (temp_dmiu2_dx + const_2_C2_x * temp_miu2);
-    deriv[4] = dy0dy() * temp * lambda_z0 * (temp_dmiu2_dy + const_2_C2_y * temp_miu2);
-    deriv[5] = dz0dz() * temp * temp_miu2 * lambda * const_1_p_2_C2_z2;
+    deriv[3] = temp * lambda_z0 * (temp_dmiu2_dx + const_2_C2_x * temp_miu2);
+    deriv[4] = temp * lambda_z0 * (temp_dmiu2_dy + const_2_C2_y * temp_miu2);
+    deriv[5] = temp * temp_miu2 * lambda * const_1_p_2_C2_z2;
 
     // dmiu3 dx/dy/dz
-    deriv[6] = dx0dx() * temp * lambda_y0 * (temp_dmiu3_dx + const_2_C2_x * temp_miu3);
-    deriv[7] = dy0dy() * temp * temp_miu3 * lambda * const_1_p_2_C2_y2;
-    deriv[8] = dz0dz() * temp * lambda_y0 * (temp_dmiu3_dz + const_2_C2_z * temp_miu3);
+    deriv[6] = temp * lambda_y0 * (temp_dmiu3_dx + const_2_C2_x * temp_miu3);
+    deriv[7] = temp * temp_miu3 * lambda * const_1_p_2_C2_y2;
+    deriv[8] = temp * lambda_y0 * (temp_dmiu3_dz + const_2_C2_z * temp_miu3);
 
     // dmiu4 dx/dy/dz
-    deriv[9] = dx0dx() * temp * lambda_y0 * (temp_dmiu4_dx + const_2_C2_x * temp_miu4);
-    deriv[10] = dy0dy() * temp * temp_miu4 * lambda * const_1_p_2_C2_y2;
-    deriv[11] = dz0dz() * temp * lambda_y0 * (temp_dmiu4_dz + const_2_C2_z * temp_miu4);
+    deriv[9] = temp * lambda_y0 * (temp_dmiu4_dx + const_2_C2_x * temp_miu4);
+    deriv[10] = temp * temp_miu4 * lambda * const_1_p_2_C2_y2;
+    deriv[11] = temp * lambda_y0 * (temp_dmiu4_dz + const_2_C2_z * temp_miu4);
 
     // dmiu5 dx/dy/dz
-    deriv[12] = dx0dx() * temp * temp_miu5 * lambda * const_1_p_2_C2_x2;
-    deriv[13] = dy0dy() * temp * lambda_x0 * (temp_dmiu5_dy + const_2_C2_y * temp_miu5);
-    deriv[14] = dz0dz() * temp * lambda_x0 * (temp_dmiu5_dz + const_2_C2_z * temp_miu5);
+    deriv[12] = temp * temp_miu5 * lambda * const_1_p_2_C2_x2;
+    deriv[13] = temp * lambda_x0 * (temp_dmiu5_dy + const_2_C2_y * temp_miu5);
+    deriv[14] = temp * lambda_x0 * (temp_dmiu5_dz + const_2_C2_z * temp_miu5);
 
     // dmiu6 dx/dy/dz
-    deriv[15] = dx0dx() * temp * temp_miu6 * lambda * const_1_p_2_C2_x2;
-    deriv[16] = dy0dy() * temp * lambda_x0 * (temp_dmiu6_dy + const_2_C2_y * temp_miu6);
-    deriv[17] = dz0dz() * temp * lambda_x0 * (temp_dmiu6_dz + const_2_C2_z * temp_miu6);
+    deriv[15] = temp * temp_miu6 * lambda * const_1_p_2_C2_x2;
+    deriv[16] = temp * lambda_x0 * (temp_dmiu6_dy + const_2_C2_y * temp_miu6);
+    deriv[17] = temp * lambda_x0 * (temp_dmiu6_dz + const_2_C2_z * temp_miu6);
 
     value[0] = miu_9_8_1;
     value[1] = miu_9_8_2;
@@ -5192,19 +5181,19 @@ void calc_MCSH_9_9(double x0, double y0, double z0, double r0_sqr, double A, dou
     double const_2_C2_z = 2.0 * C2 * z0;
 
     // dmiu1 dx/dy/dz
-    deriv[0] = dx0dx() * temp * (temp_dmiu1_dx + const_2_C2_x * temp_miu1);
-    deriv[1] = dy0dy() * temp * (temp_dmiu1_dy + const_2_C2_y * temp_miu1);
-    deriv[2] = dz0dz() * temp * (temp_dmiu1_dz + const_2_C2_z * temp_miu1);
+    deriv[0] = temp * (temp_dmiu1_dx + const_2_C2_x * temp_miu1);
+    deriv[1] = temp * (temp_dmiu1_dy + const_2_C2_y * temp_miu1);
+    deriv[2] = temp * (temp_dmiu1_dz + const_2_C2_z * temp_miu1);
 
     // dmiu2 dx/dy/dz
-    deriv[3] = dx0dx() * temp * (temp_dmiu2_dx + const_2_C2_x * temp_miu2);
-    deriv[4] = dy0dy() * temp * (temp_dmiu2_dy + const_2_C2_y * temp_miu2);
-    deriv[5] = dz0dz() * temp * (temp_dmiu2_dz + const_2_C2_z * temp_miu2);
+    deriv[3] = temp * (temp_dmiu2_dx + const_2_C2_x * temp_miu2);
+    deriv[4] = temp * (temp_dmiu2_dy + const_2_C2_y * temp_miu2);
+    deriv[5] = temp * (temp_dmiu2_dz + const_2_C2_z * temp_miu2);
 
     // dmiu3 dx/dy/dz
-    deriv[6] = dx0dx() * temp * (temp_dmiu3_dx + const_2_C2_x * temp_miu3);
-    deriv[7] = dy0dy() * temp * (temp_dmiu3_dy + const_2_C2_y * temp_miu3);
-    deriv[8] = dz0dz() * temp * (temp_dmiu3_dz + const_2_C2_z * temp_miu3);
+    deriv[6] = temp * (temp_dmiu3_dx + const_2_C2_x * temp_miu3);
+    deriv[7] = temp * (temp_dmiu3_dy + const_2_C2_y * temp_miu3);
+    deriv[8] = temp * (temp_dmiu3_dz + const_2_C2_z * temp_miu3);
 
     value[0] = miu_9_9_1;
     value[1] = miu_9_9_2;
@@ -5310,19 +5299,19 @@ void calc_MCSH_9_10(double x0, double y0, double z0, double r0_sqr, double A, do
     double const_1_p_2_C2_z2 = 1.0 + 2.0 * C2 * z0_sqr;
 
     // dmiu1 dx/dy/dz
-    deriv[0] = dx0dx() * temp * lambda_z0 * (temp_dmiu1_dx + const_2_C2_x * temp_miu1);
-    deriv[1] = dy0dy() * temp * lambda_z0 * (temp_dmiu1_dy + const_2_C2_y * temp_miu1);
-    deriv[2] = dz0dz() * temp * temp_miu1 * lambda * const_1_p_2_C2_z2;
+    deriv[0] = temp * lambda_z0 * (temp_dmiu1_dx + const_2_C2_x * temp_miu1);
+    deriv[1] = temp * lambda_z0 * (temp_dmiu1_dy + const_2_C2_y * temp_miu1);
+    deriv[2] = temp * temp_miu1 * lambda * const_1_p_2_C2_z2;
 
     // dmiu3 dx/dy/dz
-    deriv[3] = dx0dx() * temp * lambda_y0 * (temp_dmiu2_dx + const_2_C2_x * temp_miu2);
-    deriv[4] = dy0dy() * temp * temp_miu2 * lambda * const_1_p_2_C2_y2;
-    deriv[5] = dz0dz() * temp * lambda_y0 * (temp_dmiu2_dz + const_2_C2_z * temp_miu2);
+    deriv[3] = temp * lambda_y0 * (temp_dmiu2_dx + const_2_C2_x * temp_miu2);
+    deriv[4] = temp * temp_miu2 * lambda * const_1_p_2_C2_y2;
+    deriv[5] = temp * lambda_y0 * (temp_dmiu2_dz + const_2_C2_z * temp_miu2);
 
     // dmiu5 dx/dy/dz
-    deriv[6] = dx0dx() * temp * temp_miu3 * lambda * const_1_p_2_C2_x2;
-    deriv[7] = dy0dy() * temp * lambda_x0 * (temp_dmiu3_dy + const_2_C2_y * temp_miu3);
-    deriv[8] = dz0dz() * temp * lambda_x0 * (temp_dmiu3_dz + const_2_C2_z * temp_miu3);
+    deriv[6] = temp * temp_miu3 * lambda * const_1_p_2_C2_x2;
+    deriv[7] = temp * lambda_x0 * (temp_dmiu3_dy + const_2_C2_y * temp_miu3);
+    deriv[8] = temp * lambda_x0 * (temp_dmiu3_dz + const_2_C2_z * temp_miu3);
 
     value[0] = miu_9_10_1;
     value[1] = miu_9_10_2;
@@ -5465,34 +5454,34 @@ void calc_MCSH_9_11(double x0, double y0, double z0, double r0_sqr, double A, do
     double const_2_C2_z = 2.0 * C2 * z0;
 
     // dmiu1 dx/dy/dz
-    deriv[0] = dx0dx() * temp * (temp_dmiu1_dx + const_2_C2_x * temp_miu1);
-    deriv[1] = dy0dy() * temp * (temp_dmiu1_dy + const_2_C2_y * temp_miu1);
-    deriv[2] = dz0dz() * temp * (temp_dmiu1_dz + const_2_C2_z * temp_miu1);
+    deriv[0] = temp * (temp_dmiu1_dx + const_2_C2_x * temp_miu1);
+    deriv[1] = temp * (temp_dmiu1_dy + const_2_C2_y * temp_miu1);
+    deriv[2] = temp * (temp_dmiu1_dz + const_2_C2_z * temp_miu1);
 
     // dmiu2 dx/dy/dz
-    deriv[3] = dx0dx() * temp * (temp_dmiu2_dx + const_2_C2_x * temp_miu2);
-    deriv[4] = dy0dy() * temp * (temp_dmiu2_dy + const_2_C2_y * temp_miu2);
-    deriv[5] = dz0dz() * temp * (temp_dmiu2_dz + const_2_C2_z * temp_miu2);
+    deriv[3] = temp * (temp_dmiu2_dx + const_2_C2_x * temp_miu2);
+    deriv[4] = temp * (temp_dmiu2_dy + const_2_C2_y * temp_miu2);
+    deriv[5] = temp * (temp_dmiu2_dz + const_2_C2_z * temp_miu2);
 
     // dmiu3 dx/dy/dz
-    deriv[6] = dx0dx() * temp * (temp_dmiu3_dx + const_2_C2_x * temp_miu3);
-    deriv[7] = dy0dy() * temp * (temp_dmiu3_dy + const_2_C2_y * temp_miu3);
-    deriv[8] = dz0dz() * temp * (temp_dmiu3_dz + const_2_C2_z * temp_miu3);
+    deriv[6] = temp * (temp_dmiu3_dx + const_2_C2_x * temp_miu3);
+    deriv[7] = temp * (temp_dmiu3_dy + const_2_C2_y * temp_miu3);
+    deriv[8] = temp * (temp_dmiu3_dz + const_2_C2_z * temp_miu3);
 
     // dmiu4 dx/dy/dz
-    deriv[9] = dx0dx() * temp * (temp_dmiu4_dx + const_2_C2_x * temp_miu4);
-    deriv[10] = dy0dy() * temp * (temp_dmiu4_dy + const_2_C2_y * temp_miu4);
-    deriv[11] = dz0dz() * temp * (temp_dmiu4_dz + const_2_C2_z * temp_miu4);
+    deriv[9] = temp * (temp_dmiu4_dx + const_2_C2_x * temp_miu4);
+    deriv[10] = temp * (temp_dmiu4_dy + const_2_C2_y * temp_miu4);
+    deriv[11] = temp * (temp_dmiu4_dz + const_2_C2_z * temp_miu4);
 
     // dmiu5 dx/dy/dz
-    deriv[12] = dx0dx() * temp * (temp_dmiu5_dx + const_2_C2_x * temp_miu5);
-    deriv[13] = dy0dy() * temp * (temp_dmiu5_dy + const_2_C2_y * temp_miu5);
-    deriv[14] = dz0dz() * temp * (temp_dmiu5_dz + const_2_C2_z * temp_miu5);
+    deriv[12] = temp * (temp_dmiu5_dx + const_2_C2_x * temp_miu5);
+    deriv[13] = temp * (temp_dmiu5_dy + const_2_C2_y * temp_miu5);
+    deriv[14] = temp * (temp_dmiu5_dz + const_2_C2_z * temp_miu5);
 
     // dmiu6 dx/dy/dz
-    deriv[15] = dx0dx() * temp * (temp_dmiu6_dx + const_2_C2_x * temp_miu6);
-    deriv[16] = dy0dy() * temp * (temp_dmiu6_dy + const_2_C2_y * temp_miu6);
-    deriv[17] = dz0dz() * temp * (temp_dmiu6_dz + const_2_C2_z * temp_miu6);
+    deriv[15] = temp * (temp_dmiu6_dx + const_2_C2_x * temp_miu6);
+    deriv[16] = temp * (temp_dmiu6_dy + const_2_C2_y * temp_miu6);
+    deriv[17] = temp * (temp_dmiu6_dz + const_2_C2_z * temp_miu6);
 
     value[0] = miu_9_11_1;
     value[1] = miu_9_11_2;
@@ -5547,19 +5536,19 @@ void calc_MCSH_9_12(double x0, double y0, double z0, double r0_sqr, double A, do
 
     double sum_ts = t1 + t2 + t3 + t4 + t5 + t6 + t7 + t8;
 
-    double sum_dtdx = temp_dx_3 * (34459425.0 * temp_y_3 * temp_z_3 - 6081075.0 * temp_y_3 * lambda_z0 - 6081075 * lambda_y0 * temp_z_3 + 1216215.0 * lambda_y0 * lambda_z0)
-                       + lambda * (-6081075.0 * temp_y_3 * temp_z_3 + 1216215.0 * temp_y_3 * lambda_z0 + 1216215 * lambda_y0 * temp_z_3 - 280665.0 * lambda_y0 * lambda_z0);
-    double sum_dtdy = temp_dy_3 * (34459425.0 * temp_x_3 * temp_z_3 - 6081075.0 * temp_x_3 * lambda_z0 - 6081075 * lambda_x0 * temp_z_3 + 1216215.0 * lambda_x0 * lambda_z0)
-                       + lambda * (-6081075.0 * temp_x_3 * temp_z_3 + 1216215.0 * temp_x_3 * lambda_z0 + 1216215 * lambda_x0 * temp_z_3 - 280665.0 * lambda_x0 * lambda_z0);
-    double sum_dtdz = temp_dz_3 * (34459425.0 * temp_x_3 * temp_y_3 - 6081075.0 * temp_x_3 * lambda_y0 - 6081075 * lambda_x0 * temp_y_3 + 1216215.0 * lambda_x0 * lambda_y0)
-                       + lambda * (-6081075.0 * temp_x_3 * temp_y_3 + 1216215.0 * temp_x_3 * lambda_y0 + 1216215 * lambda_x0 * temp_y_3 - 280665.0 * lambda_x0 * lambda_y0);
+    double sum_dtdx = temp_dx_3 * (34459425.0 * temp_y_3 * temp_z_3 - 6081075.0 * temp_y_3 * lambda_z0 - 6081075.0 * lambda_y0 * temp_z_3 + 1216215.0 * lambda_y0 * lambda_z0)
+                       + lambda * (-6081075.0 * temp_y_3 * temp_z_3 + 1216215.0 * temp_y_3 * lambda_z0 + 1216215.0 * lambda_y0 * temp_z_3 - 280665.0 * lambda_y0 * lambda_z0);
+    double sum_dtdy = temp_dy_3 * (34459425.0 * temp_x_3 * temp_z_3 - 6081075.0 * temp_x_3 * lambda_z0 - 6081075.0 * lambda_x0 * temp_z_3 + 1216215.0 * lambda_x0 * lambda_z0)
+                       + lambda * (-6081075.0 * temp_x_3 * temp_z_3 + 1216215.0 * temp_x_3 * lambda_z0 + 1216215.0 * lambda_x0 * temp_z_3 - 280665.0 * lambda_x0 * lambda_z0);
+    double sum_dtdz = temp_dz_3 * (34459425.0 * temp_x_3 * temp_y_3 - 6081075.0 * temp_x_3 * lambda_y0 - 6081075.0 * lambda_x0 * temp_y_3 + 1216215.0 * lambda_x0 * lambda_y0)
+                       + lambda * (-6081075.0 * temp_x_3 * temp_y_3 + 1216215.0 * temp_x_3 * lambda_y0 + 1216215.0 * lambda_x0 * temp_y_3 - 280665.0 * lambda_x0 * lambda_y0);
 
 
     double m_9_12 = temp * sum_ts;
 
-    deriv[0] = dx0dx() * temp * (2.0 * C2 * x0 * sum_ts + sum_dtdx);
-    deriv[1] = dy0dy() * temp * (2.0 * C2 * y0 * sum_ts + sum_dtdy);
-    deriv[2] = dz0dz() * temp * (2.0 * C2 * z0 * sum_ts + sum_dtdz);
+    deriv[0] = temp * (2.0 * C2 * x0 * sum_ts + sum_dtdx);
+    deriv[1] = temp * (2.0 * C2 * y0 * sum_ts + sum_dtdy);
+    deriv[2] = temp * (2.0 * C2 * z0 * sum_ts + sum_dtdz);
 
     value[0] = m_9_12;
 }

--- a/amptorch/descriptor/MCSH/atomistic_mcsh.h
+++ b/amptorch/descriptor/MCSH/atomistic_mcsh.h
@@ -143,3 +143,74 @@ void calc_MCSH_9_12(double x0, double y0, double z0, double r0_sqr, double A, do
 
 int get_mcsh_type(int mcsh_order, int group_num);
 AtomisticMCSHFunction get_mcsh_function(int mcsh_order, int group_num);
+
+
+
+
+
+typedef void (*AtomisticMCSHFunctionNoderiv) ( double, double, double, double, double, double, double, double, double *);
+
+void calc_MCSH_0_1_noderiv(double x0, double y0, double z0, double r0_sqr, double A, double B, double alpha, double beta, double *value);
+
+void calc_MCSH_1_1_noderiv(double x0, double y0, double z0, double r0_sqr, double A, double B, double alpha, double beta, double *value);
+
+void calc_MCSH_2_1_noderiv(double x0, double y0, double z0, double r0_sqr, double A, double B, double alpha, double beta, double *value);
+void calc_MCSH_2_2_noderiv(double x0, double y0, double z0, double r0_sqr, double A, double B, double alpha, double beta, double *value);
+
+void calc_MCSH_3_1_noderiv(double x0, double y0, double z0, double r0_sqr, double A, double B, double alpha, double beta, double *value);
+void calc_MCSH_3_2_noderiv(double x0, double y0, double z0, double r0_sqr, double A, double B, double alpha, double beta, double *value);
+void calc_MCSH_3_3_noderiv(double x0, double y0, double z0, double r0_sqr, double A, double B, double alpha, double beta, double *value);
+
+void calc_MCSH_4_1_noderiv(double x0, double y0, double z0, double r0_sqr, double A, double B, double alpha, double beta, double *value);
+void calc_MCSH_4_2_noderiv(double x0, double y0, double z0, double r0_sqr, double A, double B, double alpha, double beta, double *value);
+void calc_MCSH_4_3_noderiv(double x0, double y0, double z0, double r0_sqr, double A, double B, double alpha, double beta, double *value);
+void calc_MCSH_4_4_noderiv(double x0, double y0, double z0, double r0_sqr, double A, double B, double alpha, double beta, double *value);
+
+void calc_MCSH_5_1_noderiv(double x0, double y0, double z0, double r0_sqr, double A, double B, double alpha, double beta, double *value);
+void calc_MCSH_5_2_noderiv(double x0, double y0, double z0, double r0_sqr, double A, double B, double alpha, double beta, double *value);
+void calc_MCSH_5_3_noderiv(double x0, double y0, double z0, double r0_sqr, double A, double B, double alpha, double beta, double *value);
+void calc_MCSH_5_4_noderiv(double x0, double y0, double z0, double r0_sqr, double A, double B, double alpha, double beta, double *value);
+void calc_MCSH_5_5_noderiv(double x0, double y0, double z0, double r0_sqr, double A, double B, double alpha, double beta, double *value);
+
+void calc_MCSH_6_1_noderiv(double x0, double y0, double z0, double r0_sqr, double A, double B, double alpha, double beta, double *value);
+void calc_MCSH_6_2_noderiv(double x0, double y0, double z0, double r0_sqr, double A, double B, double alpha, double beta, double *value);
+void calc_MCSH_6_3_noderiv(double x0, double y0, double z0, double r0_sqr, double A, double B, double alpha, double beta, double *value);
+void calc_MCSH_6_4_noderiv(double x0, double y0, double z0, double r0_sqr, double A, double B, double alpha, double beta, double *value);
+void calc_MCSH_6_5_noderiv(double x0, double y0, double z0, double r0_sqr, double A, double B, double alpha, double beta, double *value);
+void calc_MCSH_6_6_noderiv(double x0, double y0, double z0, double r0_sqr, double A, double B, double alpha, double beta, double *value);
+void calc_MCSH_6_7_noderiv(double x0, double y0, double z0, double r0_sqr, double A, double B, double alpha, double beta, double *value);
+
+void calc_MCSH_7_1_noderiv(double x0, double y0, double z0, double r0_sqr, double A, double B, double alpha, double beta, double *value);
+void calc_MCSH_7_2_noderiv(double x0, double y0, double z0, double r0_sqr, double A, double B, double alpha, double beta, double *value);
+void calc_MCSH_7_3_noderiv(double x0, double y0, double z0, double r0_sqr, double A, double B, double alpha, double beta, double *value);
+void calc_MCSH_7_4_noderiv(double x0, double y0, double z0, double r0_sqr, double A, double B, double alpha, double beta, double *value);
+void calc_MCSH_7_5_noderiv(double x0, double y0, double z0, double r0_sqr, double A, double B, double alpha, double beta, double *value);
+void calc_MCSH_7_6_noderiv(double x0, double y0, double z0, double r0_sqr, double A, double B, double alpha, double beta, double *value);
+void calc_MCSH_7_7_noderiv(double x0, double y0, double z0, double r0_sqr, double A, double B, double alpha, double beta, double *value);
+void calc_MCSH_7_8_noderiv(double x0, double y0, double z0, double r0_sqr, double A, double B, double alpha, double beta, double *value);
+
+void calc_MCSH_8_1_noderiv(double x0, double y0, double z0, double r0_sqr, double A, double B, double alpha, double beta, double *value);
+void calc_MCSH_8_2_noderiv(double x0, double y0, double z0, double r0_sqr, double A, double B, double alpha, double beta, double *value);
+void calc_MCSH_8_3_noderiv(double x0, double y0, double z0, double r0_sqr, double A, double B, double alpha, double beta, double *value);
+void calc_MCSH_8_4_noderiv(double x0, double y0, double z0, double r0_sqr, double A, double B, double alpha, double beta, double *value);
+void calc_MCSH_8_5_noderiv(double x0, double y0, double z0, double r0_sqr, double A, double B, double alpha, double beta, double *value);
+void calc_MCSH_8_6_noderiv(double x0, double y0, double z0, double r0_sqr, double A, double B, double alpha, double beta, double *value);
+void calc_MCSH_8_7_noderiv(double x0, double y0, double z0, double r0_sqr, double A, double B, double alpha, double beta, double *value);
+void calc_MCSH_8_8_noderiv(double x0, double y0, double z0, double r0_sqr, double A, double B, double alpha, double beta, double *value);
+void calc_MCSH_8_9_noderiv(double x0, double y0, double z0, double r0_sqr, double A, double B, double alpha, double beta, double *value);
+void calc_MCSH_8_10_noderiv(double x0, double y0, double z0, double r0_sqr, double A, double B, double alpha, double beta, double *value);
+
+void calc_MCSH_9_1_noderiv(double x0, double y0, double z0, double r0_sqr, double A, double B, double alpha, double beta, double *value);
+void calc_MCSH_9_2_noderiv(double x0, double y0, double z0, double r0_sqr, double A, double B, double alpha, double beta, double *value);
+void calc_MCSH_9_3_noderiv(double x0, double y0, double z0, double r0_sqr, double A, double B, double alpha, double beta, double *value);
+void calc_MCSH_9_4_noderiv(double x0, double y0, double z0, double r0_sqr, double A, double B, double alpha, double beta, double *value);
+void calc_MCSH_9_5_noderiv(double x0, double y0, double z0, double r0_sqr, double A, double B, double alpha, double beta, double *value);
+void calc_MCSH_9_6_noderiv(double x0, double y0, double z0, double r0_sqr, double A, double B, double alpha, double beta, double *value);
+void calc_MCSH_9_7_noderiv(double x0, double y0, double z0, double r0_sqr, double A, double B, double alpha, double beta, double *value);
+void calc_MCSH_9_8_noderiv(double x0, double y0, double z0, double r0_sqr, double A, double B, double alpha, double beta, double *value);
+void calc_MCSH_9_9_noderiv(double x0, double y0, double z0, double r0_sqr, double A, double B, double alpha, double beta, double *value);
+void calc_MCSH_9_10_noderiv(double x0, double y0, double z0, double r0_sqr, double A, double B, double alpha, double beta, double *value);
+void calc_MCSH_9_11_noderiv(double x0, double y0, double z0, double r0_sqr, double A, double B, double alpha, double beta, double *value);
+void calc_MCSH_9_12_noderiv(double x0, double y0, double z0, double r0_sqr, double A, double B, double alpha, double beta, double *value);
+
+AtomisticMCSHFunctionNoderiv get_mcsh_function_noderiv(int mcsh_order, int group_num);

--- a/amptorch/descriptor/MCSH/calculate_atomistic_mcsh.cpp
+++ b/amptorch/descriptor/MCSH/calculate_atomistic_mcsh.cpp
@@ -278,9 +278,12 @@ extern "C" int calculate_atomistic_mcsh(double** cell, double** cart, double** s
                     // dMdx = (1.0/M) * (sum_miu1 * sum_dmiu1_dxj[j] + sum_miu2 * sum_dmiu2_dxj[j] + sum_miu3 * sum_dmiu3_dxj[j]) * weight;
                     // dMdy = (1.0/M) * (sum_miu1 * sum_dmiu1_dyj[j] + sum_miu2 * sum_dmiu2_dyj[j] + sum_miu3 * sum_dmiu3_dyj[j]) * weight;
                     // dMdz = (1.0/M) * (sum_miu1 * sum_dmiu1_dzj[j] + sum_miu2 * sum_dmiu2_dzj[j] + sum_miu3 * sum_dmiu3_dzj[j]) * weight;
-                    dMdx = 2.0 * (sum_miu1 * sum_dmiu1_dxj[j] + sum_miu2 * sum_dmiu2_dxj[j] + sum_miu3 * sum_dmiu3_dxj[j]) * weight;
-                    dMdy = 2.0 * (sum_miu1 * sum_dmiu1_dyj[j] + sum_miu2 * sum_dmiu2_dyj[j] + sum_miu3 * sum_dmiu3_dyj[j]) * weight;
-                    dMdz = 2.0 * (sum_miu1 * sum_dmiu1_dzj[j] + sum_miu2 * sum_dmiu2_dzj[j] + sum_miu3 * sum_dmiu3_dzj[j]) * weight;
+                    // dMdx = 2.0 * (sum_miu1 * sum_dmiu1_dxj[j] + sum_miu2 * sum_dmiu2_dxj[j] + sum_miu3 * sum_dmiu3_dxj[j]) * weight;
+                    // dMdy = 2.0 * (sum_miu1 * sum_dmiu1_dyj[j] + sum_miu2 * sum_dmiu2_dyj[j] + sum_miu3 * sum_dmiu3_dyj[j]) * weight;
+                    // dMdz = 2.0 * (sum_miu1 * sum_dmiu1_dzj[j] + sum_miu2 * sum_dmiu2_dzj[j] + sum_miu3 * sum_dmiu3_dzj[j]) * weight;
+                    dMdx = 2.0;
+                    dMdy = 2.0;
+                    dMdz = 2.0;
                     dmcsh[ii*nmcsh + m][nei_list_i[j*2 + 1]*3] += dMdx;
                     dmcsh[ii*nmcsh + m][nei_list_i[j*2 + 1]*3 + 1] += dMdy;
                     dmcsh[ii*nmcsh + m][nei_list_i[j*2 + 1]*3 + 2] += dMdz;

--- a/amptorch/descriptor/MCSH/calculate_atomistic_mcsh.cpp
+++ b/amptorch/descriptor/MCSH/calculate_atomistic_mcsh.cpp
@@ -281,9 +281,9 @@ extern "C" int calculate_atomistic_mcsh(double** cell, double** cart, double** s
                     // dMdx = 2.0 * (sum_miu1 * sum_dmiu1_dxj[j] + sum_miu2 * sum_dmiu2_dxj[j] + sum_miu3 * sum_dmiu3_dxj[j]) * weight;
                     // dMdy = 2.0 * (sum_miu1 * sum_dmiu1_dyj[j] + sum_miu2 * sum_dmiu2_dyj[j] + sum_miu3 * sum_dmiu3_dyj[j]) * weight;
                     // dMdz = 2.0 * (sum_miu1 * sum_dmiu1_dzj[j] + sum_miu2 * sum_dmiu2_dzj[j] + sum_miu3 * sum_dmiu3_dzj[j]) * weight;
-                    dMdx = 2.0;
-                    dMdy = 2.0;
-                    dMdz = 2.0;
+                    dMdx = 2.0 * sum_miu1;
+                    dMdy = 2.0 * sum_miu1;
+                    dMdz = 2.0 * sum_miu1;
                     dmcsh[ii*nmcsh + m][nei_list_i[j*2 + 1]*3] += dMdx;
                     dmcsh[ii*nmcsh + m][nei_list_i[j*2 + 1]*3 + 1] += dMdy;
                     dmcsh[ii*nmcsh + m][nei_list_i[j*2 + 1]*3 + 2] += dMdz;

--- a/amptorch/descriptor/MCSH/calculate_atomistic_mcsh.cpp
+++ b/amptorch/descriptor/MCSH/calculate_atomistic_mcsh.cpp
@@ -290,16 +290,16 @@ extern "C" int calculate_atomistic_mcsh(double** cell, double** cart, double** s
                         sum_dmiu3_dzj[j] += deriv[8];
                     }
                 }
-                M = sqrt(sum_miu1*sum_miu1 + sum_miu2*sum_miu2 + sum_miu3*sum_miu3);
-                // M = sum_miu1*sum_miu1 + sum_miu2*sum_miu2 + sum_miu3*sum_miu3;
+                // M = sqrt(sum_miu1*sum_miu1 + sum_miu2*sum_miu2 + sum_miu3*sum_miu3);
+                M = sum_miu1*sum_miu1 + sum_miu2*sum_miu2 + sum_miu3*sum_miu3;
                 double dMdx, dMdy, dMdz;
                 for (int j = 0; j < nneigh; ++j) {
-                    dMdx = (1.0/M) * (sum_miu1 * sum_dmiu1_dxj[j] + sum_miu2 * sum_dmiu2_dxj[j] + sum_miu3 * sum_dmiu3_dxj[j]) * weight;
-                    dMdy = (1.0/M) * (sum_miu1 * sum_dmiu1_dyj[j] + sum_miu2 * sum_dmiu2_dyj[j] + sum_miu3 * sum_dmiu3_dyj[j]) * weight;
-                    dMdz = (1.0/M) * (sum_miu1 * sum_dmiu1_dzj[j] + sum_miu2 * sum_dmiu2_dzj[j] + sum_miu3 * sum_dmiu3_dzj[j]) * weight;
-                    // dMdx = 2.0 * (sum_miu1 * sum_dmiu1_dxj[j] + sum_miu2 * sum_dmiu2_dxj[j] + sum_miu3 * sum_dmiu3_dxj[j]) * weight;
-                    // dMdy = 2.0 * (sum_miu1 * sum_dmiu1_dyj[j] + sum_miu2 * sum_dmiu2_dyj[j] + sum_miu3 * sum_dmiu3_dyj[j]) * weight;
-                    // dMdz = 2.0 * (sum_miu1 * sum_dmiu1_dzj[j] + sum_miu2 * sum_dmiu2_dzj[j] + sum_miu3 * sum_dmiu3_dzj[j]) * weight;
+                    // dMdx = (1.0/M) * (sum_miu1 * sum_dmiu1_dxj[j] + sum_miu2 * sum_dmiu2_dxj[j] + sum_miu3 * sum_dmiu3_dxj[j]) * weight;
+                    // dMdy = (1.0/M) * (sum_miu1 * sum_dmiu1_dyj[j] + sum_miu2 * sum_dmiu2_dyj[j] + sum_miu3 * sum_dmiu3_dyj[j]) * weight;
+                    // dMdz = (1.0/M) * (sum_miu1 * sum_dmiu1_dzj[j] + sum_miu2 * sum_dmiu2_dzj[j] + sum_miu3 * sum_dmiu3_dzj[j]) * weight;
+                    dMdx = 2.0 * (sum_miu1 * sum_dmiu1_dxj[j] + sum_miu2 * sum_dmiu2_dxj[j] + sum_miu3 * sum_dmiu3_dxj[j]) * weight;
+                    dMdy = 2.0 * (sum_miu1 * sum_dmiu1_dyj[j] + sum_miu2 * sum_dmiu2_dyj[j] + sum_miu3 * sum_dmiu3_dyj[j]) * weight;
+                    dMdz = 2.0 * (sum_miu1 * sum_dmiu1_dzj[j] + sum_miu2 * sum_dmiu2_dzj[j] + sum_miu3 * sum_dmiu3_dzj[j]) * weight;
 
                     dmcsh[ii*nmcsh + m][nei_list_i[j*2 + 1]*3] += dMdx;
                     dmcsh[ii*nmcsh + m][nei_list_i[j*2 + 1]*3 + 1] += dMdy;
@@ -401,35 +401,35 @@ extern "C" int calculate_atomistic_mcsh(double** cell, double** cart, double** s
                         sum_dmiu6_dzj[j] += deriv[17];
                     }
                 }
-                M = sqrt(sum_miu1*sum_miu1 + sum_miu2*sum_miu2 + sum_miu3*sum_miu3 +
-                         sum_miu4*sum_miu4 + sum_miu5*sum_miu5 + sum_miu6*sum_miu6);
-                // M = sum_miu1*sum_miu1 + sum_miu2*sum_miu2 + sum_miu3*sum_miu3 +
-                //     sum_miu4*sum_miu4 + sum_miu5*sum_miu5 + sum_miu6*sum_miu6;
+                // M = sqrt(sum_miu1*sum_miu1 + sum_miu2*sum_miu2 + sum_miu3*sum_miu3 +
+                //          sum_miu4*sum_miu4 + sum_miu5*sum_miu5 + sum_miu6*sum_miu6);
+                M = sum_miu1*sum_miu1 + sum_miu2*sum_miu2 + sum_miu3*sum_miu3 +
+                    sum_miu4*sum_miu4 + sum_miu5*sum_miu5 + sum_miu6*sum_miu6;
                 double dMdx, dMdy, dMdz;
                 for (int j = 0; j < nneigh; ++j) {
-                    dMdx = (1.0/M) * (sum_miu1 * sum_dmiu1_dxj[j] + sum_miu2 * sum_dmiu2_dxj[j] + 
-                                    sum_miu3 * sum_dmiu3_dxj[j] + sum_miu4 * sum_dmiu4_dxj[j] + 
-                                    sum_miu5 * sum_dmiu5_dxj[j] + sum_miu6 * sum_dmiu6_dxj[j]) * weight;
-
-                    dMdy = (1.0/M) * (sum_miu1 * sum_dmiu1_dyj[j] + sum_miu2 * sum_dmiu2_dyj[j] + 
-                                    sum_miu3 * sum_dmiu3_dyj[j] + sum_miu4 * sum_dmiu4_dyj[j] + 
-                                    sum_miu5 * sum_dmiu5_dyj[j] + sum_miu6 * sum_dmiu6_dyj[j]) * weight;
-
-                    dMdz = (1.0/M) * (sum_miu1 * sum_dmiu1_dzj[j] + sum_miu2 * sum_dmiu2_dzj[j] + 
-                                    sum_miu3 * sum_dmiu3_dzj[j] + sum_miu4 * sum_dmiu4_dzj[j] + 
-                                    sum_miu5 * sum_dmiu5_dzj[j] + sum_miu6 * sum_dmiu6_dzj[j]) * weight;
-
-                    // dMdx = (2.0) * (sum_miu1 * sum_dmiu1_dxj[j] + sum_miu2 * sum_dmiu2_dxj[j] + 
+                    // dMdx = (1.0/M) * (sum_miu1 * sum_dmiu1_dxj[j] + sum_miu2 * sum_dmiu2_dxj[j] + 
                     //                 sum_miu3 * sum_dmiu3_dxj[j] + sum_miu4 * sum_dmiu4_dxj[j] + 
                     //                 sum_miu5 * sum_dmiu5_dxj[j] + sum_miu6 * sum_dmiu6_dxj[j]) * weight;
 
-                    // dMdy = (2.0) * (sum_miu1 * sum_dmiu1_dyj[j] + sum_miu2 * sum_dmiu2_dyj[j] + 
+                    // dMdy = (1.0/M) * (sum_miu1 * sum_dmiu1_dyj[j] + sum_miu2 * sum_dmiu2_dyj[j] + 
                     //                 sum_miu3 * sum_dmiu3_dyj[j] + sum_miu4 * sum_dmiu4_dyj[j] + 
                     //                 sum_miu5 * sum_dmiu5_dyj[j] + sum_miu6 * sum_dmiu6_dyj[j]) * weight;
 
-                    // dMdz = (2.0) * (sum_miu1 * sum_dmiu1_dzj[j] + sum_miu2 * sum_dmiu2_dzj[j] + 
+                    // dMdz = (1.0/M) * (sum_miu1 * sum_dmiu1_dzj[j] + sum_miu2 * sum_dmiu2_dzj[j] + 
                     //                 sum_miu3 * sum_dmiu3_dzj[j] + sum_miu4 * sum_dmiu4_dzj[j] + 
                     //                 sum_miu5 * sum_dmiu5_dzj[j] + sum_miu6 * sum_dmiu6_dzj[j]) * weight;
+
+                    dMdx = (2.0) * (sum_miu1 * sum_dmiu1_dxj[j] + sum_miu2 * sum_dmiu2_dxj[j] + 
+                                    sum_miu3 * sum_dmiu3_dxj[j] + sum_miu4 * sum_dmiu4_dxj[j] + 
+                                    sum_miu5 * sum_dmiu5_dxj[j] + sum_miu6 * sum_dmiu6_dxj[j]) * weight;
+
+                    dMdy = (2.0) * (sum_miu1 * sum_dmiu1_dyj[j] + sum_miu2 * sum_dmiu2_dyj[j] + 
+                                    sum_miu3 * sum_dmiu3_dyj[j] + sum_miu4 * sum_dmiu4_dyj[j] + 
+                                    sum_miu5 * sum_dmiu5_dyj[j] + sum_miu6 * sum_dmiu6_dyj[j]) * weight;
+
+                    dMdz = (2.0) * (sum_miu1 * sum_dmiu1_dzj[j] + sum_miu2 * sum_dmiu2_dzj[j] + 
+                                    sum_miu3 * sum_dmiu3_dzj[j] + sum_miu4 * sum_dmiu4_dzj[j] + 
+                                    sum_miu5 * sum_dmiu5_dzj[j] + sum_miu6 * sum_dmiu6_dzj[j]) * weight;
 
                     dmcsh[ii*nmcsh + m][nei_list_i[j*2 + 1]*3] += dMdx;
                     dmcsh[ii*nmcsh + m][nei_list_i[j*2 + 1]*3 + 1] += dMdy;

--- a/amptorch/descriptor/MCSH/calculate_atomistic_mcsh.cpp
+++ b/amptorch/descriptor/MCSH/calculate_atomistic_mcsh.cpp
@@ -271,12 +271,16 @@ extern "C" int calculate_atomistic_mcsh(double** cell, double** cart, double** s
                         sum_dmiu3_dzj[j] += deriv[8];
                     }
                 }
-                M = sqrt(sum_miu1*sum_miu1 + sum_miu2*sum_miu2 + sum_miu3*sum_miu3);
+                // M = sqrt(sum_miu1*sum_miu1 + sum_miu2*sum_miu2 + sum_miu3*sum_miu3);
+                M = sum_miu1*sum_miu1 + sum_miu2*sum_miu2 + sum_miu3*sum_miu3;
                 double dMdx, dMdy, dMdz;
                 for (int j = 0; j < nneigh; ++j) {
-                    dMdx = (1.0/M) * (sum_miu1 * sum_dmiu1_dxj[j] + sum_miu2 * sum_dmiu2_dxj[j] + sum_miu3 * sum_dmiu3_dxj[j]) * weight;
-                    dMdy = (1.0/M) * (sum_miu1 * sum_dmiu1_dyj[j] + sum_miu2 * sum_dmiu2_dyj[j] + sum_miu3 * sum_dmiu3_dyj[j]) * weight;
-                    dMdz = (1.0/M) * (sum_miu1 * sum_dmiu1_dzj[j] + sum_miu2 * sum_dmiu2_dzj[j] + sum_miu3 * sum_dmiu3_dzj[j]) * weight;
+                    // dMdx = (1.0/M) * (sum_miu1 * sum_dmiu1_dxj[j] + sum_miu2 * sum_dmiu2_dxj[j] + sum_miu3 * sum_dmiu3_dxj[j]) * weight;
+                    // dMdy = (1.0/M) * (sum_miu1 * sum_dmiu1_dyj[j] + sum_miu2 * sum_dmiu2_dyj[j] + sum_miu3 * sum_dmiu3_dyj[j]) * weight;
+                    // dMdz = (1.0/M) * (sum_miu1 * sum_dmiu1_dzj[j] + sum_miu2 * sum_dmiu2_dzj[j] + sum_miu3 * sum_dmiu3_dzj[j]) * weight;
+                    dMdx = 2.0 * (sum_miu1 * sum_dmiu1_dxj[j] + sum_miu2 * sum_dmiu2_dxj[j] + sum_miu3 * sum_dmiu3_dxj[j]) * weight;
+                    dMdy = 2.0 * (sum_miu1 * sum_dmiu1_dyj[j] + sum_miu2 * sum_dmiu2_dyj[j] + sum_miu3 * sum_dmiu3_dyj[j]) * weight;
+                    dMdz = 2.0 * (sum_miu1 * sum_dmiu1_dzj[j] + sum_miu2 * sum_dmiu2_dzj[j] + sum_miu3 * sum_dmiu3_dzj[j]) * weight;
                     dmcsh[ii*nmcsh + m][nei_list_i[j*2 + 1]*3] += dMdx;
                     dmcsh[ii*nmcsh + m][nei_list_i[j*2 + 1]*3 + 1] += dMdy;
                     dmcsh[ii*nmcsh + m][nei_list_i[j*2 + 1]*3 + 2] += dMdz;

--- a/amptorch/descriptor/MCSH/calculate_atomistic_mcsh.cpp
+++ b/amptorch/descriptor/MCSH/calculate_atomistic_mcsh.cpp
@@ -249,29 +249,29 @@ extern "C" int calculate_atomistic_mcsh(double** cell, double** cart, double** s
                 // double sum_dmiu3_dxj[20], sum_dmiu3_dyj[20], sum_dmiu3_dzj[20];
 
 
-                double* sum_dmiu1_dxj = NULL, sum_dmiu1_dyj = NULL, sum_dmiu1_dzj = NULL;   // Pointer to int, initialize to nothing.
-                double* sum_dmiu2_dxj = NULL, sum_dmiu2_dyj = NULL, sum_dmiu2_dzj = NULL;   // Pointer to int, initialize to nothing.
-                double* sum_dmiu3_dxj = NULL, sum_dmiu3_dyj = NULL, sum_dmiu3_dzj = NULL;   // Pointer to int, initialize to nothing.
+                // double* sum_dmiu1_dxj = NULL, sum_dmiu1_dyj = NULL, sum_dmiu1_dzj = NULL;   // Pointer to int, initialize to nothing.
+                // double* sum_dmiu2_dxj = NULL, sum_dmiu2_dyj = NULL, sum_dmiu2_dzj = NULL;   // Pointer to int, initialize to nothing.
+                // double* sum_dmiu3_dxj = NULL, sum_dmiu3_dyj = NULL, sum_dmiu3_dzj = NULL;   // Pointer to int, initialize to nothing.
 
-                sum_dmiu1_dxj = new double[nneigh];  // Allocate n ints and save ptr in a.
-                sum_dmiu2_dxj = new double[nneigh];  // Allocate n ints and save ptr in a.
-                sum_dmiu3_dxj = new double[nneigh];  // Allocate n ints and save ptr in a.
-                sum_dmiu1_dyj = new double[nneigh];  // Allocate n ints and save ptr in a.
-                sum_dmiu2_dyj = new double[nneigh];  // Allocate n ints and save ptr in a.
-                sum_dmiu3_dyj = new double[nneigh];  // Allocate n ints and save ptr in a.
-                sum_dmiu1_dzj = new double[nneigh];  // Allocate n ints and save ptr in a.
-                sum_dmiu2_dzj = new double[nneigh];  // Allocate n ints and save ptr in a.
-                sum_dmiu3_dzj = new double[nneigh];  // Allocate n ints and save ptr in a.
-                for (int j=0; j<n; j++) {
+                double* sum_dmiu1_dxj = new double[nneigh];  // Allocate n ints and save ptr in a.
+                double* sum_dmiu2_dxj = new double[nneigh];  // Allocate n ints and save ptr in a.
+                double* sum_dmiu3_dxj = new double[nneigh];  // Allocate n ints and save ptr in a.
+                double* sum_dmiu1_dyj = new double[nneigh];  // Allocate n ints and save ptr in a.
+                double* sum_dmiu2_dyj = new double[nneigh];  // Allocate n ints and save ptr in a.
+                double* sum_dmiu3_dyj = new double[nneigh];  // Allocate n ints and save ptr in a.
+                double* sum_dmiu1_dzj = new double[nneigh];  // Allocate n ints and save ptr in a.
+                double* sum_dmiu2_dzj = new double[nneigh];  // Allocate n ints and save ptr in a.
+                double* sum_dmiu3_dzj = new double[nneigh];  // Allocate n ints and save ptr in a.
+                for (int j=0; j<nneigh; j++) {
                     sum_dmiu1_dxj[j] = 0;    // Initialize all elements to zero.
-                    sum_dmiu1_dxj[j] = 0;    // Initialize all elements to zero.
-                    sum_dmiu1_dxj[j] = 0;    // Initialize all elements to zero.
-                    sum_dmiu1_dxj[j] = 0;    // Initialize all elements to zero.
-                    sum_dmiu1_dxj[j] = 0;    // Initialize all elements to zero.
-                    sum_dmiu1_dxj[j] = 0;    // Initialize all elements to zero.
-                    sum_dmiu1_dxj[j] = 0;    // Initialize all elements to zero.
-                    sum_dmiu1_dxj[j] = 0;    // Initialize all elements to zero.
-                    sum_dmiu1_dxj[j] = 0;    // Initialize all elements to zero.  
+                    sum_dmiu2_dxj[j] = 0;    // Initialize all elements to zero.
+                    sum_dmiu3_dxj[j] = 0;    // Initialize all elements to zero.
+                    sum_dmiu1_dyj[j] = 0;    // Initialize all elements to zero.
+                    sum_dmiu2_dyj[j] = 0;    // Initialize all elements to zero.
+                    sum_dmiu3_dyj[j] = 0;    // Initialize all elements to zero.
+                    sum_dmiu1_dzj[j] = 0;    // Initialize all elements to zero.
+                    sum_dmiu2_dzj[j] = 0;    // Initialize all elements to zero.
+                    sum_dmiu3_dzj[j] = 0;    // Initialize all elements to zero.  
                 }
                 
 

--- a/amptorch/descriptor/MCSH/calculate_atomistic_mcsh.cpp
+++ b/amptorch/descriptor/MCSH/calculate_atomistic_mcsh.cpp
@@ -289,18 +289,23 @@ extern "C" int calculate_atomistic_mcsh(double** cell, double** cart, double** s
                 // M = sqrt(sum_miu1*sum_miu1 + sum_miu2*sum_miu2 + sum_miu3*sum_miu3);
                 M = sum_miu1*sum_miu1 + sum_miu2*sum_miu2 + sum_miu3*sum_miu3;
                 double dMdx, dMdy, dMdz;
-                for (int j = 0; j < nneigh; ++j) {
-                    dMdx = (1.0/M) * (sum_miu1 * sum_dmiu1_dxj[j] + sum_miu2 * sum_dmiu2_dxj[j] + sum_miu3 * sum_dmiu3_dxj[j]) * weight;
-                    dMdy = (1.0/M) * (sum_miu1 * sum_dmiu1_dyj[j] + sum_miu2 * sum_dmiu2_dyj[j] + sum_miu3 * sum_dmiu3_dyj[j]) * weight;
-                    dMdz = (1.0/M) * (sum_miu1 * sum_dmiu1_dzj[j] + sum_miu2 * sum_dmiu2_dzj[j] + sum_miu3 * sum_dmiu3_dzj[j]) * weight;
+                if (abs(M) <= 1e-8) {
+                    M = 0;
+                }
+                else {
+                    for (int j = 0; j < nneigh; ++j) {
+                        dMdx = (1.0/M) * (sum_miu1 * sum_dmiu1_dxj[j] + sum_miu2 * sum_dmiu2_dxj[j] + sum_miu3 * sum_dmiu3_dxj[j]) * weight;
+                        dMdy = (1.0/M) * (sum_miu1 * sum_dmiu1_dyj[j] + sum_miu2 * sum_dmiu2_dyj[j] + sum_miu3 * sum_dmiu3_dyj[j]) * weight;
+                        dMdz = (1.0/M) * (sum_miu1 * sum_dmiu1_dzj[j] + sum_miu2 * sum_dmiu2_dzj[j] + sum_miu3 * sum_dmiu3_dzj[j]) * weight;
 
-                    dmcsh[ii*nmcsh + m][nei_list_i[j*2 + 1]*3] += dMdx;
-                    dmcsh[ii*nmcsh + m][nei_list_i[j*2 + 1]*3 + 1] += dMdy;
-                    dmcsh[ii*nmcsh + m][nei_list_i[j*2 + 1]*3 + 2] += dMdz;
+                        dmcsh[ii*nmcsh + m][nei_list_i[j*2 + 1]*3] += dMdx;
+                        dmcsh[ii*nmcsh + m][nei_list_i[j*2 + 1]*3 + 1] += dMdy;
+                        dmcsh[ii*nmcsh + m][nei_list_i[j*2 + 1]*3 + 2] += dMdz;
 
-                    dmcsh[ii*nmcsh + m][i*3]     -= dMdx;
-                    dmcsh[ii*nmcsh + m][i*3 + 1] -= dMdy;
-                    dmcsh[ii*nmcsh + m][i*3 + 2] -= dMdz;
+                        dmcsh[ii*nmcsh + m][i*3]     -= dMdx;
+                        dmcsh[ii*nmcsh + m][i*3 + 1] -= dMdy;
+                        dmcsh[ii*nmcsh + m][i*3 + 2] -= dMdz;
+                    }
                 }
                 M = M * weight;
                 mcsh[ii][m] += M;
@@ -397,27 +402,33 @@ extern "C" int calculate_atomistic_mcsh(double** cell, double** cart, double** s
                 M = sqrt(sum_miu1*sum_miu1 + sum_miu2*sum_miu2 + sum_miu3*sum_miu3 +
                          sum_miu4*sum_miu4 + sum_miu5*sum_miu5 + sum_miu6*sum_miu6);
                 double dMdx, dMdy, dMdz;
-                for (int j = 0; j < nneigh; ++j) {
-                    dMdx = (1.0/M) * (sum_miu1 * sum_dmiu1_dxj[j] + sum_miu2 * sum_dmiu2_dxj[j] + 
-                                    sum_miu3 * sum_dmiu3_dxj[j] + sum_miu4 * sum_dmiu4_dxj[j] + 
-                                    sum_miu5 * sum_dmiu5_dxj[j] + sum_miu6 * sum_dmiu6_dxj[j]) * weight;
-
-                    dMdy = (1.0/M) * (sum_miu1 * sum_dmiu1_dyj[j] + sum_miu2 * sum_dmiu2_dyj[j] + 
-                                    sum_miu3 * sum_dmiu3_dyj[j] + sum_miu4 * sum_dmiu4_dyj[j] + 
-                                    sum_miu5 * sum_dmiu5_dyj[j] + sum_miu6 * sum_dmiu6_dyj[j]) * weight;
-
-                    dMdz = (1.0/M) * (sum_miu1 * sum_dmiu1_dzj[j] + sum_miu2 * sum_dmiu2_dzj[j] + 
-                                    sum_miu3 * sum_dmiu3_dzj[j] + sum_miu4 * sum_dmiu4_dzj[j] + 
-                                    sum_miu5 * sum_dmiu5_dzj[j] + sum_miu6 * sum_dmiu6_dzj[j]) * weight;
-
-                    dmcsh[ii*nmcsh + m][nei_list_i[j*2 + 1]*3] += dMdx;
-                    dmcsh[ii*nmcsh + m][nei_list_i[j*2 + 1]*3 + 1] += dMdy;
-                    dmcsh[ii*nmcsh + m][nei_list_i[j*2 + 1]*3 + 2] += dMdz;
-
-                    dmcsh[ii*nmcsh + m][i*3]     -= dMdx;
-                    dmcsh[ii*nmcsh + m][i*3 + 1] -= dMdy;
-                    dmcsh[ii*nmcsh + m][i*3 + 2] -= dMdz;
+                if (abs(M) <= 1e-8) {
+                    M = 0;
                 }
+                else {
+                    for (int j = 0; j < nneigh; ++j) {
+                        dMdx = (1.0/M) * (sum_miu1 * sum_dmiu1_dxj[j] + sum_miu2 * sum_dmiu2_dxj[j] + 
+                                        sum_miu3 * sum_dmiu3_dxj[j] + sum_miu4 * sum_dmiu4_dxj[j] + 
+                                        sum_miu5 * sum_dmiu5_dxj[j] + sum_miu6 * sum_dmiu6_dxj[j]) * weight;
+
+                        dMdy = (1.0/M) * (sum_miu1 * sum_dmiu1_dyj[j] + sum_miu2 * sum_dmiu2_dyj[j] + 
+                                        sum_miu3 * sum_dmiu3_dyj[j] + sum_miu4 * sum_dmiu4_dyj[j] + 
+                                        sum_miu5 * sum_dmiu5_dyj[j] + sum_miu6 * sum_dmiu6_dyj[j]) * weight;
+
+                        dMdz = (1.0/M) * (sum_miu1 * sum_dmiu1_dzj[j] + sum_miu2 * sum_dmiu2_dzj[j] + 
+                                        sum_miu3 * sum_dmiu3_dzj[j] + sum_miu4 * sum_dmiu4_dzj[j] + 
+                                        sum_miu5 * sum_dmiu5_dzj[j] + sum_miu6 * sum_dmiu6_dzj[j]) * weight;
+
+                        dmcsh[ii*nmcsh + m][nei_list_i[j*2 + 1]*3] += dMdx;
+                        dmcsh[ii*nmcsh + m][nei_list_i[j*2 + 1]*3 + 1] += dMdy;
+                        dmcsh[ii*nmcsh + m][nei_list_i[j*2 + 1]*3 + 2] += dMdz;
+
+                        dmcsh[ii*nmcsh + m][i*3]     -= dMdx;
+                        dmcsh[ii*nmcsh + m][i*3 + 1] -= dMdy;
+                        dmcsh[ii*nmcsh + m][i*3 + 2] -= dMdz;
+                    }
+                }
+                
                 M = M * weight;
                 mcsh[ii][m] += M;
 
@@ -633,7 +644,7 @@ extern "C" int calculate_atomistic_mcsh_noderiv(double** cell, double** cart, do
             // double weight = params_d[m][1]; 
             double M = 0.0;
             if (mcsh_type == 1){
-                double m_desc[1], deriv[3];
+                double m_desc[1];
                 
                 for (int j = 0; j < nneigh; ++j) {
 
@@ -653,7 +664,7 @@ extern "C" int calculate_atomistic_mcsh_noderiv(double** cell, double** cart, do
             if (mcsh_type == 2){
                 double sum_miu1 = 0.0, sum_miu2 = 0.0, sum_miu3 = 0.0;
 
-                double miu[3], deriv[9];
+                double miu[3];
                 for (int j = 0; j < nneigh; ++j) {
                     int neigh_atom_element_index = nei_list_i[j*2];
                     int neigh_atom_element_order = element_index_to_order[neigh_atom_element_index];
@@ -676,7 +687,7 @@ extern "C" int calculate_atomistic_mcsh_noderiv(double** cell, double** cart, do
             if (mcsh_type == 3){
                 double sum_miu1 = 0.0, sum_miu2 = 0.0, sum_miu3 = 0.0, sum_miu4 = 0.0, sum_miu5 = 0.0, sum_miu6 = 0.0;
 
-                double miu[6], deriv[18];
+                double miu[6];
                 for (int j = 0; j < nneigh; ++j) {
                     int neigh_atom_element_index = nei_list_i[j*2];
                     int neigh_atom_element_order = element_index_to_order[neigh_atom_element_index];
@@ -1343,7 +1354,7 @@ extern "C" int calculate_atomistic_mcsh_norm_noderiv(double** cell, double** car
             // double weight = params_d[m][1]; 
             double M = 0.0;
             if (mcsh_type == 1){
-                double m_desc[1], deriv[3];
+                double m_desc[1];
                 
                 for (int j = 0; j < nneigh; ++j) {
 
@@ -1364,7 +1375,7 @@ extern "C" int calculate_atomistic_mcsh_norm_noderiv(double** cell, double** car
             if (mcsh_type == 2){
                 double sum_miu1 = 0.0, sum_miu2 = 0.0, sum_miu3 = 0.0;
 
-                double miu[3], deriv[9];
+                double miu[3];
                 for (int j = 0; j < nneigh; ++j) {
                     int neigh_atom_element_index = nei_list_i[j*2];
                     int neigh_atom_element_order = element_index_to_order[neigh_atom_element_index];
@@ -1388,7 +1399,7 @@ extern "C" int calculate_atomistic_mcsh_norm_noderiv(double** cell, double** car
             if (mcsh_type == 3){
                 double sum_miu1 = 0.0, sum_miu2 = 0.0, sum_miu3 = 0.0, sum_miu4 = 0.0, sum_miu5 = 0.0, sum_miu6 = 0.0;
 
-                double miu[6], deriv[18];
+                double miu[6];
                 for (int j = 0; j < nneigh; ++j) {
                     int neigh_atom_element_index = nei_list_i[j*2];
                     int neigh_atom_element_order = element_index_to_order[neigh_atom_element_index];

--- a/amptorch/descriptor/MCSH/calculate_atomistic_mcsh.cpp
+++ b/amptorch/descriptor/MCSH/calculate_atomistic_mcsh.cpp
@@ -241,18 +241,6 @@ extern "C" int calculate_atomistic_mcsh(double** cell, double** cart, double** s
             if (mcsh_type == 2){
                 double sum_miu1 = 0, sum_miu2 = 0, sum_miu3 = 0;
 
-                // double sum_dmiu1_dxj[nneigh], sum_dmiu1_dyj[nneigh], sum_dmiu1_dzj[nneigh];
-                // double sum_dmiu2_dxj[nneigh], sum_dmiu2_dyj[nneigh], sum_dmiu2_dzj[nneigh];
-                // double sum_dmiu3_dxj[nneigh], sum_dmiu3_dyj[nneigh], sum_dmiu3_dzj[nneigh];
-                // double sum_dmiu1_dxj[20], sum_dmiu1_dyj[20], sum_dmiu1_dzj[20];
-                // double sum_dmiu2_dxj[20], sum_dmiu2_dyj[20], sum_dmiu2_dzj[20];
-                // double sum_dmiu3_dxj[20], sum_dmiu3_dyj[20], sum_dmiu3_dzj[20];
-
-
-                // double* sum_dmiu1_dxj = NULL, sum_dmiu1_dyj = NULL, sum_dmiu1_dzj = NULL;   // Pointer to int, initialize to nothing.
-                // double* sum_dmiu2_dxj = NULL, sum_dmiu2_dyj = NULL, sum_dmiu2_dzj = NULL;   // Pointer to int, initialize to nothing.
-                // double* sum_dmiu3_dxj = NULL, sum_dmiu3_dyj = NULL, sum_dmiu3_dzj = NULL;   // Pointer to int, initialize to nothing.
-
                 double* sum_dmiu1_dxj = new double[nneigh];  // Allocate n ints and save ptr in a.
                 double* sum_dmiu2_dxj = new double[nneigh];  // Allocate n ints and save ptr in a.
                 double* sum_dmiu3_dxj = new double[nneigh];  // Allocate n ints and save ptr in a.
@@ -273,8 +261,6 @@ extern "C" int calculate_atomistic_mcsh(double** cell, double** cart, double** s
                     sum_dmiu2_dzj[j] = 0;    // Initialize all elements to zero.
                     sum_dmiu3_dzj[j] = 0;    // Initialize all elements to zero.  
                 }
-                
-
 
                 double miu[3], deriv[9];
                 for (int j = 0; j < nneigh; ++j) {
@@ -343,6 +329,45 @@ extern "C" int calculate_atomistic_mcsh(double** cell, double** cart, double** s
                 double sum_dmiu5_dxj[nneigh], sum_dmiu5_dyj[nneigh], sum_dmiu5_dzj[nneigh];
                 double sum_dmiu6_dxj[nneigh], sum_dmiu6_dyj[nneigh], sum_dmiu6_dzj[nneigh];
 
+                double* sum_dmiu1_dxj = new double[nneigh];  // Allocate n ints and save ptr in a.
+                double* sum_dmiu2_dxj = new double[nneigh];  // Allocate n ints and save ptr in a.
+                double* sum_dmiu3_dxj = new double[nneigh];  // Allocate n ints and save ptr in a.
+                double* sum_dmiu4_dxj = new double[nneigh];  // Allocate n ints and save ptr in a.
+                double* sum_dmiu5_dxj = new double[nneigh];  // Allocate n ints and save ptr in a.
+                double* sum_dmiu6_dxj = new double[nneigh];  // Allocate n ints and save ptr in a.
+                double* sum_dmiu1_dyj = new double[nneigh];  // Allocate n ints and save ptr in a.
+                double* sum_dmiu2_dyj = new double[nneigh];  // Allocate n ints and save ptr in a.
+                double* sum_dmiu3_dyj = new double[nneigh];  // Allocate n ints and save ptr in a.
+                double* sum_dmiu4_dyj = new double[nneigh];  // Allocate n ints and save ptr in a.
+                double* sum_dmiu5_dyj = new double[nneigh];  // Allocate n ints and save ptr in a.
+                double* sum_dmiu6_dyj = new double[nneigh];  // Allocate n ints and save ptr in a.
+                double* sum_dmiu1_dzj = new double[nneigh];  // Allocate n ints and save ptr in a.
+                double* sum_dmiu2_dzj = new double[nneigh];  // Allocate n ints and save ptr in a.
+                double* sum_dmiu3_dzj = new double[nneigh];  // Allocate n ints and save ptr in a.
+                double* sum_dmiu4_dzj = new double[nneigh];  // Allocate n ints and save ptr in a.
+                double* sum_dmiu5_dzj = new double[nneigh];  // Allocate n ints and save ptr in a.
+                double* sum_dmiu6_dzj = new double[nneigh];  // Allocate n ints and save ptr in a.
+                for (int j=0; j<nneigh; j++) {
+                    sum_dmiu1_dxj[j] = 0;    // Initialize all elements to zero.
+                    sum_dmiu2_dxj[j] = 0;    // Initialize all elements to zero.
+                    sum_dmiu3_dxj[j] = 0;    // Initialize all elements to zero.
+                    sum_dmiu4_dxj[j] = 0;    // Initialize all elements to zero.
+                    sum_dmiu5_dxj[j] = 0;    // Initialize all elements to zero.
+                    sum_dmiu6_dxj[j] = 0;    // Initialize all elements to zero.
+                    sum_dmiu1_dyj[j] = 0;    // Initialize all elements to zero.
+                    sum_dmiu2_dyj[j] = 0;    // Initialize all elements to zero.
+                    sum_dmiu3_dyj[j] = 0;    // Initialize all elements to zero. 
+                    sum_dmiu4_dyj[j] = 0;    // Initialize all elements to zero.
+                    sum_dmiu5_dyj[j] = 0;    // Initialize all elements to zero.
+                    sum_dmiu6_dyj[j] = 0;    // Initialize all elements to zero.
+                    sum_dmiu1_dzj[j] = 0;    // Initialize all elements to zero.
+                    sum_dmiu2_dzj[j] = 0;    // Initialize all elements to zero.
+                    sum_dmiu3_dzj[j] = 0;    // Initialize all elements to zero.
+                    sum_dmiu4_dzj[j] = 0;    // Initialize all elements to zero.
+                    sum_dmiu5_dzj[j] = 0;    // Initialize all elements to zero.
+                    sum_dmiu6_dzj[j] = 0;    // Initialize all elements to zero. 
+                }
+
                 double miu[6], deriv[18];
                 for (int j = 0; j < nneigh; ++j) {
                     int neigh_atom_element_index = nei_list_i[j*2];
@@ -405,6 +430,25 @@ extern "C" int calculate_atomistic_mcsh(double** cell, double** cart, double** s
                 }
                 M = M * weight;
                 mcsh[ii][m] += M;
+
+                delete [] sum_dmiu1_dxj;
+                delete [] sum_dmiu2_dxj; 
+                delete [] sum_dmiu3_dxj; 
+                delete [] sum_dmiu4_dxj; 
+                delete [] sum_dmiu5_dxj; 
+                delete [] sum_dmiu6_dxj; 
+                delete [] sum_dmiu1_dyj; 
+                delete [] sum_dmiu2_dyj; 
+                delete [] sum_dmiu3_dyj; 
+                delete [] sum_dmiu4_dyj;
+                delete [] sum_dmiu5_dyj; 
+                delete [] sum_dmiu6_dyj; 
+                delete [] sum_dmiu1_dzj; 
+                delete [] sum_dmiu2_dzj; 
+                delete [] sum_dmiu3_dzj; 
+                delete [] sum_dmiu4_dzj; 
+                delete [] sum_dmiu5_dzj; 
+                delete [] sum_dmiu6_dzj; 
             }
         }
         delete[] nei_list_d;

--- a/amptorch/descriptor/MCSH/calculate_atomistic_mcsh.cpp
+++ b/amptorch/descriptor/MCSH/calculate_atomistic_mcsh.cpp
@@ -223,9 +223,12 @@ extern "C" int calculate_atomistic_mcsh(double** cell, double** cart, double** s
                         dMdy += deriv[1];
                         dMdz += deriv[2];
                     }
-                    dMdx = dMdx * weight;
-                    dMdy = dMdy * weight;
-                    dMdz = dMdz * weight;
+                    // dMdx = dMdx * weight;
+                    // dMdy = dMdy * weight;
+                    // dMdz = dMdz * weight;
+                    dMdx = 2.0 * M * dMdx * weight;
+                    dMdy = 2.0 * M * dMdy * weight;
+                    dMdz = 2.0 * M * dMdz * weight;
                     dmcsh[ii*nmcsh + m][nei_list_i[j*2 + 1]*3] += dMdx;
                     dmcsh[ii*nmcsh + m][nei_list_i[j*2 + 1]*3 + 1] += dMdy;
                     dmcsh[ii*nmcsh + m][nei_list_i[j*2 + 1]*3 + 2] += dMdz;
@@ -234,7 +237,8 @@ extern "C" int calculate_atomistic_mcsh(double** cell, double** cart, double** s
                     dmcsh[ii*nmcsh + m][i*3 + 1] -= dMdy;
                     dmcsh[ii*nmcsh + m][i*3 + 2] -= dMdz;
                 }
-                M = M * weight;
+                // M = M * weight;
+                M = M * M * weight;
                 mcsh[ii][m] += M;
             }
 
@@ -286,16 +290,16 @@ extern "C" int calculate_atomistic_mcsh(double** cell, double** cart, double** s
                         sum_dmiu3_dzj[j] += deriv[8];
                     }
                 }
-                M = sqrt(sum_miu1*sum_miu1 + sum_miu2*sum_miu2 + sum_miu3*sum_miu3);
-                // M = sum_miu1*sum_miu1 + sum_miu2*sum_miu2 + sum_miu3*sum_miu3;
+                // M = sqrt(sum_miu1*sum_miu1 + sum_miu2*sum_miu2 + sum_miu3*sum_miu3);
+                M = sum_miu1*sum_miu1 + sum_miu2*sum_miu2 + sum_miu3*sum_miu3;
                 double dMdx, dMdy, dMdz;
                 for (int j = 0; j < nneigh; ++j) {
-                    dMdx = (1.0/M) * (sum_miu1 * sum_dmiu1_dxj[j] + sum_miu2 * sum_dmiu2_dxj[j] + sum_miu3 * sum_dmiu3_dxj[j]) * weight;
-                    dMdy = (1.0/M) * (sum_miu1 * sum_dmiu1_dyj[j] + sum_miu2 * sum_dmiu2_dyj[j] + sum_miu3 * sum_dmiu3_dyj[j]) * weight;
-                    dMdz = (1.0/M) * (sum_miu1 * sum_dmiu1_dzj[j] + sum_miu2 * sum_dmiu2_dzj[j] + sum_miu3 * sum_dmiu3_dzj[j]) * weight;
-                    // dMdx = 2.0 * (sum_miu1 * sum_dmiu1_dxj[j] + sum_miu2 * sum_dmiu2_dxj[j] + sum_miu3 * sum_dmiu3_dxj[j]) * weight;
-                    // dMdy = 2.0 * (sum_miu1 * sum_dmiu1_dyj[j] + sum_miu2 * sum_dmiu2_dyj[j] + sum_miu3 * sum_dmiu3_dyj[j]) * weight;
-                    // dMdz = 2.0 * (sum_miu1 * sum_dmiu1_dzj[j] + sum_miu2 * sum_dmiu2_dzj[j] + sum_miu3 * sum_dmiu3_dzj[j]) * weight;
+                    // dMdx = (1.0/M) * (sum_miu1 * sum_dmiu1_dxj[j] + sum_miu2 * sum_dmiu2_dxj[j] + sum_miu3 * sum_dmiu3_dxj[j]) * weight;
+                    // dMdy = (1.0/M) * (sum_miu1 * sum_dmiu1_dyj[j] + sum_miu2 * sum_dmiu2_dyj[j] + sum_miu3 * sum_dmiu3_dyj[j]) * weight;
+                    // dMdz = (1.0/M) * (sum_miu1 * sum_dmiu1_dzj[j] + sum_miu2 * sum_dmiu2_dzj[j] + sum_miu3 * sum_dmiu3_dzj[j]) * weight;
+                    dMdx = 2.0 * (sum_miu1 * sum_dmiu1_dxj[j] + sum_miu2 * sum_dmiu2_dxj[j] + sum_miu3 * sum_dmiu3_dxj[j]) * weight;
+                    dMdy = 2.0 * (sum_miu1 * sum_dmiu1_dyj[j] + sum_miu2 * sum_dmiu2_dyj[j] + sum_miu3 * sum_dmiu3_dyj[j]) * weight;
+                    dMdz = 2.0 * (sum_miu1 * sum_dmiu1_dzj[j] + sum_miu2 * sum_dmiu2_dzj[j] + sum_miu3 * sum_dmiu3_dzj[j]) * weight;
 
                     dmcsh[ii*nmcsh + m][nei_list_i[j*2 + 1]*3] += dMdx;
                     dmcsh[ii*nmcsh + m][nei_list_i[j*2 + 1]*3 + 1] += dMdy;
@@ -397,19 +401,33 @@ extern "C" int calculate_atomistic_mcsh(double** cell, double** cart, double** s
                         sum_dmiu6_dzj[j] += deriv[17];
                     }
                 }
-                M = sqrt(sum_miu1*sum_miu1 + sum_miu2*sum_miu2 + sum_miu3*sum_miu3 +
-                         sum_miu4*sum_miu4 + sum_miu5*sum_miu5 + sum_miu6*sum_miu6);
+                // M = sqrt(sum_miu1*sum_miu1 + sum_miu2*sum_miu2 + sum_miu3*sum_miu3 +
+                //          sum_miu4*sum_miu4 + sum_miu5*sum_miu5 + sum_miu6*sum_miu6);
+                M = sum_miu1*sum_miu1 + sum_miu2*sum_miu2 + sum_miu3*sum_miu3 +
+                    sum_miu4*sum_miu4 + sum_miu5*sum_miu5 + sum_miu6*sum_miu6;
                 double dMdx, dMdy, dMdz;
                 for (int j = 0; j < nneigh; ++j) {
-                    dMdx = (1.0/M) * (sum_miu1 * sum_dmiu1_dxj[j] + sum_miu2 * sum_dmiu2_dxj[j] + 
+                    // dMdx = (1.0/M) * (sum_miu1 * sum_dmiu1_dxj[j] + sum_miu2 * sum_dmiu2_dxj[j] + 
+                    //                 sum_miu3 * sum_dmiu3_dxj[j] + sum_miu4 * sum_dmiu4_dxj[j] + 
+                    //                 sum_miu5 * sum_dmiu5_dxj[j] + sum_miu6 * sum_dmiu6_dxj[j]) * weight;
+
+                    // dMdy = (1.0/M) * (sum_miu1 * sum_dmiu1_dyj[j] + sum_miu2 * sum_dmiu2_dyj[j] + 
+                    //                 sum_miu3 * sum_dmiu3_dyj[j] + sum_miu4 * sum_dmiu4_dyj[j] + 
+                    //                 sum_miu5 * sum_dmiu5_dyj[j] + sum_miu6 * sum_dmiu6_dyj[j]) * weight;
+
+                    // dMdz = (1.0/M) * (sum_miu1 * sum_dmiu1_dzj[j] + sum_miu2 * sum_dmiu2_dzj[j] + 
+                    //                 sum_miu3 * sum_dmiu3_dzj[j] + sum_miu4 * sum_dmiu4_dzj[j] + 
+                    //                 sum_miu5 * sum_dmiu5_dzj[j] + sum_miu6 * sum_dmiu6_dzj[j]) * weight;
+
+                    dMdx = (2.0) * (sum_miu1 * sum_dmiu1_dxj[j] + sum_miu2 * sum_dmiu2_dxj[j] + 
                                     sum_miu3 * sum_dmiu3_dxj[j] + sum_miu4 * sum_dmiu4_dxj[j] + 
                                     sum_miu5 * sum_dmiu5_dxj[j] + sum_miu6 * sum_dmiu6_dxj[j]) * weight;
 
-                    dMdy = (1.0/M) * (sum_miu1 * sum_dmiu1_dyj[j] + sum_miu2 * sum_dmiu2_dyj[j] + 
+                    dMdy = (2.0) * (sum_miu1 * sum_dmiu1_dyj[j] + sum_miu2 * sum_dmiu2_dyj[j] + 
                                     sum_miu3 * sum_dmiu3_dyj[j] + sum_miu4 * sum_dmiu4_dyj[j] + 
                                     sum_miu5 * sum_dmiu5_dyj[j] + sum_miu6 * sum_dmiu6_dyj[j]) * weight;
 
-                    dMdz = (1.0/M) * (sum_miu1 * sum_dmiu1_dzj[j] + sum_miu2 * sum_dmiu2_dzj[j] + 
+                    dMdz = (2.0) * (sum_miu1 * sum_dmiu1_dzj[j] + sum_miu2 * sum_dmiu2_dzj[j] + 
                                     sum_miu3 * sum_dmiu3_dzj[j] + sum_miu4 * sum_dmiu4_dzj[j] + 
                                     sum_miu5 * sum_dmiu5_dzj[j] + sum_miu6 * sum_dmiu6_dzj[j]) * weight;
 

--- a/amptorch/descriptor/MCSH/calculate_atomistic_mcsh.cpp
+++ b/amptorch/descriptor/MCSH/calculate_atomistic_mcsh.cpp
@@ -281,9 +281,9 @@ extern "C" int calculate_atomistic_mcsh(double** cell, double** cart, double** s
                     // dMdx = 2.0 * (sum_miu1 * sum_dmiu1_dxj[j] + sum_miu2 * sum_dmiu2_dxj[j] + sum_miu3 * sum_dmiu3_dxj[j]) * weight;
                     // dMdy = 2.0 * (sum_miu1 * sum_dmiu1_dyj[j] + sum_miu2 * sum_dmiu2_dyj[j] + sum_miu3 * sum_dmiu3_dyj[j]) * weight;
                     // dMdz = 2.0 * (sum_miu1 * sum_dmiu1_dzj[j] + sum_miu2 * sum_dmiu2_dzj[j] + sum_miu3 * sum_dmiu3_dzj[j]) * weight;
-                    dMdx = 2.0 * sum_miu1;
-                    dMdy = 2.0 * sum_miu1;
-                    dMdz = 2.0 * sum_miu1;
+                    dMdx = 2.0 * (sum_miu1 * sum_dmiu1_dxj[j]);
+                    dMdy = 2.0 * (sum_miu1 * sum_dmiu1_dyj[j]);
+                    dMdz = 2.0 * (sum_miu1 * sum_dmiu1_dzj[j]);
                     dmcsh[ii*nmcsh + m][nei_list_i[j*2 + 1]*3] += dMdx;
                     dmcsh[ii*nmcsh + m][nei_list_i[j*2 + 1]*3 + 1] += dMdy;
                     dmcsh[ii*nmcsh + m][nei_list_i[j*2 + 1]*3 + 2] += dMdz;

--- a/amptorch/descriptor/MCSH/calculate_atomistic_mcsh.cpp
+++ b/amptorch/descriptor/MCSH/calculate_atomistic_mcsh.cpp
@@ -202,7 +202,9 @@ extern "C" int calculate_atomistic_mcsh(double** cell, double** cart, double** s
             AtomisticMCSHFunction mcsh_function = get_mcsh_function(params_i[m][0], params_i[m][1]);
 
             // params_d: sigma, weight, A, beta, cutoff
-            double weight = params_d[m][1], A = params_d[m][2], beta = params_d[m][3];
+            double A = params_d[m][2], beta = params_d[m][3];
+            double weight = 1.0 
+            //weight = params_d[m][1]; 
             double M = 0;
             if (mcsh_type == 1){
                 double m_desc[1], deriv[3];
@@ -272,13 +274,13 @@ extern "C" int calculate_atomistic_mcsh(double** cell, double** cart, double** s
                     dMdx = (1/M) * (sum_miu1 * sum_dmiu1_dxj[j] + sum_miu2 * sum_dmiu2_dxj[j] + sum_miu3 * sum_dmiu3_dxj[j]) * weight;
                     dMdy = (1/M) * (sum_miu1 * sum_dmiu1_dyj[j] + sum_miu2 * sum_dmiu2_dyj[j] + sum_miu3 * sum_dmiu3_dyj[j]) * weight;
                     dMdz = (1/M) * (sum_miu1 * sum_dmiu1_dzj[j] + sum_miu2 * sum_dmiu2_dzj[j] + sum_miu3 * sum_dmiu3_dzj[j]) * weight;
-                    dmcsh[ii*nmcsh + m][nei_list_i[j*2 + 1]*3] += dMdx;
-                    dmcsh[ii*nmcsh + m][nei_list_i[j*2 + 1]*3 + 1] += dMdy;
-                    dmcsh[ii*nmcsh + m][nei_list_i[j*2 + 1]*3 + 2] += dMdz;
+                    // dmcsh[ii*nmcsh + m][nei_list_i[j*2 + 1]*3] += dMdx;
+                    // dmcsh[ii*nmcsh + m][nei_list_i[j*2 + 1]*3 + 1] += dMdy;
+                    // dmcsh[ii*nmcsh + m][nei_list_i[j*2 + 1]*3 + 2] += dMdz;
 
-                    dmcsh[ii*nmcsh + m][i*3]     -= dMdx;
-                    dmcsh[ii*nmcsh + m][i*3 + 1] -= dMdy;
-                    dmcsh[ii*nmcsh + m][i*3 + 2] -= dMdz;
+                    // dmcsh[ii*nmcsh + m][i*3]     -= dMdx;
+                    // dmcsh[ii*nmcsh + m][i*3 + 1] -= dMdy;
+                    // dmcsh[ii*nmcsh + m][i*3 + 2] -= dMdz;
                 }
                 M = M * weight;
                 mcsh[ii][m] += M;

--- a/amptorch/descriptor/MCSH/calculate_atomistic_mcsh.cpp
+++ b/amptorch/descriptor/MCSH/calculate_atomistic_mcsh.cpp
@@ -281,9 +281,9 @@ extern "C" int calculate_atomistic_mcsh(double** cell, double** cart, double** s
                     // dMdx = 2.0 * (sum_miu1 * sum_dmiu1_dxj[j] + sum_miu2 * sum_dmiu2_dxj[j] + sum_miu3 * sum_dmiu3_dxj[j]) * weight;
                     // dMdy = 2.0 * (sum_miu1 * sum_dmiu1_dyj[j] + sum_miu2 * sum_dmiu2_dyj[j] + sum_miu3 * sum_dmiu3_dyj[j]) * weight;
                     // dMdz = 2.0 * (sum_miu1 * sum_dmiu1_dzj[j] + sum_miu2 * sum_dmiu2_dzj[j] + sum_miu3 * sum_dmiu3_dzj[j]) * weight;
-                    dMdx = 2.0 * (sum_miu1 * sum_dmiu1_dxj[j]);
-                    dMdy = 2.0 * (sum_miu1 * sum_dmiu1_dyj[j]);
-                    dMdz = 2.0 * (sum_miu1 * sum_dmiu1_dzj[j]);
+                    dMdx = 2.0 * (sum_miu1);
+                    dMdy = 2.0 * (sum_miu1);
+                    dMdz = 2.0 * (sum_miu1);
                     dmcsh[ii*nmcsh + m][nei_list_i[j*2 + 1]*3] += dMdx;
                     dmcsh[ii*nmcsh + m][nei_list_i[j*2 + 1]*3 + 1] += dMdy;
                     dmcsh[ii*nmcsh + m][nei_list_i[j*2 + 1]*3 + 2] += dMdz;

--- a/amptorch/descriptor/MCSH/calculate_atomistic_mcsh.cpp
+++ b/amptorch/descriptor/MCSH/calculate_atomistic_mcsh.cpp
@@ -244,9 +244,38 @@ extern "C" int calculate_atomistic_mcsh(double** cell, double** cart, double** s
                 // double sum_dmiu1_dxj[nneigh], sum_dmiu1_dyj[nneigh], sum_dmiu1_dzj[nneigh];
                 // double sum_dmiu2_dxj[nneigh], sum_dmiu2_dyj[nneigh], sum_dmiu2_dzj[nneigh];
                 // double sum_dmiu3_dxj[nneigh], sum_dmiu3_dyj[nneigh], sum_dmiu3_dzj[nneigh];
-                double sum_dmiu1_dxj[20], sum_dmiu1_dyj[20], sum_dmiu1_dzj[20];
-                double sum_dmiu2_dxj[20], sum_dmiu2_dyj[20], sum_dmiu2_dzj[20];
-                double sum_dmiu3_dxj[20], sum_dmiu3_dyj[20], sum_dmiu3_dzj[20];
+                // double sum_dmiu1_dxj[20], sum_dmiu1_dyj[20], sum_dmiu1_dzj[20];
+                // double sum_dmiu2_dxj[20], sum_dmiu2_dyj[20], sum_dmiu2_dzj[20];
+                // double sum_dmiu3_dxj[20], sum_dmiu3_dyj[20], sum_dmiu3_dzj[20];
+
+
+                double* sum_dmiu1_dxj = NULL, sum_dmiu1_dyj = NULL, sum_dmiu1_dzj = NULL;   // Pointer to int, initialize to nothing.
+                double* sum_dmiu2_dxj = NULL, sum_dmiu2_dyj = NULL, sum_dmiu2_dzj = NULL;   // Pointer to int, initialize to nothing.
+                double* sum_dmiu3_dxj = NULL, sum_dmiu3_dyj = NULL, sum_dmiu3_dzj = NULL;   // Pointer to int, initialize to nothing.
+
+                sum_dmiu1_dxj = new double[nneigh];  // Allocate n ints and save ptr in a.
+                sum_dmiu2_dxj = new double[nneigh];  // Allocate n ints and save ptr in a.
+                sum_dmiu3_dxj = new double[nneigh];  // Allocate n ints and save ptr in a.
+                sum_dmiu1_dyj = new double[nneigh];  // Allocate n ints and save ptr in a.
+                sum_dmiu2_dyj = new double[nneigh];  // Allocate n ints and save ptr in a.
+                sum_dmiu3_dyj = new double[nneigh];  // Allocate n ints and save ptr in a.
+                sum_dmiu1_dzj = new double[nneigh];  // Allocate n ints and save ptr in a.
+                sum_dmiu2_dzj = new double[nneigh];  // Allocate n ints and save ptr in a.
+                sum_dmiu3_dzj = new double[nneigh];  // Allocate n ints and save ptr in a.
+                for (int j=0; j<n; j++) {
+                    sum_dmiu1_dxj[j] = 0;    // Initialize all elements to zero.
+                    sum_dmiu1_dxj[j] = 0;    // Initialize all elements to zero.
+                    sum_dmiu1_dxj[j] = 0;    // Initialize all elements to zero.
+                    sum_dmiu1_dxj[j] = 0;    // Initialize all elements to zero.
+                    sum_dmiu1_dxj[j] = 0;    // Initialize all elements to zero.
+                    sum_dmiu1_dxj[j] = 0;    // Initialize all elements to zero.
+                    sum_dmiu1_dxj[j] = 0;    // Initialize all elements to zero.
+                    sum_dmiu1_dxj[j] = 0;    // Initialize all elements to zero.
+                    sum_dmiu1_dxj[j] = 0;    // Initialize all elements to zero.  
+                }
+                
+
+
                 double miu[3], deriv[9];
                 for (int j = 0; j < nneigh; ++j) {
                     int neigh_atom_element_index = nei_list_i[j*2];
@@ -271,19 +300,17 @@ extern "C" int calculate_atomistic_mcsh(double** cell, double** cart, double** s
                         sum_dmiu3_dzj[j] += deriv[8];
                     }
                 }
-                // M = sqrt(sum_miu1*sum_miu1 + sum_miu2*sum_miu2 + sum_miu3*sum_miu3);
-                M = sum_miu1*sum_miu1 + sum_miu2*sum_miu2 + sum_miu3*sum_miu3;
+                M = sqrt(sum_miu1*sum_miu1 + sum_miu2*sum_miu2 + sum_miu3*sum_miu3);
+                // M = sum_miu1*sum_miu1 + sum_miu2*sum_miu2 + sum_miu3*sum_miu3;
                 double dMdx, dMdy, dMdz;
                 for (int j = 0; j < nneigh; ++j) {
-                    // dMdx = (1.0/M) * (sum_miu1 * sum_dmiu1_dxj[j] + sum_miu2 * sum_dmiu2_dxj[j] + sum_miu3 * sum_dmiu3_dxj[j]) * weight;
-                    // dMdy = (1.0/M) * (sum_miu1 * sum_dmiu1_dyj[j] + sum_miu2 * sum_dmiu2_dyj[j] + sum_miu3 * sum_dmiu3_dyj[j]) * weight;
-                    // dMdz = (1.0/M) * (sum_miu1 * sum_dmiu1_dzj[j] + sum_miu2 * sum_dmiu2_dzj[j] + sum_miu3 * sum_dmiu3_dzj[j]) * weight;
+                    dMdx = (1.0/M) * (sum_miu1 * sum_dmiu1_dxj[j] + sum_miu2 * sum_dmiu2_dxj[j] + sum_miu3 * sum_dmiu3_dxj[j]) * weight;
+                    dMdy = (1.0/M) * (sum_miu1 * sum_dmiu1_dyj[j] + sum_miu2 * sum_dmiu2_dyj[j] + sum_miu3 * sum_dmiu3_dyj[j]) * weight;
+                    dMdz = (1.0/M) * (sum_miu1 * sum_dmiu1_dzj[j] + sum_miu2 * sum_dmiu2_dzj[j] + sum_miu3 * sum_dmiu3_dzj[j]) * weight;
                     // dMdx = 2.0 * (sum_miu1 * sum_dmiu1_dxj[j] + sum_miu2 * sum_dmiu2_dxj[j] + sum_miu3 * sum_dmiu3_dxj[j]) * weight;
                     // dMdy = 2.0 * (sum_miu1 * sum_dmiu1_dyj[j] + sum_miu2 * sum_dmiu2_dyj[j] + sum_miu3 * sum_dmiu3_dyj[j]) * weight;
                     // dMdz = 2.0 * (sum_miu1 * sum_dmiu1_dzj[j] + sum_miu2 * sum_dmiu2_dzj[j] + sum_miu3 * sum_dmiu3_dzj[j]) * weight;
-                    dMdx = 2.0 * (sum_miu1);
-                    dMdy = 2.0 * (sum_miu1);
-                    dMdz = 2.0 * (sum_miu1);
+
                     dmcsh[ii*nmcsh + m][nei_list_i[j*2 + 1]*3] += dMdx;
                     dmcsh[ii*nmcsh + m][nei_list_i[j*2 + 1]*3 + 1] += dMdy;
                     dmcsh[ii*nmcsh + m][nei_list_i[j*2 + 1]*3 + 2] += dMdz;
@@ -294,6 +321,16 @@ extern "C" int calculate_atomistic_mcsh(double** cell, double** cart, double** s
                 }
                 M = M * weight;
                 mcsh[ii][m] += M;
+
+                delete [] sum_dmiu1_dxj;
+                delete [] sum_dmiu2_dxj; 
+                delete [] sum_dmiu3_dxj; 
+                delete [] sum_dmiu1_dyj; 
+                delete [] sum_dmiu2_dyj; 
+                delete [] sum_dmiu3_dyj; 
+                delete [] sum_dmiu1_dzj; 
+                delete [] sum_dmiu2_dzj; 
+                delete [] sum_dmiu3_dzj; 
             }
 
             if (mcsh_type == 3){

--- a/amptorch/descriptor/MCSH/calculate_atomistic_mcsh.cpp
+++ b/amptorch/descriptor/MCSH/calculate_atomistic_mcsh.cpp
@@ -203,7 +203,7 @@ extern "C" int calculate_atomistic_mcsh(double** cell, double** cart, double** s
 
             // params_d: sigma, weight, A, beta, cutoff
             double A = params_d[m][2], beta = params_d[m][3];
-            double weight = 1.0 
+            double weight = 1.0;
             //weight = params_d[m][1]; 
             double M = 0;
             if (mcsh_type == 1){

--- a/amptorch/descriptor/MCSH/calculate_atomistic_mcsh.cpp
+++ b/amptorch/descriptor/MCSH/calculate_atomistic_mcsh.cpp
@@ -203,8 +203,8 @@ extern "C" int calculate_atomistic_mcsh(double** cell, double** cart, double** s
 
             // params_d: sigma, weight, A, beta, cutoff
             double A = params_d[m][2], beta = params_d[m][3];
-            // double weight = 1.0;
-            double weight = params_d[m][1]; 
+            double weight = 1.0;
+            // double weight = params_d[m][1]; 
             double M = 0;
             if (mcsh_type == 1){
                 double m_desc[1], deriv[3];

--- a/amptorch/descriptor/MCSH/calculate_atomistic_mcsh.cpp
+++ b/amptorch/descriptor/MCSH/calculate_atomistic_mcsh.cpp
@@ -274,13 +274,13 @@ extern "C" int calculate_atomistic_mcsh(double** cell, double** cart, double** s
                     dMdx = (1/M) * (sum_miu1 * sum_dmiu1_dxj[j] + sum_miu2 * sum_dmiu2_dxj[j] + sum_miu3 * sum_dmiu3_dxj[j]) * weight;
                     dMdy = (1/M) * (sum_miu1 * sum_dmiu1_dyj[j] + sum_miu2 * sum_dmiu2_dyj[j] + sum_miu3 * sum_dmiu3_dyj[j]) * weight;
                     dMdz = (1/M) * (sum_miu1 * sum_dmiu1_dzj[j] + sum_miu2 * sum_dmiu2_dzj[j] + sum_miu3 * sum_dmiu3_dzj[j]) * weight;
-                    // dmcsh[ii*nmcsh + m][nei_list_i[j*2 + 1]*3] += dMdx;
-                    // dmcsh[ii*nmcsh + m][nei_list_i[j*2 + 1]*3 + 1] += dMdy;
-                    // dmcsh[ii*nmcsh + m][nei_list_i[j*2 + 1]*3 + 2] += dMdz;
+                    dmcsh[ii*nmcsh + m][nei_list_i[j*2 + 1]*3] += dMdx;
+                    dmcsh[ii*nmcsh + m][nei_list_i[j*2 + 1]*3 + 1] += dMdy;
+                    dmcsh[ii*nmcsh + m][nei_list_i[j*2 + 1]*3 + 2] += dMdz;
 
-                    // dmcsh[ii*nmcsh + m][i*3]     -= dMdx;
-                    // dmcsh[ii*nmcsh + m][i*3 + 1] -= dMdy;
-                    // dmcsh[ii*nmcsh + m][i*3 + 2] -= dMdz;
+                    dmcsh[ii*nmcsh + m][i*3]     -= dMdx;
+                    dmcsh[ii*nmcsh + m][i*3 + 1] -= dMdy;
+                    dmcsh[ii*nmcsh + m][i*3 + 2] -= dMdz;
                 }
                 M = M * weight;
                 mcsh[ii][m] += M;

--- a/amptorch/descriptor/MCSH/calculate_atomistic_mcsh.cpp
+++ b/amptorch/descriptor/MCSH/calculate_atomistic_mcsh.cpp
@@ -271,9 +271,9 @@ extern "C" int calculate_atomistic_mcsh(double** cell, double** cart, double** s
                 M = sqrt(sum_miu1*sum_miu1 + sum_miu2*sum_miu2 + sum_miu3*sum_miu3);
                 double dMdx, dMdy, dMdz;
                 for (int j = 0; j < nneigh; ++j) {
-                    dMdx = (1/M) * (sum_miu1 * sum_dmiu1_dxj[j] + sum_miu2 * sum_dmiu2_dxj[j] + sum_miu3 * sum_dmiu3_dxj[j]) * weight;
-                    dMdy = (1/M) * (sum_miu1 * sum_dmiu1_dyj[j] + sum_miu2 * sum_dmiu2_dyj[j] + sum_miu3 * sum_dmiu3_dyj[j]) * weight;
-                    dMdz = (1/M) * (sum_miu1 * sum_dmiu1_dzj[j] + sum_miu2 * sum_dmiu2_dzj[j] + sum_miu3 * sum_dmiu3_dzj[j]) * weight;
+                    dMdx = (1.0/M) * (sum_miu1 * sum_dmiu1_dxj[j] + sum_miu2 * sum_dmiu2_dxj[j] + sum_miu3 * sum_dmiu3_dxj[j]) * weight;
+                    dMdy = (1.0/M) * (sum_miu1 * sum_dmiu1_dyj[j] + sum_miu2 * sum_dmiu2_dyj[j] + sum_miu3 * sum_dmiu3_dyj[j]) * weight;
+                    dMdz = (1.0/M) * (sum_miu1 * sum_dmiu1_dzj[j] + sum_miu2 * sum_dmiu2_dzj[j] + sum_miu3 * sum_dmiu3_dzj[j]) * weight;
                     dmcsh[ii*nmcsh + m][nei_list_i[j*2 + 1]*3] += dMdx;
                     dmcsh[ii*nmcsh + m][nei_list_i[j*2 + 1]*3 + 1] += dMdy;
                     dmcsh[ii*nmcsh + m][nei_list_i[j*2 + 1]*3 + 2] += dMdz;

--- a/amptorch/descriptor/MCSH/calculate_atomistic_mcsh.cpp
+++ b/amptorch/descriptor/MCSH/calculate_atomistic_mcsh.cpp
@@ -223,9 +223,9 @@ extern "C" int calculate_atomistic_mcsh(double** cell, double** cart, double** s
                         dMdy += deriv[1];
                         dMdz += deriv[2];
                     }
-                    // dMdx = dMdx * weight;
-                    // dMdy = dMdy * weight;
-                    // dMdz = dMdz * weight;
+                    dMdx = dMdx * weight;
+                    dMdy = dMdy * weight;
+                    dMdz = dMdz * weight;
                     dMdx = 2.0 * M * dMdx * weight;
                     dMdy = 2.0 * M * dMdy * weight;
                     dMdz = 2.0 * M * dMdz * weight;
@@ -237,8 +237,8 @@ extern "C" int calculate_atomistic_mcsh(double** cell, double** cart, double** s
                     dmcsh[ii*nmcsh + m][i*3 + 1] -= dMdy;
                     dmcsh[ii*nmcsh + m][i*3 + 2] -= dMdz;
                 }
-                // M = M * weight;
-                M = M * M * weight;
+                M = M * weight;
+                // M = M * M * weight;
                 mcsh[ii][m] += M;
             }
 
@@ -290,16 +290,16 @@ extern "C" int calculate_atomistic_mcsh(double** cell, double** cart, double** s
                         sum_dmiu3_dzj[j] += deriv[8];
                     }
                 }
-                // M = sqrt(sum_miu1*sum_miu1 + sum_miu2*sum_miu2 + sum_miu3*sum_miu3);
-                M = sum_miu1*sum_miu1 + sum_miu2*sum_miu2 + sum_miu3*sum_miu3;
+                M = sqrt(sum_miu1*sum_miu1 + sum_miu2*sum_miu2 + sum_miu3*sum_miu3);
+                // M = sum_miu1*sum_miu1 + sum_miu2*sum_miu2 + sum_miu3*sum_miu3;
                 double dMdx, dMdy, dMdz;
                 for (int j = 0; j < nneigh; ++j) {
-                    // dMdx = (1.0/M) * (sum_miu1 * sum_dmiu1_dxj[j] + sum_miu2 * sum_dmiu2_dxj[j] + sum_miu3 * sum_dmiu3_dxj[j]) * weight;
-                    // dMdy = (1.0/M) * (sum_miu1 * sum_dmiu1_dyj[j] + sum_miu2 * sum_dmiu2_dyj[j] + sum_miu3 * sum_dmiu3_dyj[j]) * weight;
-                    // dMdz = (1.0/M) * (sum_miu1 * sum_dmiu1_dzj[j] + sum_miu2 * sum_dmiu2_dzj[j] + sum_miu3 * sum_dmiu3_dzj[j]) * weight;
-                    dMdx = 2.0 * (sum_miu1 * sum_dmiu1_dxj[j] + sum_miu2 * sum_dmiu2_dxj[j] + sum_miu3 * sum_dmiu3_dxj[j]) * weight;
-                    dMdy = 2.0 * (sum_miu1 * sum_dmiu1_dyj[j] + sum_miu2 * sum_dmiu2_dyj[j] + sum_miu3 * sum_dmiu3_dyj[j]) * weight;
-                    dMdz = 2.0 * (sum_miu1 * sum_dmiu1_dzj[j] + sum_miu2 * sum_dmiu2_dzj[j] + sum_miu3 * sum_dmiu3_dzj[j]) * weight;
+                    dMdx = (1.0/M) * (sum_miu1 * sum_dmiu1_dxj[j] + sum_miu2 * sum_dmiu2_dxj[j] + sum_miu3 * sum_dmiu3_dxj[j]) * weight;
+                    dMdy = (1.0/M) * (sum_miu1 * sum_dmiu1_dyj[j] + sum_miu2 * sum_dmiu2_dyj[j] + sum_miu3 * sum_dmiu3_dyj[j]) * weight;
+                    dMdz = (1.0/M) * (sum_miu1 * sum_dmiu1_dzj[j] + sum_miu2 * sum_dmiu2_dzj[j] + sum_miu3 * sum_dmiu3_dzj[j]) * weight;
+                    // dMdx = 2.0 * (sum_miu1 * sum_dmiu1_dxj[j] + sum_miu2 * sum_dmiu2_dxj[j] + sum_miu3 * sum_dmiu3_dxj[j]) * weight;
+                    // dMdy = 2.0 * (sum_miu1 * sum_dmiu1_dyj[j] + sum_miu2 * sum_dmiu2_dyj[j] + sum_miu3 * sum_dmiu3_dyj[j]) * weight;
+                    // dMdz = 2.0 * (sum_miu1 * sum_dmiu1_dzj[j] + sum_miu2 * sum_dmiu2_dzj[j] + sum_miu3 * sum_dmiu3_dzj[j]) * weight;
 
                     dmcsh[ii*nmcsh + m][nei_list_i[j*2 + 1]*3] += dMdx;
                     dmcsh[ii*nmcsh + m][nei_list_i[j*2 + 1]*3 + 1] += dMdy;
@@ -401,35 +401,35 @@ extern "C" int calculate_atomistic_mcsh(double** cell, double** cart, double** s
                         sum_dmiu6_dzj[j] += deriv[17];
                     }
                 }
-                // M = sqrt(sum_miu1*sum_miu1 + sum_miu2*sum_miu2 + sum_miu3*sum_miu3 +
-                //          sum_miu4*sum_miu4 + sum_miu5*sum_miu5 + sum_miu6*sum_miu6);
-                M = sum_miu1*sum_miu1 + sum_miu2*sum_miu2 + sum_miu3*sum_miu3 +
-                    sum_miu4*sum_miu4 + sum_miu5*sum_miu5 + sum_miu6*sum_miu6;
+                M = sqrt(sum_miu1*sum_miu1 + sum_miu2*sum_miu2 + sum_miu3*sum_miu3 +
+                         sum_miu4*sum_miu4 + sum_miu5*sum_miu5 + sum_miu6*sum_miu6);
+                // M = sum_miu1*sum_miu1 + sum_miu2*sum_miu2 + sum_miu3*sum_miu3 +
+                //     sum_miu4*sum_miu4 + sum_miu5*sum_miu5 + sum_miu6*sum_miu6;
                 double dMdx, dMdy, dMdz;
                 for (int j = 0; j < nneigh; ++j) {
-                    // dMdx = (1.0/M) * (sum_miu1 * sum_dmiu1_dxj[j] + sum_miu2 * sum_dmiu2_dxj[j] + 
-                    //                 sum_miu3 * sum_dmiu3_dxj[j] + sum_miu4 * sum_dmiu4_dxj[j] + 
-                    //                 sum_miu5 * sum_dmiu5_dxj[j] + sum_miu6 * sum_dmiu6_dxj[j]) * weight;
-
-                    // dMdy = (1.0/M) * (sum_miu1 * sum_dmiu1_dyj[j] + sum_miu2 * sum_dmiu2_dyj[j] + 
-                    //                 sum_miu3 * sum_dmiu3_dyj[j] + sum_miu4 * sum_dmiu4_dyj[j] + 
-                    //                 sum_miu5 * sum_dmiu5_dyj[j] + sum_miu6 * sum_dmiu6_dyj[j]) * weight;
-
-                    // dMdz = (1.0/M) * (sum_miu1 * sum_dmiu1_dzj[j] + sum_miu2 * sum_dmiu2_dzj[j] + 
-                    //                 sum_miu3 * sum_dmiu3_dzj[j] + sum_miu4 * sum_dmiu4_dzj[j] + 
-                    //                 sum_miu5 * sum_dmiu5_dzj[j] + sum_miu6 * sum_dmiu6_dzj[j]) * weight;
-
-                    dMdx = (2.0) * (sum_miu1 * sum_dmiu1_dxj[j] + sum_miu2 * sum_dmiu2_dxj[j] + 
+                    dMdx = (1.0/M) * (sum_miu1 * sum_dmiu1_dxj[j] + sum_miu2 * sum_dmiu2_dxj[j] + 
                                     sum_miu3 * sum_dmiu3_dxj[j] + sum_miu4 * sum_dmiu4_dxj[j] + 
                                     sum_miu5 * sum_dmiu5_dxj[j] + sum_miu6 * sum_dmiu6_dxj[j]) * weight;
 
-                    dMdy = (2.0) * (sum_miu1 * sum_dmiu1_dyj[j] + sum_miu2 * sum_dmiu2_dyj[j] + 
+                    dMdy = (1.0/M) * (sum_miu1 * sum_dmiu1_dyj[j] + sum_miu2 * sum_dmiu2_dyj[j] + 
                                     sum_miu3 * sum_dmiu3_dyj[j] + sum_miu4 * sum_dmiu4_dyj[j] + 
                                     sum_miu5 * sum_dmiu5_dyj[j] + sum_miu6 * sum_dmiu6_dyj[j]) * weight;
 
-                    dMdz = (2.0) * (sum_miu1 * sum_dmiu1_dzj[j] + sum_miu2 * sum_dmiu2_dzj[j] + 
+                    dMdz = (1.0/M) * (sum_miu1 * sum_dmiu1_dzj[j] + sum_miu2 * sum_dmiu2_dzj[j] + 
                                     sum_miu3 * sum_dmiu3_dzj[j] + sum_miu4 * sum_dmiu4_dzj[j] + 
                                     sum_miu5 * sum_dmiu5_dzj[j] + sum_miu6 * sum_dmiu6_dzj[j]) * weight;
+
+                    // dMdx = (2.0) * (sum_miu1 * sum_dmiu1_dxj[j] + sum_miu2 * sum_dmiu2_dxj[j] + 
+                    //                 sum_miu3 * sum_dmiu3_dxj[j] + sum_miu4 * sum_dmiu4_dxj[j] + 
+                    //                 sum_miu5 * sum_dmiu5_dxj[j] + sum_miu6 * sum_dmiu6_dxj[j]) * weight;
+
+                    // dMdy = (2.0) * (sum_miu1 * sum_dmiu1_dyj[j] + sum_miu2 * sum_dmiu2_dyj[j] + 
+                    //                 sum_miu3 * sum_dmiu3_dyj[j] + sum_miu4 * sum_dmiu4_dyj[j] + 
+                    //                 sum_miu5 * sum_dmiu5_dyj[j] + sum_miu6 * sum_dmiu6_dyj[j]) * weight;
+
+                    // dMdz = (2.0) * (sum_miu1 * sum_dmiu1_dzj[j] + sum_miu2 * sum_dmiu2_dzj[j] + 
+                    //                 sum_miu3 * sum_dmiu3_dzj[j] + sum_miu4 * sum_dmiu4_dzj[j] + 
+                    //                 sum_miu5 * sum_dmiu5_dzj[j] + sum_miu6 * sum_dmiu6_dzj[j]) * weight;
 
                     dmcsh[ii*nmcsh + m][nei_list_i[j*2 + 1]*3] += dMdx;
                     dmcsh[ii*nmcsh + m][nei_list_i[j*2 + 1]*3 + 1] += dMdy;

--- a/amptorch/descriptor/MCSH/calculate_atomistic_mcsh.cpp
+++ b/amptorch/descriptor/MCSH/calculate_atomistic_mcsh.cpp
@@ -223,9 +223,9 @@ extern "C" int calculate_atomistic_mcsh(double** cell, double** cart, double** s
                         dMdy += deriv[1];
                         dMdz += deriv[2];
                     }
-                    dMdx = dMdx * weight;
-                    dMdy = dMdy * weight;
-                    dMdz = dMdz * weight;
+                    // dMdx = dMdx * weight;
+                    // dMdy = dMdy * weight;
+                    // dMdz = dMdz * weight;
                     dMdx = 2.0 * M * dMdx * weight;
                     dMdy = 2.0 * M * dMdy * weight;
                     dMdz = 2.0 * M * dMdz * weight;
@@ -237,8 +237,8 @@ extern "C" int calculate_atomistic_mcsh(double** cell, double** cart, double** s
                     dmcsh[ii*nmcsh + m][i*3 + 1] -= dMdy;
                     dmcsh[ii*nmcsh + m][i*3 + 2] -= dMdz;
                 }
-                M = M * weight;
-                // M = M * M * weight;
+                // M = M * weight;
+                M = M * M * weight;
                 mcsh[ii][m] += M;
             }
 

--- a/amptorch/descriptor/MCSH/calculate_atomistic_mcsh.cpp
+++ b/amptorch/descriptor/MCSH/calculate_atomistic_mcsh.cpp
@@ -241,25 +241,25 @@ extern "C" int calculate_atomistic_mcsh(double** cell, double** cart, double** s
             if (mcsh_type == 2){
                 double sum_miu1 = 0, sum_miu2 = 0, sum_miu3 = 0;
 
-                double* sum_dmiu1_dxj = new double[nneigh];  // Allocate n ints and save ptr in a.
-                double* sum_dmiu2_dxj = new double[nneigh];  // Allocate n ints and save ptr in a.
-                double* sum_dmiu3_dxj = new double[nneigh];  // Allocate n ints and save ptr in a.
-                double* sum_dmiu1_dyj = new double[nneigh];  // Allocate n ints and save ptr in a.
-                double* sum_dmiu2_dyj = new double[nneigh];  // Allocate n ints and save ptr in a.
-                double* sum_dmiu3_dyj = new double[nneigh];  // Allocate n ints and save ptr in a.
-                double* sum_dmiu1_dzj = new double[nneigh];  // Allocate n ints and save ptr in a.
-                double* sum_dmiu2_dzj = new double[nneigh];  // Allocate n ints and save ptr in a.
-                double* sum_dmiu3_dzj = new double[nneigh];  // Allocate n ints and save ptr in a.
+                double* sum_dmiu1_dxj = new double[nneigh];
+                double* sum_dmiu2_dxj = new double[nneigh];
+                double* sum_dmiu3_dxj = new double[nneigh];
+                double* sum_dmiu1_dyj = new double[nneigh];
+                double* sum_dmiu2_dyj = new double[nneigh];
+                double* sum_dmiu3_dyj = new double[nneigh];
+                double* sum_dmiu1_dzj = new double[nneigh];
+                double* sum_dmiu2_dzj = new double[nneigh];
+                double* sum_dmiu3_dzj = new double[nneigh];
                 for (int j=0; j<nneigh; j++) {
-                    sum_dmiu1_dxj[j] = 0;    // Initialize all elements to zero.
-                    sum_dmiu2_dxj[j] = 0;    // Initialize all elements to zero.
-                    sum_dmiu3_dxj[j] = 0;    // Initialize all elements to zero.
-                    sum_dmiu1_dyj[j] = 0;    // Initialize all elements to zero.
-                    sum_dmiu2_dyj[j] = 0;    // Initialize all elements to zero.
-                    sum_dmiu3_dyj[j] = 0;    // Initialize all elements to zero.
-                    sum_dmiu1_dzj[j] = 0;    // Initialize all elements to zero.
-                    sum_dmiu2_dzj[j] = 0;    // Initialize all elements to zero.
-                    sum_dmiu3_dzj[j] = 0;    // Initialize all elements to zero.  
+                    sum_dmiu1_dxj[j] = 0;
+                    sum_dmiu2_dxj[j] = 0;
+                    sum_dmiu3_dxj[j] = 0;
+                    sum_dmiu1_dyj[j] = 0;
+                    sum_dmiu2_dyj[j] = 0;
+                    sum_dmiu3_dyj[j] = 0;
+                    sum_dmiu1_dzj[j] = 0;
+                    sum_dmiu2_dzj[j] = 0;
+                    sum_dmiu3_dzj[j] = 0;  
                 }
 
                 double miu[3], deriv[9];
@@ -322,50 +322,43 @@ extern "C" int calculate_atomistic_mcsh(double** cell, double** cart, double** s
             if (mcsh_type == 3){
                 double sum_miu1 = 0, sum_miu2 = 0, sum_miu3 = 0, sum_miu4 = 0, sum_miu5 = 0, sum_miu6 = 0;
 
-                double sum_dmiu1_dxj[nneigh], sum_dmiu1_dyj[nneigh], sum_dmiu1_dzj[nneigh];
-                double sum_dmiu2_dxj[nneigh], sum_dmiu2_dyj[nneigh], sum_dmiu2_dzj[nneigh];
-                double sum_dmiu3_dxj[nneigh], sum_dmiu3_dyj[nneigh], sum_dmiu3_dzj[nneigh];
-                double sum_dmiu4_dxj[nneigh], sum_dmiu4_dyj[nneigh], sum_dmiu4_dzj[nneigh];
-                double sum_dmiu5_dxj[nneigh], sum_dmiu5_dyj[nneigh], sum_dmiu5_dzj[nneigh];
-                double sum_dmiu6_dxj[nneigh], sum_dmiu6_dyj[nneigh], sum_dmiu6_dzj[nneigh];
-
-                double* sum_dmiu1_dxj = new double[nneigh];  // Allocate n ints and save ptr in a.
-                double* sum_dmiu2_dxj = new double[nneigh];  // Allocate n ints and save ptr in a.
-                double* sum_dmiu3_dxj = new double[nneigh];  // Allocate n ints and save ptr in a.
-                double* sum_dmiu4_dxj = new double[nneigh];  // Allocate n ints and save ptr in a.
-                double* sum_dmiu5_dxj = new double[nneigh];  // Allocate n ints and save ptr in a.
-                double* sum_dmiu6_dxj = new double[nneigh];  // Allocate n ints and save ptr in a.
-                double* sum_dmiu1_dyj = new double[nneigh];  // Allocate n ints and save ptr in a.
-                double* sum_dmiu2_dyj = new double[nneigh];  // Allocate n ints and save ptr in a.
-                double* sum_dmiu3_dyj = new double[nneigh];  // Allocate n ints and save ptr in a.
-                double* sum_dmiu4_dyj = new double[nneigh];  // Allocate n ints and save ptr in a.
-                double* sum_dmiu5_dyj = new double[nneigh];  // Allocate n ints and save ptr in a.
-                double* sum_dmiu6_dyj = new double[nneigh];  // Allocate n ints and save ptr in a.
-                double* sum_dmiu1_dzj = new double[nneigh];  // Allocate n ints and save ptr in a.
-                double* sum_dmiu2_dzj = new double[nneigh];  // Allocate n ints and save ptr in a.
-                double* sum_dmiu3_dzj = new double[nneigh];  // Allocate n ints and save ptr in a.
-                double* sum_dmiu4_dzj = new double[nneigh];  // Allocate n ints and save ptr in a.
-                double* sum_dmiu5_dzj = new double[nneigh];  // Allocate n ints and save ptr in a.
-                double* sum_dmiu6_dzj = new double[nneigh];  // Allocate n ints and save ptr in a.
+                double* sum_dmiu1_dxj = new double[nneigh];
+                double* sum_dmiu2_dxj = new double[nneigh];
+                double* sum_dmiu3_dxj = new double[nneigh];
+                double* sum_dmiu4_dxj = new double[nneigh];
+                double* sum_dmiu5_dxj = new double[nneigh];
+                double* sum_dmiu6_dxj = new double[nneigh];
+                double* sum_dmiu1_dyj = new double[nneigh];
+                double* sum_dmiu2_dyj = new double[nneigh];
+                double* sum_dmiu3_dyj = new double[nneigh];
+                double* sum_dmiu4_dyj = new double[nneigh];
+                double* sum_dmiu5_dyj = new double[nneigh];
+                double* sum_dmiu6_dyj = new double[nneigh];
+                double* sum_dmiu1_dzj = new double[nneigh];
+                double* sum_dmiu2_dzj = new double[nneigh];
+                double* sum_dmiu3_dzj = new double[nneigh];
+                double* sum_dmiu4_dzj = new double[nneigh];
+                double* sum_dmiu5_dzj = new double[nneigh];
+                double* sum_dmiu6_dzj = new double[nneigh];
                 for (int j=0; j<nneigh; j++) {
-                    sum_dmiu1_dxj[j] = 0;    // Initialize all elements to zero.
-                    sum_dmiu2_dxj[j] = 0;    // Initialize all elements to zero.
-                    sum_dmiu3_dxj[j] = 0;    // Initialize all elements to zero.
-                    sum_dmiu4_dxj[j] = 0;    // Initialize all elements to zero.
-                    sum_dmiu5_dxj[j] = 0;    // Initialize all elements to zero.
-                    sum_dmiu6_dxj[j] = 0;    // Initialize all elements to zero.
-                    sum_dmiu1_dyj[j] = 0;    // Initialize all elements to zero.
-                    sum_dmiu2_dyj[j] = 0;    // Initialize all elements to zero.
-                    sum_dmiu3_dyj[j] = 0;    // Initialize all elements to zero. 
-                    sum_dmiu4_dyj[j] = 0;    // Initialize all elements to zero.
-                    sum_dmiu5_dyj[j] = 0;    // Initialize all elements to zero.
-                    sum_dmiu6_dyj[j] = 0;    // Initialize all elements to zero.
-                    sum_dmiu1_dzj[j] = 0;    // Initialize all elements to zero.
-                    sum_dmiu2_dzj[j] = 0;    // Initialize all elements to zero.
-                    sum_dmiu3_dzj[j] = 0;    // Initialize all elements to zero.
-                    sum_dmiu4_dzj[j] = 0;    // Initialize all elements to zero.
-                    sum_dmiu5_dzj[j] = 0;    // Initialize all elements to zero.
-                    sum_dmiu6_dzj[j] = 0;    // Initialize all elements to zero. 
+                    sum_dmiu1_dxj[j] = 0;
+                    sum_dmiu2_dxj[j] = 0;
+                    sum_dmiu3_dxj[j] = 0;
+                    sum_dmiu4_dxj[j] = 0;
+                    sum_dmiu5_dxj[j] = 0;
+                    sum_dmiu6_dxj[j] = 0;
+                    sum_dmiu1_dyj[j] = 0;
+                    sum_dmiu2_dyj[j] = 0;
+                    sum_dmiu3_dyj[j] = 0; 
+                    sum_dmiu4_dyj[j] = 0;
+                    sum_dmiu5_dyj[j] = 0;
+                    sum_dmiu6_dyj[j] = 0;
+                    sum_dmiu1_dzj[j] = 0;
+                    sum_dmiu2_dzj[j] = 0;
+                    sum_dmiu3_dzj[j] = 0;
+                    sum_dmiu4_dzj[j] = 0;
+                    sum_dmiu5_dzj[j] = 0;
+                    sum_dmiu6_dzj[j] = 0; 
                 }
 
                 double miu[6], deriv[18];

--- a/amptorch/descriptor/MCSH/calculate_atomistic_mcsh.cpp
+++ b/amptorch/descriptor/MCSH/calculate_atomistic_mcsh.cpp
@@ -241,9 +241,12 @@ extern "C" int calculate_atomistic_mcsh(double** cell, double** cart, double** s
             if (mcsh_type == 2){
                 double sum_miu1 = 0, sum_miu2 = 0, sum_miu3 = 0;
 
-                double sum_dmiu1_dxj[nneigh], sum_dmiu1_dyj[nneigh], sum_dmiu1_dzj[nneigh];
-                double sum_dmiu2_dxj[nneigh], sum_dmiu2_dyj[nneigh], sum_dmiu2_dzj[nneigh];
-                double sum_dmiu3_dxj[nneigh], sum_dmiu3_dyj[nneigh], sum_dmiu3_dzj[nneigh];
+                // double sum_dmiu1_dxj[nneigh], sum_dmiu1_dyj[nneigh], sum_dmiu1_dzj[nneigh];
+                // double sum_dmiu2_dxj[nneigh], sum_dmiu2_dyj[nneigh], sum_dmiu2_dzj[nneigh];
+                // double sum_dmiu3_dxj[nneigh], sum_dmiu3_dyj[nneigh], sum_dmiu3_dzj[nneigh];
+                double sum_dmiu1_dxj[20], sum_dmiu1_dyj[20], sum_dmiu1_dzj[20];
+                double sum_dmiu2_dxj[20], sum_dmiu2_dyj[20], sum_dmiu2_dzj[20];
+                double sum_dmiu3_dxj[20], sum_dmiu3_dyj[20], sum_dmiu3_dzj[20];
                 double miu[3], deriv[9];
                 for (int j = 0; j < nneigh; ++j) {
                     int neigh_atom_element_index = nei_list_i[j*2];

--- a/amptorch/descriptor/MCSH/calculate_atomistic_mcsh.cpp
+++ b/amptorch/descriptor/MCSH/calculate_atomistic_mcsh.cpp
@@ -203,8 +203,8 @@ extern "C" int calculate_atomistic_mcsh(double** cell, double** cart, double** s
 
             // params_d: sigma, weight, A, beta, cutoff
             double A = params_d[m][2], beta = params_d[m][3];
-            double weight = 1.0;
-            //weight = params_d[m][1]; 
+            // double weight = 1.0;
+            double weight = params_d[m][1]; 
             double M = 0;
             if (mcsh_type == 1){
                 double m_desc[1], deriv[3];
@@ -336,15 +336,15 @@ extern "C" int calculate_atomistic_mcsh(double** cell, double** cart, double** s
                          sum_miu4*sum_miu4 + sum_miu5*sum_miu5 + sum_miu6*sum_miu6);
                 double dMdx, dMdy, dMdz;
                 for (int j = 0; j < nneigh; ++j) {
-                    dMdx = (1/M) * (sum_miu1 * sum_dmiu1_dxj[j] + sum_miu2 * sum_dmiu2_dxj[j] + 
+                    dMdx = (1.0/M) * (sum_miu1 * sum_dmiu1_dxj[j] + sum_miu2 * sum_dmiu2_dxj[j] + 
                                     sum_miu3 * sum_dmiu3_dxj[j] + sum_miu4 * sum_dmiu4_dxj[j] + 
                                     sum_miu5 * sum_dmiu5_dxj[j] + sum_miu6 * sum_dmiu6_dxj[j]) * weight;
 
-                    dMdy = (1/M) * (sum_miu1 * sum_dmiu1_dyj[j] + sum_miu2 * sum_dmiu2_dyj[j] + 
+                    dMdy = (1.0/M) * (sum_miu1 * sum_dmiu1_dyj[j] + sum_miu2 * sum_dmiu2_dyj[j] + 
                                     sum_miu3 * sum_dmiu3_dyj[j] + sum_miu4 * sum_dmiu4_dyj[j] + 
                                     sum_miu5 * sum_dmiu5_dyj[j] + sum_miu6 * sum_dmiu6_dyj[j]) * weight;
 
-                    dMdz = (1/M) * (sum_miu1 * sum_dmiu1_dzj[j] + sum_miu2 * sum_dmiu2_dzj[j] + 
+                    dMdz = (1.0/M) * (sum_miu1 * sum_dmiu1_dzj[j] + sum_miu2 * sum_dmiu2_dzj[j] + 
                                     sum_miu3 * sum_dmiu3_dzj[j] + sum_miu4 * sum_dmiu4_dzj[j] + 
                                     sum_miu5 * sum_dmiu5_dzj[j] + sum_miu6 * sum_dmiu6_dzj[j]) * weight;
 

--- a/amptorch/descriptor/MCSH/calculate_atomistic_mcsh.cpp
+++ b/amptorch/descriptor/MCSH/calculate_atomistic_mcsh.cpp
@@ -27,7 +27,6 @@
     // params_d: sigma, weight, A, beta, cutoff
     // atom_gaussian: 2D array (dimension: [# atom types, # gaussian * 2]), i*2: B, i*2+1: alpha
     // ngaussian: number of gaussian for each atom type [n gaussian for type 1, n gaussian for type 2 ...]
-
 extern "C" int calculate_atomistic_mcsh(double** cell, double** cart, double** scale, int* pbc_bools,
                                         int* atom_i, int natoms, int* cal_atoms, int cal_num,
                                         int** params_i, double** params_d, int nmcsh, double** atom_gaussian, int* ngaussians, int* element_index_to_order,
@@ -210,7 +209,697 @@ extern "C" int calculate_atomistic_mcsh(double** cell, double** cart, double** s
                 double m_desc[1], deriv[3];
                 
                 for (int j = 0; j < nneigh; ++j) {
-                    double dMdx = 0, dMdy = 0, dMdz = 0;
+                    double dMdx = 0.0, dMdy = 0.0, dMdz = 0.0;
+
+                    int neigh_atom_element_index = nei_list_i[j*2];
+                    int neigh_atom_element_order = element_index_to_order[neigh_atom_element_index];
+                    double x0 = nei_list_d[j*4], y0 = nei_list_d[j*4+1], z0 = nei_list_d[j*4+2], r0_sqr = nei_list_d[j*4+3];
+                    for (int g = 0; g < ngaussians[neigh_atom_element_order]; ++g){
+                        double B = atom_gaussian[neigh_atom_element_order][g*2], alpha = atom_gaussian[neigh_atom_element_order][g*2+1];
+                        mcsh_function(x0, y0, z0, r0_sqr, A, B, alpha, beta, m_desc, deriv);
+                        M += m_desc[0];
+                        dMdx += deriv[0];
+                        dMdy += deriv[1];
+                        dMdz += deriv[2];
+                    }
+                    dMdx = dMdx * weight;
+                    dMdy = dMdy * weight;
+                    dMdz = dMdz * weight;
+
+                    dmcsh[ii*nmcsh + m][nei_list_i[j*2 + 1]*3] += dMdx;
+                    dmcsh[ii*nmcsh + m][nei_list_i[j*2 + 1]*3 + 1] += dMdy;
+                    dmcsh[ii*nmcsh + m][nei_list_i[j*2 + 1]*3 + 2] += dMdz;
+
+                    dmcsh[ii*nmcsh + m][i*3]     -= dMdx;
+                    dmcsh[ii*nmcsh + m][i*3 + 1] -= dMdy;
+                    dmcsh[ii*nmcsh + m][i*3 + 2] -= dMdz;
+                }
+                M = M * weight;
+                mcsh[ii][m] += M;
+            }
+
+            if (mcsh_type == 2){
+                double sum_miu1 = 0.0, sum_miu2 = 0.0, sum_miu3 = 0.0;
+
+                double* sum_dmiu1_dxj = new double[nneigh];
+                double* sum_dmiu2_dxj = new double[nneigh];
+                double* sum_dmiu3_dxj = new double[nneigh];
+                double* sum_dmiu1_dyj = new double[nneigh];
+                double* sum_dmiu2_dyj = new double[nneigh];
+                double* sum_dmiu3_dyj = new double[nneigh];
+                double* sum_dmiu1_dzj = new double[nneigh];
+                double* sum_dmiu2_dzj = new double[nneigh];
+                double* sum_dmiu3_dzj = new double[nneigh];
+                for (int j=0; j<nneigh; j++) {
+                    sum_dmiu1_dxj[j] = 0.0;
+                    sum_dmiu2_dxj[j] = 0.0;
+                    sum_dmiu3_dxj[j] = 0.0;
+                    sum_dmiu1_dyj[j] = 0.0;
+                    sum_dmiu2_dyj[j] = 0.0;
+                    sum_dmiu3_dyj[j] = 0.0;
+                    sum_dmiu1_dzj[j] = 0.0;
+                    sum_dmiu2_dzj[j] = 0.0;
+                    sum_dmiu3_dzj[j] = 0.0;  
+                }
+
+                double miu[3], deriv[9];
+                for (int j = 0; j < nneigh; ++j) {
+                    int neigh_atom_element_index = nei_list_i[j*2];
+                    int neigh_atom_element_order = element_index_to_order[neigh_atom_element_index];
+                    double x0 = nei_list_d[j*4], y0 = nei_list_d[j*4+1], z0 = nei_list_d[j*4+2], r0_sqr = nei_list_d[j*4+3];
+                    for (int g = 0; g < ngaussians[neigh_atom_element_order]; ++g){
+                        double B = atom_gaussian[neigh_atom_element_order][g*2], alpha = atom_gaussian[neigh_atom_element_order][g*2+1];
+                        mcsh_function(x0, y0, z0, r0_sqr, A, B, alpha, beta, miu, deriv);
+                        // miu: miu_1, miu_2, miu_3
+                        // deriv: dmiu1_dxj, dmiu1_dyj, dmiu1_dzj, dmiu2_dxj, dmiu2_dyj, dmiu2_dzj, dmiu3_dxj, dmiu3_dyj, dmiu3_dzj
+                        sum_miu1 += miu[0];
+                        sum_miu2 += miu[1];
+                        sum_miu3 += miu[2];
+                        sum_dmiu1_dxj[j] += deriv[0];
+                        sum_dmiu1_dyj[j] += deriv[1];
+                        sum_dmiu1_dzj[j] += deriv[2];
+                        sum_dmiu2_dxj[j] += deriv[3];
+                        sum_dmiu2_dyj[j] += deriv[4];
+                        sum_dmiu2_dzj[j] += deriv[5];
+                        sum_dmiu3_dxj[j] += deriv[6];
+                        sum_dmiu3_dyj[j] += deriv[7];
+                        sum_dmiu3_dzj[j] += deriv[8];
+                    }
+                }
+                // M = sqrt(sum_miu1*sum_miu1 + sum_miu2*sum_miu2 + sum_miu3*sum_miu3);
+                M = sum_miu1*sum_miu1 + sum_miu2*sum_miu2 + sum_miu3*sum_miu3;
+                double dMdx, dMdy, dMdz;
+                for (int j = 0; j < nneigh; ++j) {
+                    dMdx = (1.0/M) * (sum_miu1 * sum_dmiu1_dxj[j] + sum_miu2 * sum_dmiu2_dxj[j] + sum_miu3 * sum_dmiu3_dxj[j]) * weight;
+                    dMdy = (1.0/M) * (sum_miu1 * sum_dmiu1_dyj[j] + sum_miu2 * sum_dmiu2_dyj[j] + sum_miu3 * sum_dmiu3_dyj[j]) * weight;
+                    dMdz = (1.0/M) * (sum_miu1 * sum_dmiu1_dzj[j] + sum_miu2 * sum_dmiu2_dzj[j] + sum_miu3 * sum_dmiu3_dzj[j]) * weight;
+
+                    dmcsh[ii*nmcsh + m][nei_list_i[j*2 + 1]*3] += dMdx;
+                    dmcsh[ii*nmcsh + m][nei_list_i[j*2 + 1]*3 + 1] += dMdy;
+                    dmcsh[ii*nmcsh + m][nei_list_i[j*2 + 1]*3 + 2] += dMdz;
+
+                    dmcsh[ii*nmcsh + m][i*3]     -= dMdx;
+                    dmcsh[ii*nmcsh + m][i*3 + 1] -= dMdy;
+                    dmcsh[ii*nmcsh + m][i*3 + 2] -= dMdz;
+                }
+                M = M * weight;
+                mcsh[ii][m] += M;
+
+                delete [] sum_dmiu1_dxj;
+                delete [] sum_dmiu2_dxj; 
+                delete [] sum_dmiu3_dxj; 
+                delete [] sum_dmiu1_dyj; 
+                delete [] sum_dmiu2_dyj; 
+                delete [] sum_dmiu3_dyj; 
+                delete [] sum_dmiu1_dzj; 
+                delete [] sum_dmiu2_dzj; 
+                delete [] sum_dmiu3_dzj; 
+            }
+
+            if (mcsh_type == 3){
+                double sum_miu1 = 0.0, sum_miu2 = 0.0, sum_miu3 = 0.0, sum_miu4 = 0.0, sum_miu5 = 0.0, sum_miu6 = 0.0;
+
+                double* sum_dmiu1_dxj = new double[nneigh];
+                double* sum_dmiu2_dxj = new double[nneigh];
+                double* sum_dmiu3_dxj = new double[nneigh];
+                double* sum_dmiu4_dxj = new double[nneigh];
+                double* sum_dmiu5_dxj = new double[nneigh];
+                double* sum_dmiu6_dxj = new double[nneigh];
+                double* sum_dmiu1_dyj = new double[nneigh];
+                double* sum_dmiu2_dyj = new double[nneigh];
+                double* sum_dmiu3_dyj = new double[nneigh];
+                double* sum_dmiu4_dyj = new double[nneigh];
+                double* sum_dmiu5_dyj = new double[nneigh];
+                double* sum_dmiu6_dyj = new double[nneigh];
+                double* sum_dmiu1_dzj = new double[nneigh];
+                double* sum_dmiu2_dzj = new double[nneigh];
+                double* sum_dmiu3_dzj = new double[nneigh];
+                double* sum_dmiu4_dzj = new double[nneigh];
+                double* sum_dmiu5_dzj = new double[nneigh];
+                double* sum_dmiu6_dzj = new double[nneigh];
+                for (int j=0; j<nneigh; j++) {
+                    sum_dmiu1_dxj[j] = 0.0;
+                    sum_dmiu2_dxj[j] = 0.0;
+                    sum_dmiu3_dxj[j] = 0.0;
+                    sum_dmiu4_dxj[j] = 0.0;
+                    sum_dmiu5_dxj[j] = 0.0;
+                    sum_dmiu6_dxj[j] = 0.0;
+                    sum_dmiu1_dyj[j] = 0.0;
+                    sum_dmiu2_dyj[j] = 0.0;
+                    sum_dmiu3_dyj[j] = 0.0; 
+                    sum_dmiu4_dyj[j] = 0.0;
+                    sum_dmiu5_dyj[j] = 0.0;
+                    sum_dmiu6_dyj[j] = 0.0;
+                    sum_dmiu1_dzj[j] = 0.0;
+                    sum_dmiu2_dzj[j] = 0.0;
+                    sum_dmiu3_dzj[j] = 0.0;
+                    sum_dmiu4_dzj[j] = 0.0;
+                    sum_dmiu5_dzj[j] = 0.0;
+                    sum_dmiu6_dzj[j] = 0.0; 
+                }
+
+                double miu[6], deriv[18];
+                for (int j = 0; j < nneigh; ++j) {
+                    int neigh_atom_element_index = nei_list_i[j*2];
+                    int neigh_atom_element_order = element_index_to_order[neigh_atom_element_index];
+                    double x0 = nei_list_d[j*4], y0 = nei_list_d[j*4+1], z0 = nei_list_d[j*4+2], r0_sqr = nei_list_d[j*4+3];
+                    for (int g = 0; g < ngaussians[neigh_atom_element_order]; ++g){
+                        double B = atom_gaussian[neigh_atom_element_order][g*2], alpha = atom_gaussian[neigh_atom_element_order][g*2+1];
+                        mcsh_function(x0, y0, z0, r0_sqr, A, B, alpha, beta, miu, deriv);
+                        // miu: miu_1, miu_2, miu_3
+                        // deriv: dmiu1_dxj, dmiu1_dyj, dmiu1_dzj, dmiu2_dxj, dmiu2_dyj, dmiu2_dzj, dmiu3_dxj, dmiu3_dyj, dmiu3_dzj
+                        sum_miu1 += miu[0];
+                        sum_miu2 += miu[1];
+                        sum_miu3 += miu[2];
+                        sum_miu4 += miu[3];
+                        sum_miu5 += miu[4];
+                        sum_miu6 += miu[5];
+                        sum_dmiu1_dxj[j] += deriv[0];
+                        sum_dmiu1_dyj[j] += deriv[1];
+                        sum_dmiu1_dzj[j] += deriv[2];
+                        sum_dmiu2_dxj[j] += deriv[3];
+                        sum_dmiu2_dyj[j] += deriv[4];
+                        sum_dmiu2_dzj[j] += deriv[5];
+                        sum_dmiu3_dxj[j] += deriv[6];
+                        sum_dmiu3_dyj[j] += deriv[7];
+                        sum_dmiu3_dzj[j] += deriv[8];
+                        sum_dmiu4_dxj[j] += deriv[9];
+                        sum_dmiu4_dyj[j] += deriv[10];
+                        sum_dmiu4_dzj[j] += deriv[11];
+                        sum_dmiu5_dxj[j] += deriv[12];
+                        sum_dmiu5_dyj[j] += deriv[13];
+                        sum_dmiu5_dzj[j] += deriv[14];
+                        sum_dmiu6_dxj[j] += deriv[15];
+                        sum_dmiu6_dyj[j] += deriv[16];
+                        sum_dmiu6_dzj[j] += deriv[17];
+                    }
+                }
+                M = sqrt(sum_miu1*sum_miu1 + sum_miu2*sum_miu2 + sum_miu3*sum_miu3 +
+                         sum_miu4*sum_miu4 + sum_miu5*sum_miu5 + sum_miu6*sum_miu6);
+                double dMdx, dMdy, dMdz;
+                for (int j = 0; j < nneigh; ++j) {
+                    dMdx = (1.0/M) * (sum_miu1 * sum_dmiu1_dxj[j] + sum_miu2 * sum_dmiu2_dxj[j] + 
+                                    sum_miu3 * sum_dmiu3_dxj[j] + sum_miu4 * sum_dmiu4_dxj[j] + 
+                                    sum_miu5 * sum_dmiu5_dxj[j] + sum_miu6 * sum_dmiu6_dxj[j]) * weight;
+
+                    dMdy = (1.0/M) * (sum_miu1 * sum_dmiu1_dyj[j] + sum_miu2 * sum_dmiu2_dyj[j] + 
+                                    sum_miu3 * sum_dmiu3_dyj[j] + sum_miu4 * sum_dmiu4_dyj[j] + 
+                                    sum_miu5 * sum_dmiu5_dyj[j] + sum_miu6 * sum_dmiu6_dyj[j]) * weight;
+
+                    dMdz = (1.0/M) * (sum_miu1 * sum_dmiu1_dzj[j] + sum_miu2 * sum_dmiu2_dzj[j] + 
+                                    sum_miu3 * sum_dmiu3_dzj[j] + sum_miu4 * sum_dmiu4_dzj[j] + 
+                                    sum_miu5 * sum_dmiu5_dzj[j] + sum_miu6 * sum_dmiu6_dzj[j]) * weight;
+
+                    dmcsh[ii*nmcsh + m][nei_list_i[j*2 + 1]*3] += dMdx;
+                    dmcsh[ii*nmcsh + m][nei_list_i[j*2 + 1]*3 + 1] += dMdy;
+                    dmcsh[ii*nmcsh + m][nei_list_i[j*2 + 1]*3 + 2] += dMdz;
+
+                    dmcsh[ii*nmcsh + m][i*3]     -= dMdx;
+                    dmcsh[ii*nmcsh + m][i*3 + 1] -= dMdy;
+                    dmcsh[ii*nmcsh + m][i*3 + 2] -= dMdz;
+                }
+                M = M * weight;
+                mcsh[ii][m] += M;
+
+                delete [] sum_dmiu1_dxj;
+                delete [] sum_dmiu2_dxj; 
+                delete [] sum_dmiu3_dxj; 
+                delete [] sum_dmiu4_dxj; 
+                delete [] sum_dmiu5_dxj; 
+                delete [] sum_dmiu6_dxj; 
+                delete [] sum_dmiu1_dyj; 
+                delete [] sum_dmiu2_dyj; 
+                delete [] sum_dmiu3_dyj; 
+                delete [] sum_dmiu4_dyj;
+                delete [] sum_dmiu5_dyj; 
+                delete [] sum_dmiu6_dyj; 
+                delete [] sum_dmiu1_dzj; 
+                delete [] sum_dmiu2_dzj; 
+                delete [] sum_dmiu3_dzj; 
+                delete [] sum_dmiu4_dzj; 
+                delete [] sum_dmiu5_dzj; 
+                delete [] sum_dmiu6_dzj; 
+            }
+        }
+        delete[] nei_list_d;
+        delete[] nei_list_i;
+    }
+
+    for (int i=0; i<natoms; i++) {
+        delete[] bin_i[i];
+    }
+    return 0;
+}
+
+
+
+
+extern "C" int calculate_atomistic_mcsh_noderiv(double** cell, double** cart, double** scale, int* pbc_bools,
+                                        int* atom_i, int natoms, int* cal_atoms, int cal_num,
+                                        int** params_i, double** params_d, int nmcsh, double** atom_gaussian, int* ngaussians, int* element_index_to_order,
+                                        double** mcsh) {
+
+    int total_bins, max_atoms_bin, bin_num, neigh_check_bins, nneigh;
+    int bin_range[3], nbins[3], cell_shift[3], max_bin[3], min_bin[3], pbc_bin[3];
+    //int bin_i[natoms][4];
+    double vol, tmp, tmp_r2, cutoff, cutoff_sqr;
+    double plane_d[3], total_shift[3];
+    double cross[3][3], reci[3][3], inv[3][3];//, powtwo[nsyms];
+
+
+    // Check for not implemented mcsh type.
+    for (int m=0; m < nmcsh; ++m){
+        bool implemented = false;
+        for (int i=0; i < NUM_IMPLEMENTED_TYPE; i++) {
+            if (params_i[m][0] == IMPLEMENTED_MCSH_TYPE[i][0] && params_i[m][1] == IMPLEMENTED_MCSH_TYPE[i][1]) {
+                implemented = true;
+                break;
+            }
+        }
+        if (!implemented) return 1;
+    }
+
+    int **bin_i = new int*[natoms];
+    for (int i=0; i<natoms; i++) {
+        bin_i[i] = new int[4];
+    }
+
+
+    cutoff = 0.0;
+    // let cutoff equal to the maximum of Rc
+    for (int m = 0; m < nmcsh; ++m) {
+        if (cutoff < params_d[m][4])
+            cutoff = params_d[m][4];
+    }
+
+    cutoff_sqr = cutoff * cutoff;
+
+    total_bins = 1;
+
+    // calculate the inverse matrix of cell and the distance between cell plane
+    cross[0][0] = cell[1][1]*cell[2][2] - cell[1][2]*cell[2][1];
+    cross[0][1] = cell[1][2]*cell[2][0] - cell[1][0]*cell[2][2];
+    cross[0][2] = cell[1][0]*cell[2][1] - cell[1][1]*cell[2][0];
+    cross[1][0] = cell[2][1]*cell[0][2] - cell[2][2]*cell[0][1];
+    cross[1][1] = cell[2][2]*cell[0][0] - cell[2][0]*cell[0][2];
+    cross[1][2] = cell[2][0]*cell[0][1] - cell[2][1]*cell[0][0];
+    cross[2][0] = cell[0][1]*cell[1][2] - cell[0][2]*cell[1][1];
+    cross[2][1] = cell[0][2]*cell[1][0] - cell[0][0]*cell[1][2];
+    cross[2][2] = cell[0][0]*cell[1][1] - cell[0][1]*cell[1][0];
+
+    vol = cross[0][0]*cell[0][0] + cross[0][1]*cell[0][1] + cross[0][2]*cell[0][2];
+    inv[0][0] = cross[0][0]/vol;
+    inv[0][1] = cross[1][0]/vol;
+    inv[0][2] = cross[2][0]/vol;
+    inv[1][0] = cross[0][1]/vol;
+    inv[1][1] = cross[1][1]/vol;
+    inv[1][2] = cross[2][1]/vol;
+    inv[2][0] = cross[0][2]/vol;
+    inv[2][1] = cross[1][2]/vol;
+    inv[2][2] = cross[2][2]/vol;
+
+    // bin: number of repetitive cells?
+    for (int i=0; i<3; ++i) {
+        tmp = 0;
+        for (int j=0; j<3; ++j) {
+            reci[i][j] = cross[i][j]/vol;
+            tmp += reci[i][j]*reci[i][j];
+        }
+        plane_d[i] = 1/sqrt(tmp);
+        nbins[i] = ceil(plane_d[i]/cutoff);
+        total_bins *= nbins[i];
+    }
+
+    int *atoms_bin = new int[total_bins];
+    for (int i=0; i<total_bins; ++i)
+        atoms_bin[i] = 0;
+
+    // assign the bin index to each atom
+    for (int i=0; i<natoms; ++i) {
+        for (int j=0; j<3; ++j) {
+            bin_i[i][j] = scale[i][j] * (double) nbins[j];
+        }
+        bin_i[i][3] = bin_i[i][0] + nbins[0]*bin_i[i][1] + nbins[0]*nbins[1]*bin_i[i][2];
+        atoms_bin[bin_i[i][3]]++;
+    }
+
+    max_atoms_bin = 0;
+    for (int i=0; i < total_bins; ++i) {
+        if (atoms_bin[i] > max_atoms_bin)
+            max_atoms_bin = atoms_bin[i];
+    }
+
+    delete[] atoms_bin;
+
+    // # of bins in each direction
+    neigh_check_bins = 1;
+    for (int i=0; i < 3; ++i) {
+        bin_range[i] = ceil(cutoff * nbins[i] / plane_d[i]);
+        neigh_check_bins *= 2*bin_range[i];
+    }
+
+    //for (int i=0; i < natoms; ++i) {
+    for (int ii=0; ii < cal_num; ++ii) {
+        int i=cal_atoms[ii];
+        // calculate neighbor atoms
+        double* nei_list_d = new double[max_atoms_bin * 4 * neigh_check_bins];
+        int*    nei_list_i = new int[max_atoms_bin * 2 * neigh_check_bins];
+        nneigh = 0;
+
+        for (int j=0; j < 3; ++j) {
+            max_bin[j] = bin_i[i][j] + bin_range[j];
+            min_bin[j] = bin_i[i][j] - bin_range[j];
+        }
+
+        for (int dx=min_bin[0]; dx < max_bin[0]+1; ++dx) {
+            for (int dy=min_bin[1]; dy < max_bin[1]+1; ++dy) {
+                for (int dz=min_bin[2]; dz < max_bin[2]+1; ++dz) {
+                    pbc_bin[0] = (dx%nbins[0] + nbins[0]) % nbins[0];
+                    pbc_bin[1] = (dy%nbins[1] + nbins[1]) % nbins[1];
+                    pbc_bin[2] = (dz%nbins[2] + nbins[2]) % nbins[2];
+                    cell_shift[0] = (dx-pbc_bin[0]) / nbins[0];
+                    cell_shift[1] = (dy-pbc_bin[1]) / nbins[1];
+                    cell_shift[2] = (dz-pbc_bin[2]) / nbins[2];
+
+                    bin_num = pbc_bin[0] + nbins[0]*pbc_bin[1] + nbins[0]*nbins[1]*pbc_bin[2];
+
+                    for (int j=0; j < natoms; ++j) {
+                        if (bin_i[j][3] != bin_num)
+                            continue;
+
+                        // same atom
+                        // if (!(cell_shift[0] || cell_shift[1] || cell_shift[2]) && (i == j))
+                        //     continue;
+
+                        // take care of pbc
+                        if (!pbc_bools[0] && cell_shift[0] != 0)
+                            continue;
+                        
+                        if (!pbc_bools[1] && cell_shift[1] != 0)
+                            continue;
+
+                        if (!pbc_bools[2] && cell_shift[2] != 0)
+                            continue;
+
+                        for (int a=0; a < 3; ++a) {
+                            total_shift[a] = cell_shift[0]*cell[0][a] + cell_shift[1]*cell[1][a] + cell_shift[2]*cell[2][a]
+                                             + cart[j][a] - cart[i][a];
+                        }
+
+                        // tmp = sqrt(total_shift[0]*total_shift[0] + total_shift[1]*total_shift[1] + total_shift[2]*total_shift[2]);
+                        tmp_r2 = total_shift[0]*total_shift[0] + total_shift[1]*total_shift[1] + total_shift[2]*total_shift[2];
+
+                        // if (tmp < cutoff) {
+                        if (tmp_r2 < cutoff_sqr) {
+                            for (int a=0; a < 3; ++a)
+                                nei_list_d[nneigh*4 + a] = total_shift[a];
+                            nei_list_d[nneigh*4 + 3] = tmp_r2;
+                            nei_list_i[nneigh*2]    = atom_i[j];
+                            nei_list_i[nneigh*2 + 1] = j;
+                            nneigh++;
+                        }
+                    }
+                }
+            }
+        }
+
+        for (int m = 0; m < nmcsh; ++m) {
+            int mcsh_type = get_mcsh_type(params_i[m][0], params_i[m][1]);
+            AtomisticMCSHFunctionNoderiv mcsh_function = get_mcsh_function_noderiv(params_i[m][0], params_i[m][1]);
+
+            // params_d: sigma, weight, A, beta, cutoff
+            double A = params_d[m][2], beta = params_d[m][3];
+            double weight = 1.0;
+            // double weight = params_d[m][1]; 
+            double M = 0.0;
+            if (mcsh_type == 1){
+                double m_desc[1], deriv[3];
+                
+                for (int j = 0; j < nneigh; ++j) {
+
+                    int neigh_atom_element_index = nei_list_i[j*2];
+                    int neigh_atom_element_order = element_index_to_order[neigh_atom_element_index];
+                    double x0 = nei_list_d[j*4], y0 = nei_list_d[j*4+1], z0 = nei_list_d[j*4+2], r0_sqr = nei_list_d[j*4+3];
+                    for (int g = 0; g < ngaussians[neigh_atom_element_order]; ++g){
+                        double B = atom_gaussian[neigh_atom_element_order][g*2], alpha = atom_gaussian[neigh_atom_element_order][g*2+1];
+                        mcsh_function(x0, y0, z0, r0_sqr, A, B, alpha, beta, m_desc);
+                        M += m_desc[0];
+                    }
+                }
+                M = M * weight;
+                mcsh[ii][m] += M;
+            }
+
+            if (mcsh_type == 2){
+                double sum_miu1 = 0.0, sum_miu2 = 0.0, sum_miu3 = 0.0;
+
+                double miu[3], deriv[9];
+                for (int j = 0; j < nneigh; ++j) {
+                    int neigh_atom_element_index = nei_list_i[j*2];
+                    int neigh_atom_element_order = element_index_to_order[neigh_atom_element_index];
+                    double x0 = nei_list_d[j*4], y0 = nei_list_d[j*4+1], z0 = nei_list_d[j*4+2], r0_sqr = nei_list_d[j*4+3];
+                    for (int g = 0; g < ngaussians[neigh_atom_element_order]; ++g){
+                        double B = atom_gaussian[neigh_atom_element_order][g*2], alpha = atom_gaussian[neigh_atom_element_order][g*2+1];
+                        mcsh_function(x0, y0, z0, r0_sqr, A, B, alpha, beta, miu);
+                        // miu: miu_1, miu_2, miu_3
+                        // deriv: dmiu1_dxj, dmiu1_dyj, dmiu1_dzj, dmiu2_dxj, dmiu2_dyj, dmiu2_dzj, dmiu3_dxj, dmiu3_dyj, dmiu3_dzj
+                        sum_miu1 += miu[0];
+                        sum_miu2 += miu[1];
+                        sum_miu3 += miu[2];
+                    }
+                }
+                M = sqrt(sum_miu1*sum_miu1 + sum_miu2*sum_miu2 + sum_miu3*sum_miu3);
+                M = M * weight;
+                mcsh[ii][m] += M;
+            }
+
+            if (mcsh_type == 3){
+                double sum_miu1 = 0.0, sum_miu2 = 0.0, sum_miu3 = 0.0, sum_miu4 = 0.0, sum_miu5 = 0.0, sum_miu6 = 0.0;
+
+                double miu[6], deriv[18];
+                for (int j = 0; j < nneigh; ++j) {
+                    int neigh_atom_element_index = nei_list_i[j*2];
+                    int neigh_atom_element_order = element_index_to_order[neigh_atom_element_index];
+                    double x0 = nei_list_d[j*4], y0 = nei_list_d[j*4+1], z0 = nei_list_d[j*4+2], r0_sqr = nei_list_d[j*4+3];
+                    for (int g = 0; g < ngaussians[neigh_atom_element_order]; ++g){
+                        double B = atom_gaussian[neigh_atom_element_order][g*2], alpha = atom_gaussian[neigh_atom_element_order][g*2+1];
+                        mcsh_function(x0, y0, z0, r0_sqr, A, B, alpha, beta, miu);
+                        // miu: miu_1, miu_2, miu_3
+                        // deriv: dmiu1_dxj, dmiu1_dyj, dmiu1_dzj, dmiu2_dxj, dmiu2_dyj, dmiu2_dzj, dmiu3_dxj, dmiu3_dyj, dmiu3_dzj
+                        sum_miu1 += miu[0];
+                        sum_miu2 += miu[1];
+                        sum_miu3 += miu[2];
+                        sum_miu4 += miu[3];
+                        sum_miu5 += miu[4];
+                        sum_miu6 += miu[5];
+                    }
+                }
+                M = sqrt(sum_miu1*sum_miu1 + sum_miu2*sum_miu2 + sum_miu3*sum_miu3 +
+                         sum_miu4*sum_miu4 + sum_miu5*sum_miu5 + sum_miu6*sum_miu6);
+                M = M * weight;
+                mcsh[ii][m] += M;
+            }
+        }
+        delete[] nei_list_d;
+        delete[] nei_list_i;
+    }
+
+    for (int i=0; i<natoms; i++) {
+        delete[] bin_i[i];
+    }
+    return 0;
+}
+
+
+
+
+
+
+
+
+extern "C" int calculate_atomistic_mcsh_norm(double** cell, double** cart, double** scale, int* pbc_bools,
+                                        int* atom_i, int natoms, int* cal_atoms, int cal_num,
+                                        int** params_i, double** params_d, int nmcsh, double** atom_gaussian, int* ngaussians, int* element_index_to_order,
+                                        double** mcsh, double** dmcsh) {
+
+    int total_bins, max_atoms_bin, bin_num, neigh_check_bins, nneigh;
+    int bin_range[3], nbins[3], cell_shift[3], max_bin[3], min_bin[3], pbc_bin[3];
+    //int bin_i[natoms][4];
+    double vol, tmp, tmp_r2, cutoff, cutoff_sqr;
+    double plane_d[3], total_shift[3];
+    double cross[3][3], reci[3][3], inv[3][3];//, powtwo[nsyms];
+
+
+    // Check for not implemented mcsh type.
+    for (int m=0; m < nmcsh; ++m){
+        bool implemented = false;
+        for (int i=0; i < NUM_IMPLEMENTED_TYPE; i++) {
+            if (params_i[m][0] == IMPLEMENTED_MCSH_TYPE[i][0] && params_i[m][1] == IMPLEMENTED_MCSH_TYPE[i][1]) {
+                implemented = true;
+                break;
+            }
+        }
+        if (!implemented) return 1;
+    }
+
+    int **bin_i = new int*[natoms];
+    for (int i=0; i<natoms; i++) {
+        bin_i[i] = new int[4];
+    }
+
+
+    cutoff = 0.0;
+    // let cutoff equal to the maximum of Rc
+    for (int m = 0; m < nmcsh; ++m) {
+        if (cutoff < params_d[m][4])
+            cutoff = params_d[m][4];
+    }
+
+    cutoff_sqr = cutoff * cutoff;
+
+    total_bins = 1;
+
+    // calculate the inverse matrix of cell and the distance between cell plane
+    cross[0][0] = cell[1][1]*cell[2][2] - cell[1][2]*cell[2][1];
+    cross[0][1] = cell[1][2]*cell[2][0] - cell[1][0]*cell[2][2];
+    cross[0][2] = cell[1][0]*cell[2][1] - cell[1][1]*cell[2][0];
+    cross[1][0] = cell[2][1]*cell[0][2] - cell[2][2]*cell[0][1];
+    cross[1][1] = cell[2][2]*cell[0][0] - cell[2][0]*cell[0][2];
+    cross[1][2] = cell[2][0]*cell[0][1] - cell[2][1]*cell[0][0];
+    cross[2][0] = cell[0][1]*cell[1][2] - cell[0][2]*cell[1][1];
+    cross[2][1] = cell[0][2]*cell[1][0] - cell[0][0]*cell[1][2];
+    cross[2][2] = cell[0][0]*cell[1][1] - cell[0][1]*cell[1][0];
+
+    vol = cross[0][0]*cell[0][0] + cross[0][1]*cell[0][1] + cross[0][2]*cell[0][2];
+    inv[0][0] = cross[0][0]/vol;
+    inv[0][1] = cross[1][0]/vol;
+    inv[0][2] = cross[2][0]/vol;
+    inv[1][0] = cross[0][1]/vol;
+    inv[1][1] = cross[1][1]/vol;
+    inv[1][2] = cross[2][1]/vol;
+    inv[2][0] = cross[0][2]/vol;
+    inv[2][1] = cross[1][2]/vol;
+    inv[2][2] = cross[2][2]/vol;
+
+    // bin: number of repetitive cells?
+    for (int i=0; i<3; ++i) {
+        tmp = 0;
+        for (int j=0; j<3; ++j) {
+            reci[i][j] = cross[i][j]/vol;
+            tmp += reci[i][j]*reci[i][j];
+        }
+        plane_d[i] = 1/sqrt(tmp);
+        nbins[i] = ceil(plane_d[i]/cutoff);
+        total_bins *= nbins[i];
+    }
+
+    int *atoms_bin = new int[total_bins];
+    for (int i=0; i<total_bins; ++i)
+        atoms_bin[i] = 0;
+
+    // assign the bin index to each atom
+    for (int i=0; i<natoms; ++i) {
+        for (int j=0; j<3; ++j) {
+            bin_i[i][j] = scale[i][j] * (double) nbins[j];
+        }
+        bin_i[i][3] = bin_i[i][0] + nbins[0]*bin_i[i][1] + nbins[0]*nbins[1]*bin_i[i][2];
+        atoms_bin[bin_i[i][3]]++;
+    }
+
+    max_atoms_bin = 0;
+    for (int i=0; i < total_bins; ++i) {
+        if (atoms_bin[i] > max_atoms_bin)
+            max_atoms_bin = atoms_bin[i];
+    }
+
+    delete[] atoms_bin;
+
+    // # of bins in each direction
+    neigh_check_bins = 1;
+    for (int i=0; i < 3; ++i) {
+        bin_range[i] = ceil(cutoff * nbins[i] / plane_d[i]);
+        neigh_check_bins *= 2*bin_range[i];
+    }
+
+    //for (int i=0; i < natoms; ++i) {
+    for (int ii=0; ii < cal_num; ++ii) {
+        int i=cal_atoms[ii];
+        // calculate neighbor atoms
+        double* nei_list_d = new double[max_atoms_bin * 4 * neigh_check_bins];
+        int*    nei_list_i = new int[max_atoms_bin * 2 * neigh_check_bins];
+        nneigh = 0;
+
+        for (int j=0; j < 3; ++j) {
+            max_bin[j] = bin_i[i][j] + bin_range[j];
+            min_bin[j] = bin_i[i][j] - bin_range[j];
+        }
+
+        for (int dx=min_bin[0]; dx < max_bin[0]+1; ++dx) {
+            for (int dy=min_bin[1]; dy < max_bin[1]+1; ++dy) {
+                for (int dz=min_bin[2]; dz < max_bin[2]+1; ++dz) {
+                    pbc_bin[0] = (dx%nbins[0] + nbins[0]) % nbins[0];
+                    pbc_bin[1] = (dy%nbins[1] + nbins[1]) % nbins[1];
+                    pbc_bin[2] = (dz%nbins[2] + nbins[2]) % nbins[2];
+                    cell_shift[0] = (dx-pbc_bin[0]) / nbins[0];
+                    cell_shift[1] = (dy-pbc_bin[1]) / nbins[1];
+                    cell_shift[2] = (dz-pbc_bin[2]) / nbins[2];
+
+                    bin_num = pbc_bin[0] + nbins[0]*pbc_bin[1] + nbins[0]*nbins[1]*pbc_bin[2];
+
+                    for (int j=0; j < natoms; ++j) {
+                        if (bin_i[j][3] != bin_num)
+                            continue;
+
+                        // same atom
+                        // if (!(cell_shift[0] || cell_shift[1] || cell_shift[2]) && (i == j))
+                        //     continue;
+
+                        // take care of pbc
+                        if (!pbc_bools[0] && cell_shift[0] != 0)
+                            continue;
+                        
+                        if (!pbc_bools[1] && cell_shift[1] != 0)
+                            continue;
+
+                        if (!pbc_bools[2] && cell_shift[2] != 0)
+                            continue;
+
+                        for (int a=0; a < 3; ++a) {
+                            total_shift[a] = cell_shift[0]*cell[0][a] + cell_shift[1]*cell[1][a] + cell_shift[2]*cell[2][a]
+                                             + cart[j][a] - cart[i][a];
+                        }
+
+                        // tmp = sqrt(total_shift[0]*total_shift[0] + total_shift[1]*total_shift[1] + total_shift[2]*total_shift[2]);
+                        tmp_r2 = total_shift[0]*total_shift[0] + total_shift[1]*total_shift[1] + total_shift[2]*total_shift[2];
+
+                        // if (tmp < cutoff) {
+                        if (tmp_r2 < cutoff_sqr) {
+                            for (int a=0; a < 3; ++a)
+                                nei_list_d[nneigh*4 + a] = total_shift[a];
+                            nei_list_d[nneigh*4 + 3] = tmp_r2;
+                            nei_list_i[nneigh*2]    = atom_i[j];
+                            nei_list_i[nneigh*2 + 1] = j;
+                            nneigh++;
+                        }
+                    }
+                }
+            }
+        }
+
+        for (int m = 0; m < nmcsh; ++m) {
+            int mcsh_type = get_mcsh_type(params_i[m][0], params_i[m][1]);
+            AtomisticMCSHFunction mcsh_function = get_mcsh_function(params_i[m][0], params_i[m][1]);
+
+            // params_d: sigma, weight, A, beta, cutoff
+            double A = params_d[m][2], beta = params_d[m][3];
+            double weight = 1.0;
+            // double weight = params_d[m][1]; 
+            double M = 0;
+            if (mcsh_type == 1){
+                double m_desc[1], deriv[3];
+                
+                for (int j = 0; j < nneigh; ++j) {
+                    double dMdx = 0.0, dMdy = 0.0, dMdz = 0.0;
 
                     int neigh_atom_element_index = nei_list_i[j*2];
                     int neigh_atom_element_order = element_index_to_order[neigh_atom_element_index];
@@ -243,7 +932,7 @@ extern "C" int calculate_atomistic_mcsh(double** cell, double** cart, double** s
             }
 
             if (mcsh_type == 2){
-                double sum_miu1 = 0, sum_miu2 = 0, sum_miu3 = 0;
+                double sum_miu1 = 0.0, sum_miu2 = 0.0, sum_miu3 = 0.0;
 
                 double* sum_dmiu1_dxj = new double[nneigh];
                 double* sum_dmiu2_dxj = new double[nneigh];
@@ -255,15 +944,15 @@ extern "C" int calculate_atomistic_mcsh(double** cell, double** cart, double** s
                 double* sum_dmiu2_dzj = new double[nneigh];
                 double* sum_dmiu3_dzj = new double[nneigh];
                 for (int j=0; j<nneigh; j++) {
-                    sum_dmiu1_dxj[j] = 0;
-                    sum_dmiu2_dxj[j] = 0;
-                    sum_dmiu3_dxj[j] = 0;
-                    sum_dmiu1_dyj[j] = 0;
-                    sum_dmiu2_dyj[j] = 0;
-                    sum_dmiu3_dyj[j] = 0;
-                    sum_dmiu1_dzj[j] = 0;
-                    sum_dmiu2_dzj[j] = 0;
-                    sum_dmiu3_dzj[j] = 0;  
+                    sum_dmiu1_dxj[j] = 0.0;
+                    sum_dmiu2_dxj[j] = 0.0;
+                    sum_dmiu3_dxj[j] = 0.0;
+                    sum_dmiu1_dyj[j] = 0.0;
+                    sum_dmiu2_dyj[j] = 0.0;
+                    sum_dmiu3_dyj[j] = 0.0;
+                    sum_dmiu1_dzj[j] = 0.0;
+                    sum_dmiu2_dzj[j] = 0.0;
+                    sum_dmiu3_dzj[j] = 0.0;  
                 }
 
                 double miu[3], deriv[9];
@@ -324,7 +1013,7 @@ extern "C" int calculate_atomistic_mcsh(double** cell, double** cart, double** s
             }
 
             if (mcsh_type == 3){
-                double sum_miu1 = 0, sum_miu2 = 0, sum_miu3 = 0, sum_miu4 = 0, sum_miu5 = 0, sum_miu6 = 0;
+                double sum_miu1 = 0.0, sum_miu2 = 0.0, sum_miu3 = 0.0, sum_miu4 = 0.0, sum_miu5 = 0.0, sum_miu6 = 0.0;
 
                 double* sum_dmiu1_dxj = new double[nneigh];
                 double* sum_dmiu2_dxj = new double[nneigh];
@@ -345,24 +1034,24 @@ extern "C" int calculate_atomistic_mcsh(double** cell, double** cart, double** s
                 double* sum_dmiu5_dzj = new double[nneigh];
                 double* sum_dmiu6_dzj = new double[nneigh];
                 for (int j=0; j<nneigh; j++) {
-                    sum_dmiu1_dxj[j] = 0;
-                    sum_dmiu2_dxj[j] = 0;
-                    sum_dmiu3_dxj[j] = 0;
-                    sum_dmiu4_dxj[j] = 0;
-                    sum_dmiu5_dxj[j] = 0;
-                    sum_dmiu6_dxj[j] = 0;
-                    sum_dmiu1_dyj[j] = 0;
-                    sum_dmiu2_dyj[j] = 0;
-                    sum_dmiu3_dyj[j] = 0; 
-                    sum_dmiu4_dyj[j] = 0;
-                    sum_dmiu5_dyj[j] = 0;
-                    sum_dmiu6_dyj[j] = 0;
-                    sum_dmiu1_dzj[j] = 0;
-                    sum_dmiu2_dzj[j] = 0;
-                    sum_dmiu3_dzj[j] = 0;
-                    sum_dmiu4_dzj[j] = 0;
-                    sum_dmiu5_dzj[j] = 0;
-                    sum_dmiu6_dzj[j] = 0; 
+                    sum_dmiu1_dxj[j] = 0.0;
+                    sum_dmiu2_dxj[j] = 0.0;
+                    sum_dmiu3_dxj[j] = 0.0;
+                    sum_dmiu4_dxj[j] = 0.0;
+                    sum_dmiu5_dxj[j] = 0.0;
+                    sum_dmiu6_dxj[j] = 0.0;
+                    sum_dmiu1_dyj[j] = 0.0;
+                    sum_dmiu2_dyj[j] = 0.0;
+                    sum_dmiu3_dyj[j] = 0.0; 
+                    sum_dmiu4_dyj[j] = 0.0;
+                    sum_dmiu5_dyj[j] = 0.0;
+                    sum_dmiu6_dyj[j] = 0.0;
+                    sum_dmiu1_dzj[j] = 0.0;
+                    sum_dmiu2_dzj[j] = 0.0;
+                    sum_dmiu3_dzj[j] = 0.0;
+                    sum_dmiu4_dzj[j] = 0.0;
+                    sum_dmiu5_dzj[j] = 0.0;
+                    sum_dmiu6_dzj[j] = 0.0; 
                 }
 
                 double miu[6], deriv[18];
@@ -460,6 +1149,269 @@ extern "C" int calculate_atomistic_mcsh(double** cell, double** cart, double** s
                 delete [] sum_dmiu4_dzj; 
                 delete [] sum_dmiu5_dzj; 
                 delete [] sum_dmiu6_dzj; 
+            }
+        }
+        delete[] nei_list_d;
+        delete[] nei_list_i;
+    }
+
+    for (int i=0; i<natoms; i++) {
+        delete[] bin_i[i];
+    }
+    return 0;
+}
+
+
+
+
+extern "C" int calculate_atomistic_mcsh_norm_noderiv(double** cell, double** cart, double** scale, int* pbc_bools,
+                                        int* atom_i, int natoms, int* cal_atoms, int cal_num,
+                                        int** params_i, double** params_d, int nmcsh, double** atom_gaussian, int* ngaussians, int* element_index_to_order,
+                                        double** mcsh) {
+
+    int total_bins, max_atoms_bin, bin_num, neigh_check_bins, nneigh;
+    int bin_range[3], nbins[3], cell_shift[3], max_bin[3], min_bin[3], pbc_bin[3];
+    //int bin_i[natoms][4];
+    double vol, tmp, tmp_r2, cutoff, cutoff_sqr;
+    double plane_d[3], total_shift[3];
+    double cross[3][3], reci[3][3], inv[3][3];//, powtwo[nsyms];
+
+
+    // Check for not implemented mcsh type.
+    for (int m=0; m < nmcsh; ++m){
+        bool implemented = false;
+        for (int i=0; i < NUM_IMPLEMENTED_TYPE; i++) {
+            if (params_i[m][0] == IMPLEMENTED_MCSH_TYPE[i][0] && params_i[m][1] == IMPLEMENTED_MCSH_TYPE[i][1]) {
+                implemented = true;
+                break;
+            }
+        }
+        if (!implemented) return 1;
+    }
+
+    int **bin_i = new int*[natoms];
+    for (int i=0; i<natoms; i++) {
+        bin_i[i] = new int[4];
+    }
+
+
+    cutoff = 0.0;
+    // let cutoff equal to the maximum of Rc
+    for (int m = 0; m < nmcsh; ++m) {
+        if (cutoff < params_d[m][4])
+            cutoff = params_d[m][4];
+    }
+
+    cutoff_sqr = cutoff * cutoff;
+
+    total_bins = 1;
+
+    // calculate the inverse matrix of cell and the distance between cell plane
+    cross[0][0] = cell[1][1]*cell[2][2] - cell[1][2]*cell[2][1];
+    cross[0][1] = cell[1][2]*cell[2][0] - cell[1][0]*cell[2][2];
+    cross[0][2] = cell[1][0]*cell[2][1] - cell[1][1]*cell[2][0];
+    cross[1][0] = cell[2][1]*cell[0][2] - cell[2][2]*cell[0][1];
+    cross[1][1] = cell[2][2]*cell[0][0] - cell[2][0]*cell[0][2];
+    cross[1][2] = cell[2][0]*cell[0][1] - cell[2][1]*cell[0][0];
+    cross[2][0] = cell[0][1]*cell[1][2] - cell[0][2]*cell[1][1];
+    cross[2][1] = cell[0][2]*cell[1][0] - cell[0][0]*cell[1][2];
+    cross[2][2] = cell[0][0]*cell[1][1] - cell[0][1]*cell[1][0];
+
+    vol = cross[0][0]*cell[0][0] + cross[0][1]*cell[0][1] + cross[0][2]*cell[0][2];
+    inv[0][0] = cross[0][0]/vol;
+    inv[0][1] = cross[1][0]/vol;
+    inv[0][2] = cross[2][0]/vol;
+    inv[1][0] = cross[0][1]/vol;
+    inv[1][1] = cross[1][1]/vol;
+    inv[1][2] = cross[2][1]/vol;
+    inv[2][0] = cross[0][2]/vol;
+    inv[2][1] = cross[1][2]/vol;
+    inv[2][2] = cross[2][2]/vol;
+
+    // bin: number of repetitive cells?
+    for (int i=0; i<3; ++i) {
+        tmp = 0;
+        for (int j=0; j<3; ++j) {
+            reci[i][j] = cross[i][j]/vol;
+            tmp += reci[i][j]*reci[i][j];
+        }
+        plane_d[i] = 1/sqrt(tmp);
+        nbins[i] = ceil(plane_d[i]/cutoff);
+        total_bins *= nbins[i];
+    }
+
+    int *atoms_bin = new int[total_bins];
+    for (int i=0; i<total_bins; ++i)
+        atoms_bin[i] = 0;
+
+    // assign the bin index to each atom
+    for (int i=0; i<natoms; ++i) {
+        for (int j=0; j<3; ++j) {
+            bin_i[i][j] = scale[i][j] * (double) nbins[j];
+        }
+        bin_i[i][3] = bin_i[i][0] + nbins[0]*bin_i[i][1] + nbins[0]*nbins[1]*bin_i[i][2];
+        atoms_bin[bin_i[i][3]]++;
+    }
+
+    max_atoms_bin = 0;
+    for (int i=0; i < total_bins; ++i) {
+        if (atoms_bin[i] > max_atoms_bin)
+            max_atoms_bin = atoms_bin[i];
+    }
+
+    delete[] atoms_bin;
+
+    // # of bins in each direction
+    neigh_check_bins = 1;
+    for (int i=0; i < 3; ++i) {
+        bin_range[i] = ceil(cutoff * nbins[i] / plane_d[i]);
+        neigh_check_bins *= 2*bin_range[i];
+    }
+
+    //for (int i=0; i < natoms; ++i) {
+    for (int ii=0; ii < cal_num; ++ii) {
+        int i=cal_atoms[ii];
+        // calculate neighbor atoms
+        double* nei_list_d = new double[max_atoms_bin * 4 * neigh_check_bins];
+        int*    nei_list_i = new int[max_atoms_bin * 2 * neigh_check_bins];
+        nneigh = 0;
+
+        for (int j=0; j < 3; ++j) {
+            max_bin[j] = bin_i[i][j] + bin_range[j];
+            min_bin[j] = bin_i[i][j] - bin_range[j];
+        }
+
+        for (int dx=min_bin[0]; dx < max_bin[0]+1; ++dx) {
+            for (int dy=min_bin[1]; dy < max_bin[1]+1; ++dy) {
+                for (int dz=min_bin[2]; dz < max_bin[2]+1; ++dz) {
+                    pbc_bin[0] = (dx%nbins[0] + nbins[0]) % nbins[0];
+                    pbc_bin[1] = (dy%nbins[1] + nbins[1]) % nbins[1];
+                    pbc_bin[2] = (dz%nbins[2] + nbins[2]) % nbins[2];
+                    cell_shift[0] = (dx-pbc_bin[0]) / nbins[0];
+                    cell_shift[1] = (dy-pbc_bin[1]) / nbins[1];
+                    cell_shift[2] = (dz-pbc_bin[2]) / nbins[2];
+
+                    bin_num = pbc_bin[0] + nbins[0]*pbc_bin[1] + nbins[0]*nbins[1]*pbc_bin[2];
+
+                    for (int j=0; j < natoms; ++j) {
+                        if (bin_i[j][3] != bin_num)
+                            continue;
+
+                        // same atom
+                        // if (!(cell_shift[0] || cell_shift[1] || cell_shift[2]) && (i == j))
+                        //     continue;
+
+                        // take care of pbc
+                        if (!pbc_bools[0] && cell_shift[0] != 0)
+                            continue;
+                        
+                        if (!pbc_bools[1] && cell_shift[1] != 0)
+                            continue;
+
+                        if (!pbc_bools[2] && cell_shift[2] != 0)
+                            continue;
+
+                        for (int a=0; a < 3; ++a) {
+                            total_shift[a] = cell_shift[0]*cell[0][a] + cell_shift[1]*cell[1][a] + cell_shift[2]*cell[2][a]
+                                             + cart[j][a] - cart[i][a];
+                        }
+
+                        // tmp = sqrt(total_shift[0]*total_shift[0] + total_shift[1]*total_shift[1] + total_shift[2]*total_shift[2]);
+                        tmp_r2 = total_shift[0]*total_shift[0] + total_shift[1]*total_shift[1] + total_shift[2]*total_shift[2];
+
+                        // if (tmp < cutoff) {
+                        if (tmp_r2 < cutoff_sqr) {
+                            for (int a=0; a < 3; ++a)
+                                nei_list_d[nneigh*4 + a] = total_shift[a];
+                            nei_list_d[nneigh*4 + 3] = tmp_r2;
+                            nei_list_i[nneigh*2]    = atom_i[j];
+                            nei_list_i[nneigh*2 + 1] = j;
+                            nneigh++;
+                        }
+                    }
+                }
+            }
+        }
+
+        for (int m = 0; m < nmcsh; ++m) {
+            int mcsh_type = get_mcsh_type(params_i[m][0], params_i[m][1]);
+            AtomisticMCSHFunctionNoderiv mcsh_function = get_mcsh_function_noderiv(params_i[m][0], params_i[m][1]);
+
+            // params_d: sigma, weight, A, beta, cutoff
+            double A = params_d[m][2], beta = params_d[m][3];
+            double weight = 1.0;
+            // double weight = params_d[m][1]; 
+            double M = 0.0;
+            if (mcsh_type == 1){
+                double m_desc[1], deriv[3];
+                
+                for (int j = 0; j < nneigh; ++j) {
+
+                    int neigh_atom_element_index = nei_list_i[j*2];
+                    int neigh_atom_element_order = element_index_to_order[neigh_atom_element_index];
+                    double x0 = nei_list_d[j*4], y0 = nei_list_d[j*4+1], z0 = nei_list_d[j*4+2], r0_sqr = nei_list_d[j*4+3];
+                    for (int g = 0; g < ngaussians[neigh_atom_element_order]; ++g){
+                        double B = atom_gaussian[neigh_atom_element_order][g*2], alpha = atom_gaussian[neigh_atom_element_order][g*2+1];
+                        mcsh_function(x0, y0, z0, r0_sqr, A, B, alpha, beta, m_desc);
+                        M += m_desc[0];
+                    }
+                }
+                // M = M * weight;
+                M = M * M * weight;
+                mcsh[ii][m] += M;
+            }
+
+            if (mcsh_type == 2){
+                double sum_miu1 = 0.0, sum_miu2 = 0.0, sum_miu3 = 0.0;
+
+                double miu[3], deriv[9];
+                for (int j = 0; j < nneigh; ++j) {
+                    int neigh_atom_element_index = nei_list_i[j*2];
+                    int neigh_atom_element_order = element_index_to_order[neigh_atom_element_index];
+                    double x0 = nei_list_d[j*4], y0 = nei_list_d[j*4+1], z0 = nei_list_d[j*4+2], r0_sqr = nei_list_d[j*4+3];
+                    for (int g = 0; g < ngaussians[neigh_atom_element_order]; ++g){
+                        double B = atom_gaussian[neigh_atom_element_order][g*2], alpha = atom_gaussian[neigh_atom_element_order][g*2+1];
+                        mcsh_function(x0, y0, z0, r0_sqr, A, B, alpha, beta, miu);
+                        // miu: miu_1, miu_2, miu_3
+                        // deriv: dmiu1_dxj, dmiu1_dyj, dmiu1_dzj, dmiu2_dxj, dmiu2_dyj, dmiu2_dzj, dmiu3_dxj, dmiu3_dyj, dmiu3_dzj
+                        sum_miu1 += miu[0];
+                        sum_miu2 += miu[1];
+                        sum_miu3 += miu[2];
+                    }
+                }
+                // M = sqrt(sum_miu1*sum_miu1 + sum_miu2*sum_miu2 + sum_miu3*sum_miu3);
+                M = sum_miu1*sum_miu1 + sum_miu2*sum_miu2 + sum_miu3*sum_miu3;
+                M = M * weight;
+                mcsh[ii][m] += M;
+            }
+
+            if (mcsh_type == 3){
+                double sum_miu1 = 0.0, sum_miu2 = 0.0, sum_miu3 = 0.0, sum_miu4 = 0.0, sum_miu5 = 0.0, sum_miu6 = 0.0;
+
+                double miu[6], deriv[18];
+                for (int j = 0; j < nneigh; ++j) {
+                    int neigh_atom_element_index = nei_list_i[j*2];
+                    int neigh_atom_element_order = element_index_to_order[neigh_atom_element_index];
+                    double x0 = nei_list_d[j*4], y0 = nei_list_d[j*4+1], z0 = nei_list_d[j*4+2], r0_sqr = nei_list_d[j*4+3];
+                    for (int g = 0; g < ngaussians[neigh_atom_element_order]; ++g){
+                        double B = atom_gaussian[neigh_atom_element_order][g*2], alpha = atom_gaussian[neigh_atom_element_order][g*2+1];
+                        mcsh_function(x0, y0, z0, r0_sqr, A, B, alpha, beta, miu);
+                        // miu: miu_1, miu_2, miu_3
+                        // deriv: dmiu1_dxj, dmiu1_dyj, dmiu1_dzj, dmiu2_dxj, dmiu2_dyj, dmiu2_dzj, dmiu3_dxj, dmiu3_dyj, dmiu3_dzj
+                        sum_miu1 += miu[0];
+                        sum_miu2 += miu[1];
+                        sum_miu3 += miu[2];
+                        sum_miu4 += miu[3];
+                        sum_miu5 += miu[4];
+                        sum_miu6 += miu[5];
+                    }
+                }
+                // M = sqrt(sum_miu1*sum_miu1 + sum_miu2*sum_miu2 + sum_miu3*sum_miu3 +
+                //          sum_miu4*sum_miu4 + sum_miu5*sum_miu5 + sum_miu6*sum_miu6);
+                M = sum_miu1*sum_miu1 + sum_miu2*sum_miu2 + sum_miu3*sum_miu3 +
+                    sum_miu4*sum_miu4 + sum_miu5*sum_miu5 + sum_miu6*sum_miu6;
+                M = M * weight;
+                mcsh[ii][m] += M;
             }
         }
         delete[] nei_list_d;

--- a/amptorch/descriptor/MCSH/calculate_atomistic_mcsh.h
+++ b/amptorch/descriptor/MCSH/calculate_atomistic_mcsh.h
@@ -6,3 +6,18 @@ extern "C" int calculate_atomistic_mcsh(double **, double **, double **, int*,
                                         int *, int, int*, int,
                                         int**, double **, int, double **, int *, int *,
                                         double**, double**);
+
+extern "C" int calculate_atomistic_mcsh_noderiv(double **, double **, double **, int*,
+                                        int *, int, int*, int,
+                                        int**, double **, int, double **, int *, int *,
+                                        double**); 
+
+extern "C" int calculate_atomistic_mcsh_norm(double **, double **, double **, int*,
+                                        int *, int, int*, int,
+                                        int**, double **, int, double **, int *, int *,
+                                        double**, double**);
+
+extern "C" int calculate_atomistic_mcsh_norm_noderiv(double **, double **, double **, int*,
+                                        int *, int, int*, int,
+                                        int**, double **, int, double **, int *, int *,
+                                        double**); 

--- a/amptorch/descriptor/MCSH/libmcsh_builder.py
+++ b/amptorch/descriptor/MCSH/libmcsh_builder.py
@@ -6,6 +6,21 @@ ffibuilder.cdef(
                                     int *, int, int*, int,
                                     int**, double **, int, double **, int*, int*, 
                                     double**, double**);
+        
+        int calculate_atomistic_mcsh_norm(double **, double **, double **, int*,
+                                    int *, int, int*, int,
+                                    int**, double **, int, double **, int*, int*, 
+                                    double**, double**);
+        
+        int calculate_atomistic_mcsh_noderiv(double **, double **, double **, int*,
+                                    int *, int, int*, int,
+                                    int**, double **, int, double **, int*, int*, 
+                                    double**, double**);
+        
+        int calculate_atomistic_mcsh_norm_noderiv(double **, double **, double **, int*,
+                                    int *, int, int*, int,
+                                    int**, double **, int, double **, int*, int*, 
+                                    double**, double**);
     """
 )
 ffibuilder.set_source(

--- a/amptorch/descriptor/MCSH/libmcsh_builder.py
+++ b/amptorch/descriptor/MCSH/libmcsh_builder.py
@@ -15,12 +15,12 @@ ffibuilder.cdef(
         int calculate_atomistic_mcsh_noderiv(double **, double **, double **, int*,
                                     int *, int, int*, int,
                                     int**, double **, int, double **, int*, int*, 
-                                    double**, double**);
+                                    double**);
         
         int calculate_atomistic_mcsh_norm_noderiv(double **, double **, double **, int*,
                                     int *, int, int*, int,
                                     int**, double **, int, double **, int*, int*, 
-                                    double**, double**);
+                                    double**);
     """
 )
 ffibuilder.set_source(

--- a/amptorch/descriptor/base_descriptor.py
+++ b/amptorch/descriptor/base_descriptor.py
@@ -179,6 +179,7 @@ class BaseDescriptor(ABC):
                         fp_prime_col_dict[element] = fp_primes_col
                         fp_prime_size_dict[element] = fp_primes_size
 
+                        print(fp)
                         print(fp_primes_size)
                         print(fp_primes_val)
 
@@ -299,6 +300,7 @@ class BaseDescriptor(ABC):
                     fp_prime_col_dict[element] = fp_primes_col
                     fp_prime_size_dict[element] = fp_primes_size
 
+                    print(fp)
                     print(fp_primes_size)
                     print(fp_primes_val)
 

--- a/amptorch/descriptor/base_descriptor.py
+++ b/amptorch/descriptor/base_descriptor.py
@@ -179,7 +179,7 @@ class BaseDescriptor(ABC):
                         fp_prime_col_dict[element] = fp_primes_col
                         fp_prime_size_dict[element] = fp_primes_size
 
-                        print(fp)
+                        print(fps)
                         print(fp_primes_size)
                         print(fp_primes_val)
 
@@ -300,7 +300,7 @@ class BaseDescriptor(ABC):
                     fp_prime_col_dict[element] = fp_primes_col
                     fp_prime_size_dict[element] = fp_primes_size
 
-                    print(fp)
+                    print(fps)
                     print(fp_primes_size)
                     print(fp_primes_val)
 

--- a/amptorch/descriptor/base_descriptor.py
+++ b/amptorch/descriptor/base_descriptor.py
@@ -179,10 +179,6 @@ class BaseDescriptor(ABC):
                         fp_prime_col_dict[element] = fp_primes_col
                         fp_prime_size_dict[element] = fp_primes_size
 
-                        print(fps)
-                        print(fp_primes_size)
-                        print(fp_primes_val)
-
                     else:
                         try:
                             size_info = np.array(current_element_grp["size_info"])
@@ -299,10 +295,6 @@ class BaseDescriptor(ABC):
                     fp_prime_row_dict[element] = fp_primes_row
                     fp_prime_col_dict[element] = fp_primes_col
                     fp_prime_size_dict[element] = fp_primes_size
-
-                    print(fps)
-                    print(fp_primes_size)
-                    print(fp_primes_val)
 
                 else:
 

--- a/amptorch/descriptor/base_descriptor.py
+++ b/amptorch/descriptor/base_descriptor.py
@@ -180,7 +180,7 @@ class BaseDescriptor(ABC):
                         fp_prime_size_dict[element] = fp_primes_size
 
                         print(fp_primes_size)
-                        print(max(fp_primes_val))
+                        print(fp_primes_val)
 
                     else:
                         try:
@@ -300,7 +300,7 @@ class BaseDescriptor(ABC):
                     fp_prime_size_dict[element] = fp_primes_size
 
                     print(fp_primes_size)
-                    print(max(fp_primes_val))
+                    print(fp_primes_val)
 
                 else:
 

--- a/amptorch/descriptor/base_descriptor.py
+++ b/amptorch/descriptor/base_descriptor.py
@@ -179,6 +179,10 @@ class BaseDescriptor(ABC):
                         fp_prime_col_dict[element] = fp_primes_col
                         fp_prime_size_dict[element] = fp_primes_size
 
+                        print(fps)
+                        print(fp_primes_size)
+                        print(fp_primes_val)
+
                     else:
                         try:
                             size_info = np.array(current_element_grp["size_info"])
@@ -295,6 +299,10 @@ class BaseDescriptor(ABC):
                     fp_prime_row_dict[element] = fp_primes_row
                     fp_prime_col_dict[element] = fp_primes_col
                     fp_prime_size_dict[element] = fp_primes_size
+
+                    print(fps)
+                    print(fp_primes_size)
+                    print(fp_primes_val)
 
                 else:
 

--- a/amptorch/descriptor/base_descriptor.py
+++ b/amptorch/descriptor/base_descriptor.py
@@ -179,9 +179,9 @@ class BaseDescriptor(ABC):
                         fp_prime_col_dict[element] = fp_primes_col
                         fp_prime_size_dict[element] = fp_primes_size
 
-                        print(fps)
-                        print(fp_primes_size)
-                        print(fp_primes_val)
+                        # print(fps)
+                        # print(fp_primes_size)
+                        # print(fp_primes_val)
 
                     else:
                         try:
@@ -300,9 +300,9 @@ class BaseDescriptor(ABC):
                     fp_prime_col_dict[element] = fp_primes_col
                     fp_prime_size_dict[element] = fp_primes_size
 
-                    print(fps)
-                    print(fp_primes_size)
-                    print(fp_primes_val)
+                    # print(fps)
+                    # print(fp_primes_size)
+                    # print(fp_primes_val)
 
                 else:
 

--- a/amptorch/model.py
+++ b/amptorch/model.py
@@ -105,10 +105,10 @@ class BPNN(nn.Module):
                     -1, 3
                 )
 
-                print("=====================================")
-                print(gradients)
-                print("*************************************")
-                print(batch.fprimes.t())
+                # print("=====================================")
+                # print(gradients)
+                # print("*************************************")
+                # print(batch.fprimes.t())
 
             else:
                 forces = torch.tensor([])

--- a/amptorch/model.py
+++ b/amptorch/model.py
@@ -105,6 +105,11 @@ class BPNN(nn.Module):
                     -1, 3
                 )
 
+                print("=====================================")
+                print(gradients)
+                print("*************************************")
+                print(batch.fprimes.t())
+
             else:
                 forces = torch.tensor([])
 

--- a/amptorch/preprocessing/utils.py
+++ b/amptorch/preprocessing/utils.py
@@ -30,31 +30,16 @@ class FeatureScaler:
                 idx_to_scale_prime = data.fprimes._indices()[0] % (
                     data.fingerprint.shape[1] - 1
                 )
-                print("----------")
-                print(data.fingerprint.shape)
-                # nonzero_idx = torch.where(
-                #     self.feature_max[idx_to_scale_prime]
-                #     - self.feature_min[idx_to_scale_prime]
-                # )[0]
 
                 nonzero_idx = torch.where(
                     (self.feature_max[idx_to_scale_prime] - self.feature_min[idx_to_scale_prime]) > threshold
                 )[0]
 
-                print("=====================================")
-                # print(data.fprimes)
-                print(torch.max(torch.abs(data.fprimes._values())))
-                # print((self.feature_max - self.feature_min))
-                
-                # print(self.feature_max[idx_to_scale_prime][nonzero_idx])
-                # print(self.feature_min[idx_to_scale_prime][nonzero_idx])
                 data.fprimes._values()[nonzero_idx] *= 2 / (
                     self.feature_max[idx_to_scale_prime][nonzero_idx]
                     - self.feature_min[idx_to_scale_prime][nonzero_idx]
                 )
-                print("*************************************")
-                # print(data.fprimes)
-                print(torch.max(torch.abs(data.fprimes._values())))
+
                 _values = data.fprimes._values()
                 _indices = data.fprimes._indices()
                 _size = data.fprimes.size()

--- a/amptorch/preprocessing/utils.py
+++ b/amptorch/preprocessing/utils.py
@@ -40,6 +40,7 @@ class FeatureScaler:
                 print("=====================================")
                 print(data.fprimes)
                 print(torch.max(torch.abs(data.fprimes._values())))
+                print((self.feature_max - self.feature_min))
                 
                 # print(self.feature_max[idx_to_scale_prime][nonzero_idx])
                 # print(self.feature_min[idx_to_scale_prime][nonzero_idx])

--- a/amptorch/preprocessing/utils.py
+++ b/amptorch/preprocessing/utils.py
@@ -38,7 +38,8 @@ class FeatureScaler:
                 print("=====================================")
                 print(data.fprimes)
                 
-
+                print(self.feature_max[idx_to_scale_prime][nonzero_idx])
+                print(self.feature_min[idx_to_scale_prime][nonzero_idx])
                 data.fprimes._values()[nonzero_idx] *= 2 / (
                     self.feature_max[idx_to_scale_prime][nonzero_idx]
                     - self.feature_min[idx_to_scale_prime][nonzero_idx]

--- a/amptorch/preprocessing/utils.py
+++ b/amptorch/preprocessing/utils.py
@@ -30,6 +30,8 @@ class FeatureScaler:
                 idx_to_scale_prime = data.fprimes._indices()[0] % (
                     data.fingerprint.shape[1] - 1
                 )
+                print("----------")
+                print(data.fingerprint.shape)
                 # nonzero_idx = torch.where(
                 #     self.feature_max[idx_to_scale_prime]
                 #     - self.feature_min[idx_to_scale_prime]

--- a/amptorch/preprocessing/utils.py
+++ b/amptorch/preprocessing/utils.py
@@ -18,7 +18,7 @@ class FeatureScaler:
             self.feature_mean = torch.mean(fingerprints, dim=0)
             self.feature_std = 1
 
-    def norm(self, data_list, threshold = 1e-8):
+    def norm(self, data_list, threshold = 1e-2):
         for data in data_list:
             idx_to_scale = torch.where((self.feature_max - self.feature_min) > threshold)[0]
             data.fingerprint[:, idx_to_scale] = -1 + 2 * (

--- a/amptorch/preprocessing/utils.py
+++ b/amptorch/preprocessing/utils.py
@@ -18,9 +18,9 @@ class FeatureScaler:
             self.feature_mean = torch.mean(fingerprints, dim=0)
             self.feature_std = 1
 
-    def norm(self, data_list):
+    def norm(self, data_list, threshold = 1e-6):
         for data in data_list:
-            idx_to_scale = torch.where((self.feature_max - self.feature_min) > 10e-8)[0]
+            idx_to_scale = torch.where((self.feature_max - self.feature_min) > threshold)[0]
             data.fingerprint[:, idx_to_scale] = -1 + 2 * (
                 (data.fingerprint[:, idx_to_scale] - self.feature_min[idx_to_scale])
                 / (self.feature_max[idx_to_scale] - self.feature_min[idx_to_scale])
@@ -35,7 +35,7 @@ class FeatureScaler:
                 #     - self.feature_min[idx_to_scale_prime]
                 # )[0]
 
-                nonzero_idx = torch.where((self.feature_max - self.feature_min) > 10e-8)[0]
+                nonzero_idx = torch.where((self.feature_max - self.feature_min) > threshold)[0]
 
                 print("=====================================")
                 print(data.fprimes)

--- a/amptorch/preprocessing/utils.py
+++ b/amptorch/preprocessing/utils.py
@@ -19,31 +19,31 @@ class FeatureScaler:
             self.feature_std = 1
 
     def norm(self, data_list, threshold = 1e-6):
-        # for data in data_list:
-        #     idx_to_scale = torch.where((self.feature_max - self.feature_min) > threshold)[0]
-        #     data.fingerprint[:, idx_to_scale] = -1 + 2 * (
-        #         (data.fingerprint[:, idx_to_scale] - self.feature_min[idx_to_scale])
-        #         / (self.feature_max[idx_to_scale] - self.feature_min[idx_to_scale])
-        #     )
+        for data in data_list:
+            idx_to_scale = torch.where((self.feature_max - self.feature_min) > threshold)[0]
+            data.fingerprint[:, idx_to_scale] = -1 + 2 * (
+                (data.fingerprint[:, idx_to_scale] - self.feature_min[idx_to_scale])
+                / (self.feature_max[idx_to_scale] - self.feature_min[idx_to_scale])
+            )
 
-        #     if self.forcetraining:
-        #         idx_to_scale_prime = data.fprimes._indices()[0] % (
-        #             data.fingerprint.shape[1] - 1
-        #         )
+            if self.forcetraining:
+                idx_to_scale_prime = data.fprimes._indices()[0] % (
+                    data.fingerprint.shape[1] - 1
+                )
 
-        #         nonzero_idx = torch.where(
-        #             (self.feature_max[idx_to_scale_prime] - self.feature_min[idx_to_scale_prime]) > threshold
-        #         )[0]
+                nonzero_idx = torch.where(
+                    (self.feature_max[idx_to_scale_prime] - self.feature_min[idx_to_scale_prime]) > threshold
+                )[0]
 
-        #         data.fprimes._values()[nonzero_idx] *= 2 / (
-        #             self.feature_max[idx_to_scale_prime][nonzero_idx]
-        #             - self.feature_min[idx_to_scale_prime][nonzero_idx]
-        #         )
+                data.fprimes._values()[nonzero_idx] *= 2 / (
+                    self.feature_max[idx_to_scale_prime][nonzero_idx]
+                    - self.feature_min[idx_to_scale_prime][nonzero_idx]
+                )
 
-        #         _values = data.fprimes._values()
-        #         _indices = data.fprimes._indices()
-        #         _size = data.fprimes.size()
-        #         data.fprimes = torch.sparse.FloatTensor(_indices, _values, _size)
+                _values = data.fprimes._values()
+                _indices = data.fprimes._indices()
+                _size = data.fprimes.size()
+                data.fprimes = torch.sparse.FloatTensor(_indices, _values, _size)
 
         return data_list
 

--- a/amptorch/preprocessing/utils.py
+++ b/amptorch/preprocessing/utils.py
@@ -35,17 +35,17 @@ class FeatureScaler:
                     - self.feature_min[idx_to_scale_prime]
                 )[0]
 
-                print("=====================================")
-                print(data.fprimes)
+                # print("=====================================")
+                # print(data.fprimes)
                 
-                print(self.feature_max[idx_to_scale_prime][nonzero_idx])
-                print(self.feature_min[idx_to_scale_prime][nonzero_idx])
+                # print(self.feature_max[idx_to_scale_prime][nonzero_idx])
+                # print(self.feature_min[idx_to_scale_prime][nonzero_idx])
                 data.fprimes._values()[nonzero_idx] *= 2 / (
                     self.feature_max[idx_to_scale_prime][nonzero_idx]
                     - self.feature_min[idx_to_scale_prime][nonzero_idx]
                 )
-                print("*************************************")
-                print(data.fprimes)
+                # print("*************************************")
+                # print(data.fprimes)
                 _values = data.fprimes._values()
                 _indices = data.fprimes._indices()
                 _size = data.fprimes.size()

--- a/amptorch/preprocessing/utils.py
+++ b/amptorch/preprocessing/utils.py
@@ -38,7 +38,7 @@ class FeatureScaler:
                 nonzero_idx = torch.where((self.feature_max - self.feature_min) > threshold)[0]
 
                 print("=====================================")
-                # print(data.fprimes)
+                print(data.fprimes)
                 print(torch.max(torch.abs(data.fprimes._values())))
                 
                 # print(self.feature_max[idx_to_scale_prime][nonzero_idx])
@@ -48,7 +48,7 @@ class FeatureScaler:
                     - self.feature_min[idx_to_scale_prime][nonzero_idx]
                 )
                 print("*************************************")
-                # print(data.fprimes)
+                print(data.fprimes)
                 print(torch.max(torch.abs(data.fprimes._values())))
                 _values = data.fprimes._values()
                 _indices = data.fprimes._indices()

--- a/amptorch/preprocessing/utils.py
+++ b/amptorch/preprocessing/utils.py
@@ -18,7 +18,7 @@ class FeatureScaler:
             self.feature_mean = torch.mean(fingerprints, dim=0)
             self.feature_std = 1
 
-    def norm(self, data_list, threshold = 1e-5):
+    def norm(self, data_list, threshold = 1e-6):
         for data in data_list:
             idx_to_scale = torch.where((self.feature_max - self.feature_min) > threshold)[0]
             data.fingerprint[:, idx_to_scale] = -1 + 2 * (

--- a/amptorch/preprocessing/utils.py
+++ b/amptorch/preprocessing/utils.py
@@ -19,37 +19,39 @@ class FeatureScaler:
             self.feature_std = 1
 
     def norm(self, data_list):
-        # for data in data_list:
-        #     idx_to_scale = torch.where((self.feature_max - self.feature_min) > 10e-8)[0]
-        #     data.fingerprint[:, idx_to_scale] = -1 + 2 * (
-        #         (data.fingerprint[:, idx_to_scale] - self.feature_min[idx_to_scale])
-        #         / (self.feature_max[idx_to_scale] - self.feature_min[idx_to_scale])
-        #     )
+        for data in data_list:
+            idx_to_scale = torch.where((self.feature_max - self.feature_min) > 10e-8)[0]
+            data.fingerprint[:, idx_to_scale] = -1 + 2 * (
+                (data.fingerprint[:, idx_to_scale] - self.feature_min[idx_to_scale])
+                / (self.feature_max[idx_to_scale] - self.feature_min[idx_to_scale])
+            )
 
-        #     if self.forcetraining:
-        #         idx_to_scale_prime = data.fprimes._indices()[0] % (
-        #             data.fingerprint.shape[1] - 1
-        #         )
-        #         nonzero_idx = torch.where(
-        #             self.feature_max[idx_to_scale_prime]
-        #             - self.feature_min[idx_to_scale_prime]
-        #         )[0]
+            if self.forcetraining:
+                idx_to_scale_prime = data.fprimes._indices()[0] % (
+                    data.fingerprint.shape[1] - 1
+                )
+                # nonzero_idx = torch.where(
+                #     self.feature_max[idx_to_scale_prime]
+                #     - self.feature_min[idx_to_scale_prime]
+                # )[0]
 
-        #         # print("=====================================")
-        #         # print(data.fprimes)
+                nonzero_idx = torch.where((self.feature_max - self.feature_min) > 10e-8)[0]
+
+                print("=====================================")
+                print(data.fprimes)
                 
-        #         # print(self.feature_max[idx_to_scale_prime][nonzero_idx])
-        #         # print(self.feature_min[idx_to_scale_prime][nonzero_idx])
-        #         data.fprimes._values()[nonzero_idx] *= 2 / (
-        #             self.feature_max[idx_to_scale_prime][nonzero_idx]
-        #             - self.feature_min[idx_to_scale_prime][nonzero_idx]
-        #         )
-        #         # print("*************************************")
-        #         # print(data.fprimes)
-        #         _values = data.fprimes._values()
-        #         _indices = data.fprimes._indices()
-        #         _size = data.fprimes.size()
-        #         data.fprimes = torch.sparse.FloatTensor(_indices, _values, _size)
+                print(self.feature_max[idx_to_scale_prime][nonzero_idx])
+                print(self.feature_min[idx_to_scale_prime][nonzero_idx])
+                data.fprimes._values()[nonzero_idx] *= 2 / (
+                    self.feature_max[idx_to_scale_prime][nonzero_idx]
+                    - self.feature_min[idx_to_scale_prime][nonzero_idx]
+                )
+                print("*************************************")
+                print(data.fprimes)
+                _values = data.fprimes._values()
+                _indices = data.fprimes._indices()
+                _size = data.fprimes.size()
+                data.fprimes = torch.sparse.FloatTensor(_indices, _values, _size)
 
         return data_list
 

--- a/amptorch/preprocessing/utils.py
+++ b/amptorch/preprocessing/utils.py
@@ -39,7 +39,7 @@ class FeatureScaler:
 
                 print("=====================================")
                 # print(data.fprimes)
-                print(torch.max(torch.abs(data.fprimes)))
+                print(torch.max(torch.abs(data.fprimes._values())))
                 
                 # print(self.feature_max[idx_to_scale_prime][nonzero_idx])
                 # print(self.feature_min[idx_to_scale_prime][nonzero_idx])
@@ -49,7 +49,7 @@ class FeatureScaler:
                 )
                 print("*************************************")
                 # print(data.fprimes)
-                print(torch.max(torch.abs(data.fprimes)))
+                print(torch.max(torch.abs(data.fprimes._values())))
                 _values = data.fprimes._values()
                 _indices = data.fprimes._indices()
                 _size = data.fprimes.size()

--- a/amptorch/preprocessing/utils.py
+++ b/amptorch/preprocessing/utils.py
@@ -18,7 +18,7 @@ class FeatureScaler:
             self.feature_mean = torch.mean(fingerprints, dim=0)
             self.feature_std = 1
 
-    def norm(self, data_list, threshold = 1e-2):
+    def norm(self, data_list, threshold = 1e-5):
         for data in data_list:
             idx_to_scale = torch.where((self.feature_max - self.feature_min) > threshold)[0]
             data.fingerprint[:, idx_to_scale] = -1 + 2 * (

--- a/amptorch/preprocessing/utils.py
+++ b/amptorch/preprocessing/utils.py
@@ -38,16 +38,18 @@ class FeatureScaler:
                 nonzero_idx = torch.where((self.feature_max - self.feature_min) > threshold)[0]
 
                 print("=====================================")
-                print(data.fprimes)
+                # print(data.fprimes)
+                print(torch.max(torch.abs(data.fprimes)))
                 
-                print(self.feature_max[idx_to_scale_prime][nonzero_idx])
-                print(self.feature_min[idx_to_scale_prime][nonzero_idx])
+                # print(self.feature_max[idx_to_scale_prime][nonzero_idx])
+                # print(self.feature_min[idx_to_scale_prime][nonzero_idx])
                 data.fprimes._values()[nonzero_idx] *= 2 / (
                     self.feature_max[idx_to_scale_prime][nonzero_idx]
                     - self.feature_min[idx_to_scale_prime][nonzero_idx]
                 )
                 print("*************************************")
-                print(data.fprimes)
+                # print(data.fprimes)
+                print(torch.max(torch.abs(data.fprimes)))
                 _values = data.fprimes._values()
                 _indices = data.fprimes._indices()
                 _size = data.fprimes.size()

--- a/amptorch/preprocessing/utils.py
+++ b/amptorch/preprocessing/utils.py
@@ -19,37 +19,37 @@ class FeatureScaler:
             self.feature_std = 1
 
     def norm(self, data_list):
-        for data in data_list:
-            idx_to_scale = torch.where((self.feature_max - self.feature_min) > 10e-8)[0]
-            data.fingerprint[:, idx_to_scale] = -1 + 2 * (
-                (data.fingerprint[:, idx_to_scale] - self.feature_min[idx_to_scale])
-                / (self.feature_max[idx_to_scale] - self.feature_min[idx_to_scale])
-            )
+        # for data in data_list:
+        #     idx_to_scale = torch.where((self.feature_max - self.feature_min) > 10e-8)[0]
+        #     data.fingerprint[:, idx_to_scale] = -1 + 2 * (
+        #         (data.fingerprint[:, idx_to_scale] - self.feature_min[idx_to_scale])
+        #         / (self.feature_max[idx_to_scale] - self.feature_min[idx_to_scale])
+        #     )
 
-            if self.forcetraining:
-                idx_to_scale_prime = data.fprimes._indices()[0] % (
-                    data.fingerprint.shape[1] - 1
-                )
-                nonzero_idx = torch.where(
-                    self.feature_max[idx_to_scale_prime]
-                    - self.feature_min[idx_to_scale_prime]
-                )[0]
+        #     if self.forcetraining:
+        #         idx_to_scale_prime = data.fprimes._indices()[0] % (
+        #             data.fingerprint.shape[1] - 1
+        #         )
+        #         nonzero_idx = torch.where(
+        #             self.feature_max[idx_to_scale_prime]
+        #             - self.feature_min[idx_to_scale_prime]
+        #         )[0]
 
-                # print("=====================================")
-                # print(data.fprimes)
+        #         # print("=====================================")
+        #         # print(data.fprimes)
                 
-                # print(self.feature_max[idx_to_scale_prime][nonzero_idx])
-                # print(self.feature_min[idx_to_scale_prime][nonzero_idx])
-                data.fprimes._values()[nonzero_idx] *= 2 / (
-                    self.feature_max[idx_to_scale_prime][nonzero_idx]
-                    - self.feature_min[idx_to_scale_prime][nonzero_idx]
-                )
-                # print("*************************************")
-                # print(data.fprimes)
-                _values = data.fprimes._values()
-                _indices = data.fprimes._indices()
-                _size = data.fprimes.size()
-                data.fprimes = torch.sparse.FloatTensor(_indices, _values, _size)
+        #         # print(self.feature_max[idx_to_scale_prime][nonzero_idx])
+        #         # print(self.feature_min[idx_to_scale_prime][nonzero_idx])
+        #         data.fprimes._values()[nonzero_idx] *= 2 / (
+        #             self.feature_max[idx_to_scale_prime][nonzero_idx]
+        #             - self.feature_min[idx_to_scale_prime][nonzero_idx]
+        #         )
+        #         # print("*************************************")
+        #         # print(data.fprimes)
+        #         _values = data.fprimes._values()
+        #         _indices = data.fprimes._indices()
+        #         _size = data.fprimes.size()
+        #         data.fprimes = torch.sparse.FloatTensor(_indices, _values, _size)
 
         return data_list
 

--- a/amptorch/preprocessing/utils.py
+++ b/amptorch/preprocessing/utils.py
@@ -19,31 +19,31 @@ class FeatureScaler:
             self.feature_std = 1
 
     def norm(self, data_list, threshold = 1e-6):
-        for data in data_list:
-            idx_to_scale = torch.where((self.feature_max - self.feature_min) > threshold)[0]
-            data.fingerprint[:, idx_to_scale] = -1 + 2 * (
-                (data.fingerprint[:, idx_to_scale] - self.feature_min[idx_to_scale])
-                / (self.feature_max[idx_to_scale] - self.feature_min[idx_to_scale])
-            )
+        # for data in data_list:
+        #     idx_to_scale = torch.where((self.feature_max - self.feature_min) > threshold)[0]
+        #     data.fingerprint[:, idx_to_scale] = -1 + 2 * (
+        #         (data.fingerprint[:, idx_to_scale] - self.feature_min[idx_to_scale])
+        #         / (self.feature_max[idx_to_scale] - self.feature_min[idx_to_scale])
+        #     )
 
-            if self.forcetraining:
-                idx_to_scale_prime = data.fprimes._indices()[0] % (
-                    data.fingerprint.shape[1] - 1
-                )
+        #     if self.forcetraining:
+        #         idx_to_scale_prime = data.fprimes._indices()[0] % (
+        #             data.fingerprint.shape[1] - 1
+        #         )
 
-                nonzero_idx = torch.where(
-                    (self.feature_max[idx_to_scale_prime] - self.feature_min[idx_to_scale_prime]) > threshold
-                )[0]
+        #         nonzero_idx = torch.where(
+        #             (self.feature_max[idx_to_scale_prime] - self.feature_min[idx_to_scale_prime]) > threshold
+        #         )[0]
 
-                data.fprimes._values()[nonzero_idx] *= 2 / (
-                    self.feature_max[idx_to_scale_prime][nonzero_idx]
-                    - self.feature_min[idx_to_scale_prime][nonzero_idx]
-                )
+        #         data.fprimes._values()[nonzero_idx] *= 2 / (
+        #             self.feature_max[idx_to_scale_prime][nonzero_idx]
+        #             - self.feature_min[idx_to_scale_prime][nonzero_idx]
+        #         )
 
-                _values = data.fprimes._values()
-                _indices = data.fprimes._indices()
-                _size = data.fprimes.size()
-                data.fprimes = torch.sparse.FloatTensor(_indices, _values, _size)
+        #         _values = data.fprimes._values()
+        #         _indices = data.fprimes._indices()
+        #         _size = data.fprimes.size()
+        #         data.fprimes = torch.sparse.FloatTensor(_indices, _values, _size)
 
         return data_list
 

--- a/amptorch/preprocessing/utils.py
+++ b/amptorch/preprocessing/utils.py
@@ -18,7 +18,7 @@ class FeatureScaler:
             self.feature_mean = torch.mean(fingerprints, dim=0)
             self.feature_std = 1
 
-    def norm(self, data_list, threshold = 1e1):
+    def norm(self, data_list, threshold = 1e-8):
         for data in data_list:
             idx_to_scale = torch.where((self.feature_max - self.feature_min) > threshold)[0]
             data.fingerprint[:, idx_to_scale] = -1 + 2 * (
@@ -37,12 +37,14 @@ class FeatureScaler:
                 #     - self.feature_min[idx_to_scale_prime]
                 # )[0]
 
-                nonzero_idx = torch.where((self.feature_max - self.feature_min) > threshold)[0]
+                nonzero_idx = torch.where(
+                    (self.feature_max[idx_to_scale_prime] - self.feature_min[idx_to_scale_prime]) > threshold
+                )[0]
 
                 print("=====================================")
-                print(data.fprimes)
+                # print(data.fprimes)
                 print(torch.max(torch.abs(data.fprimes._values())))
-                print((self.feature_max - self.feature_min))
+                # print((self.feature_max - self.feature_min))
                 
                 # print(self.feature_max[idx_to_scale_prime][nonzero_idx])
                 # print(self.feature_min[idx_to_scale_prime][nonzero_idx])
@@ -51,7 +53,7 @@ class FeatureScaler:
                     - self.feature_min[idx_to_scale_prime][nonzero_idx]
                 )
                 print("*************************************")
-                print(data.fprimes)
+                # print(data.fprimes)
                 print(torch.max(torch.abs(data.fprimes._values())))
                 _values = data.fprimes._values()
                 _indices = data.fprimes._indices()

--- a/amptorch/preprocessing/utils.py
+++ b/amptorch/preprocessing/utils.py
@@ -18,7 +18,7 @@ class FeatureScaler:
             self.feature_mean = torch.mean(fingerprints, dim=0)
             self.feature_std = 1
 
-    def norm(self, data_list, threshold = 1e-6):
+    def norm(self, data_list, threshold = 1e-3):
         for data in data_list:
             idx_to_scale = torch.where((self.feature_max - self.feature_min) > threshold)[0]
             data.fingerprint[:, idx_to_scale] = -1 + 2 * (

--- a/amptorch/preprocessing/utils.py
+++ b/amptorch/preprocessing/utils.py
@@ -18,7 +18,7 @@ class FeatureScaler:
             self.feature_mean = torch.mean(fingerprints, dim=0)
             self.feature_std = 1
 
-    def norm(self, data_list, threshold = 1e-3):
+    def norm(self, data_list, threshold = 1e1):
         for data in data_list:
             idx_to_scale = torch.where((self.feature_max - self.feature_min) > threshold)[0]
             data.fingerprint[:, idx_to_scale] = -1 + 2 * (

--- a/amptorch/preprocessing/utils.py
+++ b/amptorch/preprocessing/utils.py
@@ -34,10 +34,17 @@ class FeatureScaler:
                     self.feature_max[idx_to_scale_prime]
                     - self.feature_min[idx_to_scale_prime]
                 )[0]
+
+                print("=====================================")
+                print(data.fprimes)
+                
+
                 data.fprimes._values()[nonzero_idx] *= 2 / (
                     self.feature_max[idx_to_scale_prime][nonzero_idx]
                     - self.feature_min[idx_to_scale_prime][nonzero_idx]
                 )
+                print("*************************************")
+                print(data.fprimes)
                 _values = data.fprimes._values()
                 _indices = data.fprimes._indices()
                 _size = data.fprimes.size()

--- a/amptorch/trainer.py
+++ b/amptorch/trainer.py
@@ -85,8 +85,8 @@ class AtomsTrainer:
             save_fps=self.config["dataset"].get("save_fps", True),
         )
 
-        # self.feature_scaler = self.train_dataset.feature_scaler
-        # self.target_scaler = self.train_dataset.target_scaler
+        self.feature_scaler = self.train_dataset.feature_scaler
+        self.target_scaler = self.train_dataset.target_scaler
         self.input_dim = self.train_dataset.input_dim
         self.val_split = self.config["dataset"].get("val_split", 0)
         print("Loading dataset: {} images".format(len(self.train_dataset)))

--- a/amptorch/trainer.py
+++ b/amptorch/trainer.py
@@ -85,8 +85,8 @@ class AtomsTrainer:
             save_fps=self.config["dataset"].get("save_fps", True),
         )
 
-        self.feature_scaler = self.train_dataset.feature_scaler
-        self.target_scaler = self.train_dataset.target_scaler
+        # self.feature_scaler = self.train_dataset.feature_scaler
+        # self.target_scaler = self.train_dataset.target_scaler
         self.input_dim = self.train_dataset.input_dim
         self.val_split = self.config["dataset"].get("val_split", 0)
         print("Loading dataset: {} images".format(len(self.train_dataset)))

--- a/amptorch/utils.py
+++ b/amptorch/utils.py
@@ -38,6 +38,8 @@ def forces_score(net, X, y):
     _, force_pred = net.forward(X)
     print("=====================================")
     print(force_pred)
+    print("*************************************")
+    print(force_target)
     if isinstance(X, torch.utils.data.Subset):
         X = X.dataset
     force_pred = X.target_scaler.denorm(force_pred, pred="forces")

--- a/amptorch/utils.py
+++ b/amptorch/utils.py
@@ -33,7 +33,11 @@ def energy_score(net, X, y):
 
 def forces_score(net, X, y):
     mse_loss = MSELoss()
+
+    
     _, force_pred = net.forward(X)
+    print("=====================================")
+    print(force_pred)
     if isinstance(X, torch.utils.data.Subset):
         X = X.dataset
     force_pred = X.target_scaler.denorm(force_pred, pred="forces")

--- a/amptorch/utils.py
+++ b/amptorch/utils.py
@@ -39,7 +39,7 @@ def forces_score(net, X, y):
     print("=====================================")
     print(force_pred)
     print("*************************************")
-    print(force_target)
+    print(torch.FloatTensor(np.concatenate(y[1::2])))
     if isinstance(X, torch.utils.data.Subset):
         X = X.dataset
     force_pred = X.target_scaler.denorm(force_pred, pred="forces")

--- a/amptorch/utils.py
+++ b/amptorch/utils.py
@@ -36,10 +36,10 @@ def forces_score(net, X, y):
 
     
     _, force_pred = net.forward(X)
-    print("=====================================")
-    print(force_pred)
-    print("*************************************")
-    print(torch.FloatTensor(np.concatenate(y[1::2])))
+    # print("=====================================")
+    # print(force_pred)
+    # print("*************************************")
+    # print(torch.FloatTensor(np.concatenate(y[1::2])))
     if isinstance(X, torch.utils.data.Subset):
         X = X.dataset
     force_pred = X.target_scaler.denorm(force_pred, pred="forces")


### PR DESCRIPTION
force training enabled for MCSH
added "square" mode for MCSH to avoid numerical instability
can now only calculate fp without fp_primes when only energy training is enabled