### PR TITLE
pretraining config fix

### DIFF
--- a/amptorch/dataset.py
+++ b/amptorch/dataset.py
@@ -25,13 +25,7 @@ class AtomsDataset(Dataset):
         self.images = images
         self.forcetraining = forcetraining
         self.scaling = scaling
-        fp_scheme, fp_params, cutoff_params, elements = descriptor_setup
-        if fp_scheme == "gaussian":
-            self.descriptor = Gaussian(Gs=fp_params, elements=elements, **cutoff_params)
-        elif fp_scheme == "mcsh":
-            self.descriptor = AtomisticMCSH(MCSHs=fp_params, elements=elements)
-        else:
-            raise NotImplementedError
+        self.descriptor = construct_descriptor(descriptor_setup)
 
         self.a2d = AtomsToData(
             descriptor=self.descriptor,
@@ -93,3 +87,14 @@ class DataCollater:
                 ]
         else:
             return batch
+
+
+def construct_descriptor(descriptor_setup):
+    fp_scheme, fp_params, cutoff_params, elements = descriptor_setup
+    if fp_scheme == "gaussian":
+        descriptor = Gaussian(Gs=fp_params, elements=elements, **cutoff_params)
+    elif fp_scheme == "mcsh":
+        descriptor = AtomisticMCSH(MCSHs=fp_params, elements=elements)
+    else:
+        raise NotImplementedError
+    return descriptor

--- a/amptorch/tests/cutoff_funcs_test.py
+++ b/amptorch/tests/cutoff_funcs_test.py
@@ -1,3 +1,4 @@
+import copy
 import numpy as np
 import torch
 from ase import Atoms
@@ -93,9 +94,10 @@ def test_cutoff_funcs():
         "cutoff_func": "Cosine",
     }
 
-    config["dataset"]["cutoff_params"] = cosine_cutoff_params
+    config_1 = copy.deepcopy(config)
+    config_1["dataset"]["cutoff_params"] = cosine_cutoff_params
     print("training model with Cosine cutoff function")
-    print("E_MAE: %f, F_MAE: %f" % get_performance_metrics(config))
+    print("E_MAE: %f, F_MAE: %f" % get_performance_metrics(config_1))
 
     ### Polynomial cutoff function (gamma = 2.0)
 
@@ -104,9 +106,10 @@ def test_cutoff_funcs():
         "gamma": 2.0,
     }
 
+    config_2 = copy.deepcopy(config)
     config["dataset"]["cutoff_params"] = polynomial_cutoff_params
     print("training model with Polynomial cutoff function (gamma = 2.0)")
-    print("E_MAE: %f, F_MAE: %f" % get_performance_metrics(config))
+    print("E_MAE: %f, F_MAE: %f" % get_performance_metrics(config_2))
 
 
 if __name__ == "__main__":

--- a/amptorch/tests/test_script.py
+++ b/amptorch/tests/test_script.py
@@ -8,7 +8,7 @@ import unittest
 from .consistency_test import test_energy_force_consistency
 from .cutoff_funcs_test import test_cutoff_funcs
 from .gaussian_descriptor_set_test import test_gaussian_descriptor_set
-from .pretrained_test import test_pretrained
+from .pretrained_test import test_pretrained, test_pretrained_no_config
 from .training_test import test_training
 
 
@@ -24,6 +24,7 @@ class TestMethods(unittest.TestCase):
 
     def test_load_retrain(self):
         test_pretrained()
+        test_pretrained_no_config()
 
     def test_training_scenarios(self):
         test_training()

--- a/amptorch/tests/training_test.py
+++ b/amptorch/tests/training_test.py
@@ -1,3 +1,4 @@
+import copy
 import numpy as np
 import torch
 from ase import Atoms
@@ -100,13 +101,13 @@ def test_training():
     config["model"]["get_forces"] = True
     config["optim"]["force_coefficient"] = 0.04
     config["optim"]["loss"] = "mse"
-    get_force_metrics(config)
+    get_force_metrics(copy.deepcopy(config))
     print("Train energy+forces success!")
     # energy+mae loss
     config["model"]["get_forces"] = False
     config["optim"]["force_coefficient"] = 0
     config["optim"]["loss"] = "mae"
-    get_energy_metrics(config)
+    get_energy_metrics(copy.deepcopy(config))
     print("Train energy only success!")
 
     ### train+val
@@ -115,7 +116,7 @@ def test_training():
     config["optim"]["force_coefficient"] = 0
     config["optim"]["loss"] = "mae"
     config["dataset"]["val_split"] = 0.1
-    get_energy_metrics(config)
+    get_energy_metrics(copy.deepcopy(config))
     print("Val energy only success!")
 
     # energy+forces
@@ -123,7 +124,7 @@ def test_training():
     config["optim"]["force_coefficient"] = 0.04
     config["optim"]["loss"] = "mse"
     config["dataset"]["val_split"] = 0.1
-    get_force_metrics(config)
+    get_force_metrics(copy.deepcopy(config))
     print("Val energy+forces success!")
 
 

--- a/amptorch/trainer.py
+++ b/amptorch/trainer.py
@@ -12,7 +12,7 @@ from skorch import NeuralNetRegressor
 from skorch.callbacks import LRScheduler
 from skorch.dataset import CVSplit
 
-from amptorch.dataset import AtomsDataset, DataCollater
+from amptorch.dataset import AtomsDataset, DataCollater, construct_descriptor
 from amptorch.descriptor.util import list_symbols_to_indices
 from amptorch.metrics import evaluator
 from amptorch.model import BPNN, CustomLoss
@@ -23,14 +23,15 @@ from amptorch.ase_utils import AMPtorch
 
 
 class AtomsTrainer:
-    def __init__(self, config):
+    def __init__(self, config={}):
         self.config = config
         self.pretrained = False
 
-    def load(self):
+    def load(self, load_dataset=True):
         self.load_config()
         self.load_rng_seed()
-        self.load_dataset()
+        if load_dataset:
+            self.load_dataset()
         self.load_model()
         self.load_criterion()
         self.load_optimizer()
@@ -79,15 +80,13 @@ class AtomsTrainer:
         elements = np.unique(elements)
         return elements
 
-    def load_dataset(self, process=True):
-        """
-        *NOTE* `process` should only be set to `False` for testing purposes (i.e. gaussian_descriptor_set_test.py)
-        This setting should not be used for any application use of Amptorch.
-        """
+    def load_dataset(self):
         training_images = self.config["dataset"]["raw_data"]
         # TODO: Scalability when dataset to large to fit into memory
         if isinstance(training_images, str):
             training_images = ase.io.read(training_images, ":")
+        del self.config["dataset"]["raw_data"]
+
         self.elements = self.config["dataset"].get(
             "elements", self.get_unique_elements(training_images)
         )
@@ -99,34 +98,37 @@ class AtomsTrainer:
         self.cutoff_params = self.config["dataset"].get(
             "cutoff_params", {"cutoff_func": "Cosine"}
         )
-
+        descriptor_setup = (
+            self.fp_scheme,
+            self.fp_params,
+            self.cutoff_params,
+            self.elements,
+        )
         self.train_dataset = AtomsDataset(
             images=training_images,
-            descriptor_setup=(
-                self.fp_scheme,
-                self.fp_params,
-                self.cutoff_params,
-                self.elements,
-            ),
+            descriptor_setup=descriptor_setup,
             forcetraining=self.forcetraining,
             save_fps=self.config["dataset"].get("save_fps", True),
             scaling=self.config["dataset"].get(
                 "scaling", {"type": "normalize", "range": (0, 1)}
             ),
-            process=process,
         )
-        if process:
-            self.feature_scaler = self.train_dataset.feature_scaler
-            self.target_scaler = self.train_dataset.target_scaler
-            if not self.debug:
-                normalizers = {
-                    "target": self.target_scaler,
-                    "feature": self.feature_scaler,
-                }
-                torch.save(normalizers, os.path.join(self.cp_dir, "normalizers.pt"))
-            self.input_dim = self.train_dataset.input_dim
-            self.val_split = self.config["dataset"].get("val_split", 0)
-            print("Loading dataset: {} images".format(len(self.train_dataset)))
+        self.feature_scaler = self.train_dataset.feature_scaler
+        self.target_scaler = self.train_dataset.target_scaler
+        self.input_dim = self.train_dataset.input_dim
+        self.val_split = self.config["dataset"].get("val_split", 0)
+        if not self.debug:
+            normalizers = {
+                "target": self.target_scaler,
+                "feature": self.feature_scaler,
+            }
+            torch.save(normalizers, os.path.join(self.cp_dir, "normalizers.pt"))
+            # clean/organize config
+            del self.config["dataset"]["fp_params"]
+            self.config["dataset"]["descriptor"] = descriptor_setup
+            self.config["dataset"]["fp_length"] = self.input_dim
+            torch.save(self.config, os.path.join(self.cp_dir, "config.pt"))
+        print("Loading dataset: {} images".format(len(self.train_dataset)))
 
     def load_model(self):
         elements = list_symbols_to_indices(self.elements)
@@ -134,6 +136,7 @@ class AtomsTrainer:
             elements=elements, input_dim=self.input_dim, **self.config["model"]
         )
         print("Loading model: {} parameters".format(self.model.num_params))
+        self.forcetraining = self.config["model"].get("get_forces", True)
         collate_fn = DataCollater(train=True, forcetraining=self.forcetraining)
         self.parallel_collater = ParallelCollater(self.gpus, collate_fn)
         if self.gpus > 0:
@@ -146,6 +149,7 @@ class AtomsTrainer:
     def load_extras(self):
         callbacks = []
         load_best_loss = train_end_load_best_loss(self.identifier)
+        self.val_split = self.config["dataset"].get("val_split", 0)
         self.split = CVSplit(cv=self.val_split) if self.val_split != 0 else 0
 
         metrics = evaluator(
@@ -233,11 +237,13 @@ class AtomsTrainer:
             warnings.warn("No images found!", stacklevel=2)
             return images
 
+        self.descriptor = construct_descriptor(self.config["dataset"]["descriptor"])
+
         a2d = AtomsToData(
-            descriptor=self.train_dataset.descriptor,
+            descriptor=self.descriptor,
             r_energy=False,
             r_forces=False,
-            save_fps=self.save_fps,
+            save_fps=self.config["dataset"].get("save_fps", True),
             fprimes=self.forcetraining,
             cores=1,
         )
@@ -266,10 +272,22 @@ class AtomsTrainer:
         return predictions
 
     def load_pretrained(self, checkpoint_path=None):
-        print(f"Loading checkpoint from {checkpoint_path}")
-        self.load()
-        self.net.initialize()
         self.pretrained = True
+        print(f"Loading checkpoint from {checkpoint_path}")
+        assert os.path.isdir(
+            checkpoint_path
+        ), f"Checkpoint: {checkpoint_path} not found!"
+        if not self.config:
+            # prediction only
+            self.config = torch.load(os.path.join(checkpoint_path, "config.pt"))
+            self.config["cmd"]["debug"] = True
+            self.elements = self.config["dataset"]["descriptor"][-1]
+            self.input_dim = self.config["dataset"]["fp_length"]
+            self.load(load_dataset=False)
+        else:
+            # prediction+retraining
+            self.load(load_dataset=True)
+        self.net.initialize()
         try:
             self.net.load_params(
                 f_params=os.path.join(checkpoint_path, "params.pt"),
@@ -277,7 +295,9 @@ class AtomsTrainer:
                 f_criterion=os.path.join(checkpoint_path, "criterion.pt"),
                 f_history=os.path.join(checkpoint_path, "history.json"),
             )
-            # TODO(mshuaibi): remove dataset load, use saved normalizers
+            normalizers = torch.load(os.path.join(checkpoint_path, "normalizers.pt"))
+            self.feature_scaler = normalizers["feature"]
+            self.target_scaler = normalizers["target"]
         except NotImplementedError:
             print("Unable to load checkpoint!")
 


### PR DESCRIPTION
Loading a pretrained model previously requires the exact config specified (including data) to be available to use. This PR makes it such that:
- configs are saved during training in a `config.pt` file that contains all the hyperparameters necessary to reconstruct the model, normalizers, etc;
- A pretrained model may be loaded with a blank config and all the necessary information is extracted from the pretrained checkpoint:
```
trainer = AtomsTrainer()
trainer.load_pretrained(checkpoint_path)
trainer.predict(images)
```
- Include tests to verify that prediction results are consistent across trainers that train/predict in one sitting, trainers that load the previous checkpoint (with a config available identical to that used during training), and trainers that have no config and just load the same checkpoint
- Clean up some fingerprinting/preprocessing structures

Various portions of this impact some of you, can you guys review and let me know. Thanks!

Few things I'd like to clean up with how this is organized, but this gets the job done for now.

@ray38 @ruiqic @EricMusa 