### PR TITLE
Improved FeatureScaler - tqdm monitoring + code optimization

### DIFF
--- a/amptorch/preprocessing/utils.py
+++ b/amptorch/preprocessing/utils.py
@@ -81,11 +81,11 @@ class FeatureScaler:
                 fp_idx_to_scale = fp_idx % data.fingerprint.shape[1]
                 element_idx = base_atoms[fp_idx].tolist()
                 _values = data.fprimes._values()
-                for i, element in enumerate(element_idx):
-                    if self.transform == "standardize":
-                        _values[i] /= self.scales[element]["scale"][fp_idx_to_scale[i]]
-                    else:
-                        _values[i] *= self.scales[element]["scale"][fp_idx_to_scale[i]]
+                scale = torch.FloatTensor([self.scales[element]["scale"][fp_idx_to_scale[i]] for i, element in enumerate(element_idx)])
+                if self.transform == "standardize":
+                    _values[i] /= scale
+                else:
+                    _values[i] *= scale
                 _indices = data.fprimes._indices()
                 _size = data.fprimes.size()
                 data.fprimes = torch.sparse.FloatTensor(_indices, _values, _size)

--- a/amptorch/preprocessing/utils.py
+++ b/amptorch/preprocessing/utils.py
@@ -81,11 +81,16 @@ class FeatureScaler:
                 fp_idx_to_scale = fp_idx % data.fingerprint.shape[1]
                 element_idx = base_atoms[fp_idx].tolist()
                 _values = data.fprimes._values()
-                scale = torch.FloatTensor([self.scales[element]["scale"][fp_idx_to_scale[i]] for i, element in enumerate(element_idx)])
+                scale = torch.FloatTensor(
+                    [
+                        self.scales[element]["scale"][fp_idx_to_scale[i]]
+                        for i, element in enumerate(element_idx)
+                    ]
+                )
                 if self.transform == "standardize":
-                    _values[i] /= scale
+                    _values /= scale
                 else:
-                    _values[i] *= scale
+                    _values *= scale
                 _indices = data.fprimes._indices()
                 _size = data.fprimes.size()
                 data.fprimes = torch.sparse.FloatTensor(_indices, _values, _size)
@@ -117,7 +122,7 @@ class TargetScaler:
             total=len(data_list),
             unit=" scalings",
             disable=disable_tqdm,
-        ):        
+        ):
             data.energy = (data.energy - self.target_mean) / self.target_std
 
             if self.forcetraining:

--- a/amptorch/preprocessing/utils.py
+++ b/amptorch/preprocessing/utils.py
@@ -1,5 +1,14 @@
 import torch
 
+try:
+    shell = get_ipython().__class__.__name__
+    if shell == "ZMQInteractiveShell":
+        from tqdm.notebook import tqdm
+    else:
+        from tqdm import tqdm
+except NameError:
+    from tqdm import tqdm
+
 
 class FeatureScaler:
     """
@@ -42,8 +51,14 @@ class FeatureScaler:
                 offset = feature_range[0] - fpmin * scale
                 self.scales[element] = {"offset": offset, "scale": scale}
 
-    def norm(self, data_list):
-        for data in data_list:
+    def norm(self, data_list, disable_tqdm=False):
+        for data in tqdm(
+            data_list,
+            desc="Scaling Feature data (%s)" % self.transform,
+            total=len(data_list),
+            unit=" scalings",
+            disable=disable_tqdm,
+        ):
             fingerprint = data.fingerprint
             atomic_numbers = data.atomic_numbers
             for element in self.unique:
@@ -95,8 +110,14 @@ class TargetScaler:
             self.target_mean = 0
             self.target_std = 1
 
-    def norm(self, data_list):
-        for data in data_list:
+    def norm(self, data_list, disable_tqdm=False):
+        for data in tqdm(
+            data_list,
+            desc="Scaling Target data",
+            total=len(data_list),
+            unit=" scalings",
+            disable=disable_tqdm,
+        ):        
             data.energy = (data.energy - self.target_mean) / self.target_std
 
             if self.forcetraining:

--- a/amptorch/preprocessing/utils.py
+++ b/amptorch/preprocessing/utils.py
@@ -81,16 +81,18 @@ class FeatureScaler:
                 fp_idx_to_scale = fp_idx % data.fingerprint.shape[1]
                 element_idx = base_atoms[fp_idx].tolist()
                 _values = data.fprimes._values()
-                scale = torch.FloatTensor(
-                    [
-                        self.scales[element]["scale"][fp_idx_to_scale[i]]
-                        for i, element in enumerate(element_idx)
-                    ]
-                )
-                if self.transform == "standardize":
-                    _values /= scale
-                else:
-                    _values *= scale
+
+                dict_elements = {element: [] for element in set(element_idx)}
+                for i, element in enumerate(element_idx):
+                    dict_elements[element].append(i)
+
+                for element, ids in dict_elements.items():
+                    scale = self.scales[element]["scale"][fp_idx_to_scale[ids]]
+                    if self.transform == "standardize":
+                        _values[ids] /= scale
+                    else:
+                        _values[ids] *= scale
+
                 _indices = data.fprimes._indices()
                 _size = data.fprimes.size()
                 data.fprimes = torch.sparse.FloatTensor(_indices, _values, _size)

--- a/amptorch/trainer.py
+++ b/amptorch/trainer.py
@@ -228,7 +228,7 @@ class AtomsTrainer:
         elapsed_time = time.time() - stime
         print(f"Training completed in {elapsed_time}s")
 
-    def predict(self, images, batch_size=32):
+    def predict(self, images, disable_tqdm=True):
         if len(images) < 1:
             warnings.warn("No images found!", stacklevel=2)
             return images
@@ -242,8 +242,8 @@ class AtomsTrainer:
             cores=1,
         )
 
-        data_list = a2d.convert_all(images, disable_tqdm=True)
-        self.feature_scaler.norm(data_list, disable_tqdm=True)
+        data_list = a2d.convert_all(images, disable_tqdm=disable_tqdm)
+        self.feature_scaler.norm(data_list, disable_tqdm=disable_tqdm)
 
         self.net.module.eval()
         collate_fn = DataCollater(train=False, forcetraining=self.forcetraining)

--- a/amptorch/trainer.py
+++ b/amptorch/trainer.py
@@ -243,7 +243,7 @@ class AtomsTrainer:
         )
 
         data_list = a2d.convert_all(images, disable_tqdm=True)
-        self.feature_scaler.norm(data_list)
+        self.feature_scaler.norm(data_list, disable_tqdm=True)
 
         self.net.module.eval()
         collate_fn = DataCollater(train=False, forcetraining=self.forcetraining)


### PR DESCRIPTION
As title says, `FeatureScaler` got some improvements. This particular step was taking quite long for images with many atoms when force training is turned on (~200 atoms with forces gives >100,000 fp primes to be scaled), adding `tqdm` confirmed this. 

Values were previously being scaled individually in a loop. Now, the scaling values are put into a `torch.FloatTensor` first, then broadcast-multiplied once to the fp primes. The bottleneck is now due to the list comprehension needed to construct the scaling tensor. Further optimizations can probably be made by reorganizing the scaling values from the current `dict`-based data structure to an array or tensor based structure. 