### PR TITLE
keep 'fp_params' in trainer config

### DIFF
--- a/amptorch/trainer.py
+++ b/amptorch/trainer.py
@@ -124,7 +124,6 @@ class AtomsTrainer:
             }
             torch.save(normalizers, os.path.join(self.cp_dir, "normalizers.pt"))
             # clean/organize config
-            del self.config["dataset"]["fp_params"]
             self.config["dataset"]["descriptor"] = descriptor_setup
             self.config["dataset"]["fp_length"] = self.input_dim
             torch.save(self.config, os.path.join(self.cp_dir, "config.pt"))


### PR DESCRIPTION
The al_mlp framework uses the same 'trainer' object to train multiple times. This change makes sure it is able to do that.