### PR TITLE
Fix affiliation typo that is breaking JOSS build

### DIFF
--- a/paper/paper.md
+++ b/paper/paper.md
@@ -24,7 +24,7 @@ authors:
     affiliation: 1
   - name: Jacob Paras
     equal_contrib: false
-    affliation: 3
+    affiliation: 3
   - name: Rui Qi Chen
     equal-contrib: false
     affiliation: 2


### PR DESCRIPTION
Fix issue mentioned in https://github.com/openjournals/joss-reviews/issues/5035#issuecomment-1588897203 that is currently breaking the paper publish workflow