### PR TITLE
Lmdb refactor

### DIFF
--- a/amptorch/dataset.py
+++ b/amptorch/dataset.py
@@ -25,7 +25,6 @@ class AtomsDataset(Dataset):
         self.images = images
         self.forcetraining = forcetraining
         self.scaling = scaling
-        self.target_scaling = target_scaling
         self.descriptor = construct_descriptor(descriptor_setup)
 
         self.a2d = AtomsToData(

--- a/amptorch/dataset.py
+++ b/amptorch/dataset.py
@@ -19,12 +19,14 @@ class AtomsDataset(Dataset):
         forcetraining=True,
         save_fps=True,
         scaling={"type": "normalize", "range": (0, 1)},
+        target_scaling={},
         cores=1,
         process=True,
     ):
         self.images = images
         self.forcetraining = forcetraining
         self.scaling = scaling
+        self.target_scaling = target_scaling
         self.descriptor = construct_descriptor(descriptor_setup)
 
         self.a2d = AtomsToData(
@@ -42,7 +44,9 @@ class AtomsDataset(Dataset):
         data_list = self.a2d.convert_all(self.images)
 
         self.feature_scaler = FeatureScaler(data_list, self.forcetraining, self.scaling)
-        self.target_scaler = TargetScaler(data_list, self.forcetraining)
+        self.target_scaler = TargetScaler(
+            data_list, self.forcetraining, self.target_scaling
+        )
         self.feature_scaler.norm(data_list)
         self.target_scaler.norm(data_list)
 

--- a/amptorch/dataset.py
+++ b/amptorch/dataset.py
@@ -19,7 +19,6 @@ class AtomsDataset(Dataset):
         forcetraining=True,
         save_fps=True,
         scaling={"type": "normalize", "range": (0, 1)},
-        target_scaling={},
         cores=1,
         process=True,
     ):
@@ -44,9 +43,7 @@ class AtomsDataset(Dataset):
         data_list = self.a2d.convert_all(self.images)
 
         self.feature_scaler = FeatureScaler(data_list, self.forcetraining, self.scaling)
-        self.target_scaler = TargetScaler(
-            data_list, self.forcetraining, self.target_scaling
-        )
+        self.target_scaler = TargetScaler(data_list, self.forcetraining)
         self.feature_scaler.norm(data_list)
         self.target_scaler.norm(data_list)
 

--- a/amptorch/dataset_lmdb.py
+++ b/amptorch/dataset_lmdb.py
@@ -83,6 +83,121 @@ class AtomsLMDBDataset(Dataset):
     def __len__(self):
         return self.total_length
 
+    def __getitem__(self, idx):
+        db_idx = bisect.bisect(self._keylen_cumulative, idx)
+        if db_idx != 0:
+            el_idx = idx - self._keylen_cumulative[db_idx - 1]
+        else:
+            el_idx = idx
+
+        with self.envs[db_idx].begin(write=False) as txn:
+            data = txn.get(self.keys_list[db_idx][el_idx])
+            data_object = pickle.loads(data)
+
+        return data_object
+
+    def get_descriptor(self, descriptor_setup):
+        fp_scheme, fp_params, cutoff_params, elements = descriptor_setup
+        if fp_scheme == "gaussian":
+            descriptor = Gaussian(Gs=fp_params, elements=elements, **cutoff_params)
+        elif fp_scheme == "mcsh":
+            descriptor = AtomisticMCSH(MCSHs=fp_params, elements=elements)
+        else:
+            raise NotImplementedError
+        return descriptor
+
+    @property
+    def input_dim(self):
+        return self[0].fingerprint.shape[1]
+
+    def connect_db(self, lmdb_path):
+        env = lmdb.open(
+            lmdb_path,
+            subdir=False,
+            readonly=True,
+            lock=False,
+            readahead=False,
+            meminit=False,
+            max_readers=1,
+        )
+        return env
+
+
+class AtomsLMDBDatasetPartialCache(Dataset):
+    def __init__(
+        self,
+        db_paths,
+    ):
+        if len(db_paths) < 1:
+            raise ValueError("Please provide lmdb file paths")
+        self.db_paths = db_paths
+        self.envs = []
+        self.keys_list = []
+        self.length_list = []
+
+        feature_scaler_list = []
+        target_scaler_list = []
+        descriptor_setup_list = []
+        descriptor_list = []
+        elements_list = []
+        for db_path in self.db_paths:
+            temp_env = self.connect_db(db_path)
+            self.envs.append(temp_env)
+            self.keys_list.append(
+                [f"{j}".encode("ascii") for j in range(temp_env.stat()["entries"])]
+            )
+            with temp_env.begin(write=False) as txn:
+                temp_feature_scaler = pickle.loads(
+                    txn.get("feature_scaler".encode("ascii"))
+                )
+                temp_target_scaler = pickle.loads(
+                    txn.get("target_scaler".encode("ascii"))
+                )
+                temp_length = pickle.loads(txn.get("length".encode("ascii")))
+                temp_descriptor_setup = pickle.loads(
+                    txn.get("descriptor_setup".encode("ascii"))
+                )
+                temp_descriptor = self.get_descriptor(temp_descriptor_setup)
+                temp_elements = pickle.loads(txn.get("elements".encode("ascii")))
+                self.length_list.append(temp_length)
+                feature_scaler_list.append(temp_feature_scaler)
+                target_scaler_list.append(temp_target_scaler)
+                descriptor_setup_list.append(temp_descriptor_setup)
+                descriptor_list.append(temp_descriptor)
+                elements_list.append(temp_elements)
+
+        self._keylen_cumulative = np.cumsum(self.length_list).tolist()
+        self.total_length = np.sum(self.length_list)
+        self.feature_scaler = feature_scaler_list[0]
+        self.target_scaler = target_scaler_list[0]
+        self.descriptor_setup = descriptor_setup_list[0]
+        self.descriptor = descriptor_list[0]
+        self.elements = elements_list[0]
+        self.loaded_db_idx = -1
+
+        if len(self.db_paths) > 1:
+            if any(
+                feature_scaler != self.feature_scaler
+                for feature_scaler in feature_scaler_list
+            ):
+                raise ValueError(
+                    "Please make sure all lmdb used the same feature scaler"
+                )
+            if any(
+                target_scaler != self.target_scaler
+                for target_scaler in target_scaler_list
+            ):
+                raise ValueError(
+                    "Please make sure all lmdb used the same target scaler"
+                )
+            if any(descriptor != self.descriptor for descriptor in descriptor_list):
+                raise ValueError("Please make sure all lmdb used the same descriptor")
+            if any(set(elements) != set(self.elements) for elements in elements_list):
+                raise ValueError("Please make sure all lmdb used the same elements")
+
+    def __len__(self):
+        return self.total_length
+
     def __load_dataset__(self, db_idx):
         dataset = []
         with self.envs[db_idx].begin(write=False) as txn:

--- a/amptorch/dataset_lmdb.py
+++ b/amptorch/dataset_lmdb.py
@@ -45,7 +45,7 @@ class AtomsLMDBDataset(Dataset):
                 self.length_list.append(temp_length)
                 feature_scaler_list.append(temp_feature_scaler)
                 target_scaler_list.append(temp_target_scaler)
-                descriptor_setup.append(temp_descriptor)
+                descriptor_list.append(temp_descriptor)
                 elements_list.append(temp_elements)
 
         self._keylen_cumulative = np.cumsum(self.length_list).tolist()

--- a/amptorch/dataset_lmdb.py
+++ b/amptorch/dataset_lmdb.py
@@ -1,5 +1,7 @@
 import lmdb
 import pickle
+import numpt as np
+import bisect
 from tqdm import tqdm
 from torch.utils.data import Dataset
 from amptorch.descriptor.Gaussian import Gaussian
@@ -9,29 +11,74 @@ from amptorch.descriptor.MCSH import AtomisticMCSH
 class AtomsLMDBDataset(Dataset):
     def __init__(
         self,
-        db_path,
+        db_paths,
     ):
-        self.db_path = db_path
-        self.env = self.connect_db(self.db_path)
-        self.keys = [f"{j}".encode("ascii") for j in range(self.env.stat()["entries"])]
-        with self.env.begin(write=False) as txn:
-            self.feature_scaler = pickle.loads(
-                txn.get("feature_scaler".encode("ascii"))
+        if len(db_paths) < 1:
+            raise ValueError("Please provide lmdb file paths")
+        self.db_paths = db_paths
+        self.envs = []
+        self.keys_list = []
+        self.length_list = []
+
+        feature_scaler_list = []
+        target_scaler_list = []
+        descriptor_list = []
+        for db_path in self.db_paths:
+            temp_env = self.connect_db(db_path)
+            self.envs.append(temp_env)
+            self.keys_list.append(
+                [f"{j}".encode("ascii") for j in range(temp_env.stat()["entries"])]
             )
-            self.target_scaler = pickle.loads(txn.get("target_scaler".encode("ascii")))
-            self.length = pickle.loads(txn.get("length".encode("ascii")))
-            self.elements = pickle.loads(txn.get("elements".encode("ascii")))
-            self.descriptor_setup = pickle.loads(
-                txn.get("descriptor_setup".encode("ascii"))
-            )
-            self.descriptor = self.get_descriptor(self.descriptor_setup)
+            with temp_env.begin(write=False) as txn:
+                temp_feature_scaler = pickle.loads(
+                    txn.get("feature_scaler".encode("ascii"))
+                )
+                temp_target_scaler = pickle.loads(
+                    txn.get("target_scaler".encode("ascii"))
+                )
+                temp_length = pickle.loads(txn.get("length".encode("ascii")))
+                temp_descriptor = self.get_descriptor(
+                    pickle.loads(txn.get("descriptor_setup".encode("ascii")))
+                )
+                self.length_list.append(temp_length)
+                feature_scaler_list.append(temp_feature_scaler)
+                target_scaler_list.append(temp_target_scaler)
+                descriptor_setup.append(temp_descriptor)
+
+        self._keylen_cumulative = np.cumsum(self.length_list).tolist()
+        self.total_length = np.sum(self.length_list)
+        self.feature_scaler = feature_scaler_list[0]
+        self.target_scaler = target_scaler_list[0]
+        self.descriptor = descriptor_list[0]
+
+        if len(self.db_paths) > 1:
+            if any(
+                feature_scalar != self.feature_scaler
+                for feature_scaler in feature_scaler_list
+            ):
+                raise ValueError(
+                    "Please make sure all lmdb used the same feature scaler"
+                )
+            if any(
+                target_scaler != self.target_scaler
+                for target_scaler in target_scaler_list
+            ):
+                raise ValueError(
+                    "Please make sure all lmdb used the same target scaler"
+                )
+            if any(descriptor != self.descriptor for descriptor in descriptor_list):
+                raise ValueError("Please make sure all lmdb used the same descriptor")
 
     def __len__(self):
-        return self.length
+        return self.total_length
 
     def __getitem__(self, idx):
-        with self.env.begin(write=False) as txn:
-            data = txn.get(self.keys[idx])
+        db_idx = bisect.bisect(self._keylen_cumulative, idx)
+        if db_idx != 0:
+            el_idx = idx - self._keylen_cumulative[db_idx - 1]
+
+        with self.envs[db_idx].begin(write=False) as txn:
+            data = txn.get(self.keys_list[el_idx][el_idx])
             data_object = pickle.loads(data)
 
         return data_object
@@ -66,35 +113,79 @@ class AtomsLMDBDataset(Dataset):
 class AtomsLMDBDatasetCache(Dataset):
     def __init__(
         self,
-        db_path,
+        db_paths,
     ):
-        self.db_path = db_path
-        self.env = self.connect_db(self.db_path)
-        self.keys = [f"{j}".encode("ascii") for j in range(self.env.stat()["entries"])]
-        with self.env.begin(write=False) as txn:
-            self.feature_scaler = pickle.loads(
-                txn.get("feature_scaler".encode("ascii"))
+        if len(db_paths) < 1:
+            raise ValueError("Please provide lmdb file paths")
+        self.db_paths = db_paths
+        self.envs = []
+        self.keys_list = []
+        self.length_list = []
+
+        feature_scaler_list = []
+        target_scaler_list = []
+        descriptor_list = []
+        for db_path in self.db_paths:
+            temp_env = self.connect_db(db_path)
+            self.envs.append(temp_env)
+            self.keys_list.append(
+                [f"{j}".encode("ascii") for j in range(temp_env.stat()["entries"])]
             )
-            self.target_scaler = pickle.loads(txn.get("target_scaler".encode("ascii")))
-            self.length = pickle.loads(txn.get("length".encode("ascii")))
-            self.elements = pickle.loads(txn.get("elements".encode("ascii")))
-            self.descriptor_setup = pickle.loads(
-                txn.get("descriptor_setup".encode("ascii"))
-            )
-            self.descriptor = self.get_descriptor(self.descriptor_setup)
-            self.data_list = []
-            for idx in tqdm(
-                range(self.length),
-                desc="loading images from lmdb",
-                total=self.length,
-                unit=" images",
+            with temp_env.begin(write=False) as txn:
+                temp_feature_scaler = pickle.loads(
+                    txn.get("feature_scaler".encode("ascii"))
+                )
+                temp_target_scaler = pickle.loads(
+                    txn.get("target_scaler".encode("ascii"))
+                )
+                temp_length = pickle.loads(txn.get("length".encode("ascii")))
+                temp_descriptor = self.get_descriptor(
+                    pickle.loads(txn.get("descriptor_setup".encode("ascii")))
+                )
+                self.length_list.append(temp_length)
+                feature_scaler_list.append(temp_feature_scaler)
+                target_scaler_list.append(temp_target_scaler)
+                descriptor_setup.append(temp_descriptor)
+
+        self._keylen_cumulative = np.cumsum(self.length_list).tolist()
+        self.total_length = np.sum(self.length_list)
+        self.feature_scaler = feature_scaler_list[0]
+        self.target_scaler = target_scaler_list[0]
+        self.descriptor = descriptor_list[0]
+
+        if len(self.db_paths) > 1:
+            if any(
+                feature_scalar != self.feature_scaler
+                for feature_scaler in feature_scaler_list
             ):
-                data = txn.get(self.keys[idx])
-                data_object = pickle.loads(data)
-                self.data_list.append(data_object)
+                raise ValueError(
+                    "Please make sure all lmdb used the same feature scaler"
+                )
+            if any(
+                target_scaler != self.target_scaler
+                for target_scaler in target_scaler_list
+            ):
+                raise ValueError(
+                    "Please make sure all lmdb used the same target scaler"
+                )
+            if any(descriptor != self.descriptor for descriptor in descriptor_list):
+                raise ValueError("Please make sure all lmdb used the same descriptor")
+
+        self.data_list = []
+        for i, env in enumerate(self.envs):
+            with self.envs[i].begin(write=False) as txn:
+                for idx in tqdm(
+                    range(self.length_list[i]),
+                    desc="loading from {}".format(self.db_paths[i]),
+                    total=self.length_list[i],
+                    unit=" images",
+                ):
+                    data = txn.get(self.keys_list[i][idx])
+                    data_object = pickle.loads(data)
+                    self.data_list.append(data_object)
 
     def __len__(self):
-        return self.length
+        return self.total_length
 
     def __getitem__(self, idx):
         return self.data_list[idx]

--- a/amptorch/dataset_lmdb.py
+++ b/amptorch/dataset_lmdb.py
@@ -74,13 +74,6 @@ class AtomsLMDBDataset(Dataset):
                 raise ValueError(
                     "Please make sure all lmdb used the same target scaler"
                 )
-            if any(
-                descriptor_setup != self.descriptor_setup
-                for descriptor_setup in descriptor_setup_list
-            ):
-                raise ValueError(
-                    "Please make sure all lmdb used the same descriptor setup"
-                )
             if any(descriptor != self.descriptor for descriptor in descriptor_list):
                 raise ValueError("Please make sure all lmdb used the same descriptor")
             if any(set(elements) != set(self.elements) for elements in elements_list):
@@ -194,13 +187,6 @@ class AtomsLMDBDatasetCache(Dataset):
             ):
                 raise ValueError(
                     "Please make sure all lmdb used the same target scaler"
-                )
-            if any(
-                descriptor_setup != self.descriptor_setup
-                for descriptor_setup in descriptor_setup_list
-            ):
-                raise ValueError(
-                    "Please make sure all lmdb used the same descriptor setup"
                 )
             if any(descriptor != self.descriptor for descriptor in descriptor_list):
                 raise ValueError("Please make sure all lmdb used the same descriptor")

--- a/amptorch/dataset_lmdb.py
+++ b/amptorch/dataset_lmdb.py
@@ -47,6 +47,7 @@ class AtomsLMDBDataset(Dataset):
                 self.length_list.append(temp_length)
                 feature_scaler_list.append(temp_feature_scaler)
                 target_scaler_list.append(temp_target_scaler)
+                descriptor_setup_list.append(temp_descriptor_setup)
                 descriptor_list.append(temp_descriptor)
                 elements_list.append(temp_elements)
 
@@ -60,7 +61,7 @@ class AtomsLMDBDataset(Dataset):
 
         if len(self.db_paths) > 1:
             if any(
-                feature_scalar != self.feature_scaler
+                feature_scaler != self.feature_scaler
                 for feature_scaler in feature_scaler_list
             ):
                 raise ValueError(
@@ -92,9 +93,11 @@ class AtomsLMDBDataset(Dataset):
         db_idx = bisect.bisect(self._keylen_cumulative, idx)
         if db_idx != 0:
             el_idx = idx - self._keylen_cumulative[db_idx - 1]
+        else:
+            el_idx = idx
 
         with self.envs[db_idx].begin(write=False) as txn:
-            data = txn.get(self.keys_list[el_idx][el_idx])
+            data = txn.get(self.keys_list[db_idx][el_idx])
             data_object = pickle.loads(data)
 
         return data_object
@@ -165,6 +168,7 @@ class AtomsLMDBDatasetCache(Dataset):
                 self.length_list.append(temp_length)
                 feature_scaler_list.append(temp_feature_scaler)
                 target_scaler_list.append(temp_target_scaler)
+                descriptor_setup_list.append(temp_descriptor_setup)
                 descriptor_list.append(temp_descriptor)
                 elements_list.append(temp_elements)
 
@@ -178,7 +182,7 @@ class AtomsLMDBDatasetCache(Dataset):
 
         if len(self.db_paths) > 1:
             if any(
-                feature_scalar != self.feature_scaler
+                feature_scaler != self.feature_scaler
                 for feature_scaler in feature_scaler_list
             ):
                 raise ValueError(

--- a/amptorch/dataset_lmdb.py
+++ b/amptorch/dataset_lmdb.py
@@ -1,6 +1,6 @@
 import lmdb
 import pickle
-import numpt as np
+import numpy as np
 import bisect
 from tqdm import tqdm
 from torch.utils.data import Dataset

--- a/amptorch/descriptor/Gaussian/__init__.py
+++ b/amptorch/descriptor/Gaussian/__init__.py
@@ -40,10 +40,31 @@ class Gaussian(BaseDescriptor):
         if isinstance(other, BaseDescriptor):
             if self.descriptor_type != other.descriptor_type:
                 return False
-            if self.elements != other.elemts:
+            if self.elements != other.elements:
                 return False
-            if self.Gs != other.Gs:
-                return False
+            for element in self.Gs:
+                if element not in other.Gs:
+                    return False
+                if self.Gs[element]["cutoff"] != other.Gs[element]["cutoff"]:
+                    return False
+                if "G2" in self.Gs[element]:
+                    for key in self.Gs[element]["G2"]:
+                        if list(self.Gs[element]["G2"][key]) != list(
+                            other.Gs[element]["G2"][key]
+                        ):
+                            return False
+                if "G4" in self.Gs[element]:
+                    for key in self.Gs[element]["G4"]:
+                        if list(self.Gs[element]["G4"][key]) != list(
+                            other.Gs[element]["G4"][key]
+                        ):
+                            return False
+                if "G5" in self.Gs[element]:
+                    for key in self.Gs[element]["G5"]:
+                        if list(self.Gs[element]["G5"][key]) != list(
+                            other.Gs[element]["G5"][key]
+                        ):
+                            return False
             if self.cutoff_func != other.cutoff_func:
                 return False
             return True

--- a/amptorch/descriptor/Gaussian/__init__.py
+++ b/amptorch/descriptor/Gaussian/__init__.py
@@ -35,6 +35,20 @@ class Gaussian(BaseDescriptor):
         self.prepare_descriptor_parameters()
         self.get_descriptor_setup_hash()
 
+    def __eq__(self, other):
+        """Overrides the default implementation"""
+        if isinstance(other, BaseDescriptor):
+            if self.descriptor_type != other.descriptor_type:
+                return False
+            if self.elements != other.elemts:
+                return False
+            if self.Gs != other.Gs:
+                return False
+            if self.cutoff_func != other.cutoff_func:
+                return False
+            return True
+        return NotImplemented
+
     def prepare_descriptor_parameters(self):
         if isinstance(self.Gs, dict):
             self.descriptor_setup = {}

--- a/amptorch/descriptor/MCSH/__init__.py
+++ b/amptorch/descriptor/MCSH/__init__.py
@@ -26,6 +26,16 @@ class AtomisticMCSH(BaseDescriptor):
 
         self.get_descriptor_setup_hash()
 
+    def __eq__(self, other):
+        """Overrides the default implementation"""
+        if isinstance(other, BaseDescriptor):
+            if self.descriptor_type != other.descriptor_type:
+                return False
+            if self.MCSHs != other.MCSHs:
+                return False
+            return True
+        return NotImplemented
+
     def prepare_descriptor_parameters(self):
         descriptor_setup = []
         cutoff = self.MCSHs["cutoff"]

--- a/amptorch/model.py
+++ b/amptorch/model.py
@@ -93,8 +93,7 @@ class BPNN(nn.Module):
             atomic_numbers = batch.atomic_numbers
             fingerprints = batch.fingerprint
             fingerprints.requires_grad = True
-            image_idx = batch.image_idx
-            sorted_image_idx = torch.unique_consecutive(image_idx)
+            image_idx = batch.batch
             mask = self.element_mask(atomic_numbers)
             o = torch.sum(
                 mask
@@ -103,7 +102,7 @@ class BPNN(nn.Module):
                 ),
                 dim=1,
             )
-            energy = scatter(o, image_idx, dim=0)[sorted_image_idx]
+            energy = scatter(o, image_idx, dim=0)
 
             if self.get_forces:
                 gradients = grad(

--- a/amptorch/preprocessing/atoms_to_data.py
+++ b/amptorch/preprocessing/atoms_to_data.py
@@ -51,7 +51,6 @@ class AtomsToData:
         natoms = len(atoms)
         image_data = self.descriptor_data[0]
         atomic_numbers = torch.LongTensor(atoms.get_atomic_numbers())
-        image_idx = torch.full((1, natoms), idx, dtype=torch.int64).view(-1)
         image_fingerprint = torch.tensor(
             image_data["descriptors"], dtype=torch.get_default_dtype()
         )
@@ -59,9 +58,8 @@ class AtomsToData:
         # put the minimum data in torch geometric data object
         data = Data(
             fingerprint=image_fingerprint,
-            image_idx=image_idx,
             atomic_numbers=atomic_numbers,
-            natoms=natoms,
+            num_nodes=natoms,
         )
 
         # optionally include other properties

--- a/amptorch/preprocessing/utils.py
+++ b/amptorch/preprocessing/utils.py
@@ -60,7 +60,7 @@ class FeatureScaler:
                 if element not in other.scales:
                     return False
                 for key in self.scales[element]:
-                    if key not in other.scales or not torch.equal(
+                    if key not in other.scales[element] or not torch.equal(
                         self.scales[element][key], other.scales[element][key]
                     ):
                         return False

--- a/amptorch/preprocessing/utils.py
+++ b/amptorch/preprocessing/utils.py
@@ -25,31 +25,60 @@ class FeatureScaler:
         self.transform = scaling["type"]
         if self.transform not in ["normalize", "standardize"]:
             raise NotImplementedError(f"{self.transform} scaling not supported.")
-        if self.transform == "normalize" and "range" not in scaling:
-            raise NotImplementedError("Normalization requires desire range.")
-        if self.transform == "normalize":
-            feature_range = scaling["range"]
-        self.forcetraining = forcetraining
-        fingerprints = torch.cat([data.fingerprint for data in data_list], dim=0)
-        atomic_numbers = torch.cat([data.atomic_numbers for data in data_list], dim=0)
-        self.unique = torch.unique(atomic_numbers).tolist()
-        self.scales = {}
-        for element in self.unique:
-            idx = torch.where(atomic_numbers == element)[0]
-            element_fps = fingerprints[idx]
-            if self.transform == "standardize":
-                mean = torch.mean(element_fps, dim=0)
-                std = torch.std(element_fps, dim=0, unbiased=False)
-                std[std < 1e-8] = 1
-                self.scales[element] = {"offset": mean, "scale": std}
-            else:
-                fpmin = torch.min(element_fps, dim=0).values
-                fpmax = torch.max(element_fps, dim=0).values
-                data_range = fpmax - fpmin
-                data_range[data_range < 1e-8] = 1
-                scale = (feature_range[1] - feature_range[0]) / (data_range)
-                offset = feature_range[0] - fpmin * scale
-                self.scales[element] = {"offset": offset, "scale": scale}
+        if "scales" in scaling:
+            self.scales = scaling["scales"]
+            print(
+                "Use specified feature scalar:\ntype:{}\n{}".format(
+                    self.transform, self.scales
+                )
+            )
+            # check completeness
+            atomic_numbers = torch.cat(
+                [data.atomic_numbers for data in data_list], dim=0
+            )
+            self.unique = torch.unique(atomic_numbers).tolist()
+            if any(key not in self.scales for key in self.unique):
+                raise ValueError(
+                    f"Please make sure scalers for all atoms {self.unique} are specified"
+                )
+        else:
+            if self.transform == "normalize" and "range" not in scaling:
+                raise NotImplementedError("Normalization requires desire range.")
+            if self.transform == "normalize":
+                feature_range = scaling["range"]
+            self.forcetraining = forcetraining
+            fingerprints = torch.cat([data.fingerprint for data in data_list], dim=0)
+            atomic_numbers = torch.cat(
+                [data.atomic_numbers for data in data_list], dim=0
+            )
+            self.unique = torch.unique(atomic_numbers).tolist()
+            self.scales = {}
+            for element in self.unique:
+                idx = torch.where(atomic_numbers == element)[0]
+                element_fps = fingerprints[idx]
+                if self.transform == "standardize":
+                    mean = torch.mean(element_fps, dim=0)
+                    std = torch.std(element_fps, dim=0, unbiased=False)
+                    std[std < 1e-8] = 1
+                    self.scales[element] = {"offset": mean, "scale": std}
+                else:
+                    fpmin = torch.min(element_fps, dim=0).values
+                    fpmax = torch.max(element_fps, dim=0).values
+                    data_range = fpmax - fpmin
+                    data_range[data_range < 1e-8] = 1
+                    scale = (feature_range[1] - feature_range[0]) / (data_range)
+                    offset = feature_range[0] - fpmin * scale
+                    self.scales[element] = {"offset": offset, "scale": scale}
+
+    def __eq__(self, other):
+        """Overrides the default implementation"""
+        if isinstance(other, FeatureScaler):
+            if self.transform != other.transform:
+                return False
+            if self.scales != other.scales:
+                return False
+            return True
+        return NotImplemented
 
     def norm(self, data_list, disable_tqdm=False):
         for data in tqdm(
@@ -101,20 +130,38 @@ class FeatureScaler:
 
 class TargetScaler:
     """
-    Normalizes an input tensor and later reverts it.
+    Normalizes an input tensor and later reverts it (standardize).
     Adapted from https://github.com/Open-Catalyst-Project/baselines
     """
 
-    def __init__(self, data_list, forcetraining):
+    def __init__(self, data_list, forcetraining, target_scaling={}):
         self.forcetraining = forcetraining
 
-        energies = torch.tensor([data.energy for data in data_list])
-        self.target_mean = torch.mean(energies, dim=0)
-        self.target_std = torch.std(energies, dim=0)
+        if "target_mean" in target_scaling and "target_std" in target_scaling:
+            self.target_mean = target_scaling["target_mean"]
+            self.target_std = target_scaling["target_std"]
+            print(
+                "Use speficied target scaler\nmean:{}\tstd:{}".format(
+                    self.target_mean, self.target_std
+                )
+            )
+        else:
+            energies = torch.tensor([data.energy for data in data_list])
+            self.target_mean = torch.mean(energies, dim=0)
+            self.target_std = torch.std(energies, dim=0)
 
         if torch.isnan(self.target_std) or self.target_std == 0:
             self.target_mean = 0
             self.target_std = 1
+
+    def __eq__(self, other):
+        """Overrides the default implementation"""
+        if isinstance(other, TargetScaler):
+            return (
+                self.target_mean == other.target_mean
+                and self.target_std == other.target_std
+            )
+        return NotImplemented
 
     def norm(self, data_list, disable_tqdm=False):
         for data in tqdm(

--- a/amptorch/trainer.py
+++ b/amptorch/trainer.py
@@ -248,7 +248,7 @@ class AtomsTrainer:
             batch_size=self.config["optim"].get("batch_size", 32),
             max_epochs=self.config["optim"].get("epochs", 100),
             iterator_train__collate_fn=self.parallel_collater,
-            iterator_train__shuffle=True,
+            iterator_train__shuffle=self.split_mode != "inorder",
             iterator_train__pin_memory=True,
             iterator_valid__collate_fn=self.parallel_collater,
             iterator_valid__shuffle=False,

--- a/amptorch/trainer.py
+++ b/amptorch/trainer.py
@@ -136,16 +136,12 @@ class AtomsTrainer:
                 "target": self.target_scaler,
                 "feature": self.feature_scaler,
             }
-            save_normalizers(normalizers, os.path.join(self.cp_dir, "normalizers.json"))
+            # save_normalizers(normalizers, os.path.join(self.cp_dir, "normalizers.json"))
             torch.save(normalizers, os.path.join(self.cp_dir, "normalizers.pt"))
             # clean/organize config
             self.config["dataset"]["descriptor"] = descriptor_setup
             self.config["dataset"]["fp_length"] = self.input_dim
             torch.save(self.config, os.path.join(self.cp_dir, "config.pt"))
-            with open(
-                os.path.join(self.cp_dir, "config.json"), "w", encoding="utf8"
-            ) as json_file:
-                json.dump(self.config, json_file, indent=4)
         print("Loading dataset: {} images".format(len(self.train_dataset)))
 
     def load_model(self):

--- a/amptorch/utils.py
+++ b/amptorch/utils.py
@@ -1,5 +1,6 @@
 import skorch
 import json
+import os
 from skorch.utils import to_numpy
 from torch_geometric.data import Batch
 from torch.nn.parallel.scatter_gather import gather

--- a/amptorch/utils.py
+++ b/amptorch/utils.py
@@ -1,4 +1,5 @@
 import skorch
+import json
 from skorch.utils import to_numpy
 from torch_geometric.data import Batch
 from torch.nn.parallel.scatter_gather import gather
@@ -28,6 +29,23 @@ def to_tensor(X, device, accept_sparse=False):
         else:
             outputs = X[0]
         return outputs
+
+
+def save_normalizers(normalizers, path):
+    tosave = {}
+    tosave["feature"] = {
+        "type": normalizers["feature"].transform,
+        "scales": normalizers["feature"].scales,
+    }
+    tosave["target"] = {
+        "mean": normalizers["target"].target_mean,
+        "stddev": normalizers["target"].target_std,
+    }
+    with open(
+        os.path.join(self.cp_dir, "config.json"), "w", encoding="utf8"
+    ) as json_file:
+        json.dump(self.config, json_file, indent=4)
+    return
 
 
 class train_end_load_best_loss(skorch.callbacks.base.Callback):

--- a/amptorch/utils.py
+++ b/amptorch/utils.py
@@ -6,6 +6,21 @@ from torch_geometric.data import Batch
 from torch.nn.parallel.scatter_gather import gather
 
 
+class InOrderSplit:
+    def __init__(self, val_frac):
+        self.val_frac = val_frac
+
+    def __call__(self, dataset):
+        len_dataset = len(dataset)
+        len_val = int(len_dataset * self.val_frac)
+        len_train = len_dataset - len_val
+        train_idx = list(range(0, len_train))
+        val_idx = list(range(len_train, len_dataset))
+        train_dataset = torch.utils.data.Subset(dataset, train_idx)
+        val_dataset = torch.utils.data.Subset(dataset, val_idx)
+        return train_dataset, val_dataset
+
+
 def target_extractor(y):
     extracted = []
     for batch in y:

--- a/amptorch/utils.py
+++ b/amptorch/utils.py
@@ -36,16 +36,14 @@ def save_normalizers(normalizers, path):
     tosave = {}
     tosave["feature"] = {
         "type": normalizers["feature"].transform,
-        "scales": normalizers["feature"].scales,
+        "scales": normalizers["feature"].scales.numpy(),
     }
     tosave["target"] = {
-        "mean": normalizers["target"].target_mean,
-        "stddev": normalizers["target"].target_std,
+        "mean": normalizers["target"].target_mean.numpy(),
+        "stddev": normalizers["target"].target_std.numpy(),
     }
-    with open(
-        os.path.join(self.cp_dir, "config.json"), "w", encoding="utf8"
-    ) as json_file:
-        json.dump(self.config, json_file, indent=4)
+    with open(path, "w", encoding="utf8") as json_file:
+        json.dump(tosave, json_file, indent=4)
     return
 
 

--- a/examples/train_lmdb_example.py
+++ b/examples/train_lmdb_example.py
@@ -51,7 +51,7 @@ config = {
         "gpus": 0,
     },
     "dataset": {
-        "lmdb_path": "data.lmdb",
+        "lmdb_path": ["./data.lmdb", "./data2.lmdb"],
         "val_split": 0,
     },
     "cmd": {


### PR DESCRIPTION
allowed multiple lmdb to be loaded for training
added example for saving and using existing scaler, so that multiple lmdb can be constructed at the same time
to ensure robustness, add __eq__ functions for multiple classes, including scalers, descriptor, etc, and checked all the lmdbs used the same setup while training on multiple lmdb